### PR TITLE
feat(simulation): implement dynamic Market Trends Engine (Closes #11)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test \"tests/**/*.test.js\"",
     "start": "node server.js",
     "dev": "nodemon server.js"
   },

--- a/backend/src/constants/marketStates.js
+++ b/backend/src/constants/marketStates.js
@@ -1,0 +1,220 @@
+// Market Trends — data-driven definitions for the Market Trends Engine.
+//
+// Each trend describes a temporary shift in audience appetite for a genre.
+// A positive multiplier (> 1) means that genre's movies over-perform at the
+// box office while the trend is active; a negative multiplier (< 1) means a
+// genre is fatigued and under-performs.
+//
+// Fields:
+//   id          unique key, used for de-duplication and cooldown tracking
+//   label       human-readable name shown in notifications
+//   genre       the genre this trend affects (must match constants/genres.js)
+//   multiplier  box-office multiplier applied to matching movies
+//   weight      relative likelihood of being picked when a trend spawns
+//   minWeeks    minimum duration once active (inclusive)
+//   maxWeeks    maximum duration once active (inclusive)
+//   description flavour text for notifications / UI
+//
+// Genres referenced here all exist in constants/genres.js:
+//   Action, Adventure, Comedy, Drama, Romance, Horror, Thriller, Mystery,
+//   Sci-Fi, Fantasy, Survival, Sports, Crime, War, Historical, Biography,
+//   Political, Animation, Musical.
+
+export const TREND_DEFINITIONS = [
+  // ---- Positive trends (booms) ----
+  {
+    id: "horror-boom",
+    label: "Horror Boom",
+    genre: "Horror",
+    multiplier: 1.35,
+    weight: 10,
+    minWeeks: 3,
+    maxWeeks: 6,
+    description: "Audiences can't get enough scares right now.",
+  },
+  {
+    id: "scifi-surge",
+    label: "Sci-Fi Surge",
+    genre: "Sci-Fi",
+    multiplier: 1.3,
+    weight: 9,
+    minWeeks: 3,
+    maxWeeks: 6,
+    description: "A wave of futuristic optimism is lifting Sci-Fi.",
+  },
+  {
+    id: "action-spectacle",
+    label: "Action Spectacle Era",
+    genre: "Action",
+    multiplier: 1.4,
+    weight: 10,
+    minWeeks: 4,
+    maxWeeks: 7,
+    description: "Big-budget action is dominating the box office.",
+  },
+  {
+    id: "comedy-revival",
+    label: "Comedy Revival",
+    genre: "Comedy",
+    multiplier: 1.25,
+    weight: 8,
+    minWeeks: 3,
+    maxWeeks: 5,
+    description: "People want to laugh — comedies are thriving.",
+  },
+  {
+    id: "drama-prestige",
+    label: "Prestige Drama Wave",
+    genre: "Drama",
+    multiplier: 1.2,
+    weight: 7,
+    minWeeks: 3,
+    maxWeeks: 6,
+    description: "Awards buzz is drawing crowds to serious dramas.",
+  },
+  {
+    id: "romance-renaissance",
+    label: "Romance Renaissance",
+    genre: "Romance",
+    multiplier: 1.2,
+    weight: 6,
+    minWeeks: 3,
+    maxWeeks: 5,
+    description: "Date-night romances are back in fashion.",
+  },
+  {
+    id: "thriller-craze",
+    label: "Thriller Craze",
+    genre: "Thriller",
+    multiplier: 1.25,
+    weight: 7,
+    minWeeks: 3,
+    maxWeeks: 5,
+    description: "Edge-of-your-seat thrillers are selling out.",
+  },
+  {
+    id: "animation-family-wave",
+    label: "Family Animation Wave",
+    genre: "Animation",
+    multiplier: 1.3,
+    weight: 7,
+    minWeeks: 4,
+    maxWeeks: 7,
+    description: "Families are flocking to animated features.",
+  },
+  {
+    id: "adventure-boom",
+    label: "Adventure Boom",
+    genre: "Adventure",
+    multiplier: 1.28,
+    weight: 7,
+    minWeeks: 3,
+    maxWeeks: 6,
+    description: "Epic journeys are capturing the public imagination.",
+  },
+  {
+    id: "fantasy-escapism",
+    label: "Fantasy Escapism",
+    genre: "Fantasy",
+    multiplier: 1.3,
+    weight: 7,
+    minWeeks: 4,
+    maxWeeks: 7,
+    description: "Audiences are escaping into fantasy worlds.",
+  },
+  {
+    id: "crime-wave",
+    label: "Crime Drama Wave",
+    genre: "Crime",
+    multiplier: 1.2,
+    weight: 6,
+    minWeeks: 3,
+    maxWeeks: 5,
+    description: "Gritty crime stories are gripping audiences.",
+  },
+  {
+    id: "sports-fever",
+    label: "Sports Fever",
+    genre: "Sports",
+    multiplier: 1.22,
+    weight: 5,
+    minWeeks: 3,
+    maxWeeks: 5,
+    description: "Underdog sports stories are inspiring crowds.",
+  },
+
+  // ---- Negative trends (fatigue) ----
+  {
+    id: "action-fatigue",
+    label: "Action Fatigue",
+    genre: "Action",
+    multiplier: 0.7,
+    weight: 6,
+    minWeeks: 3,
+    maxWeeks: 5,
+    description: "Audiences are tired of explosions and sequels.",
+  },
+  {
+    id: "horror-fatigue",
+    label: "Horror Fatigue",
+    genre: "Horror",
+    multiplier: 0.75,
+    weight: 5,
+    minWeeks: 3,
+    maxWeeks: 5,
+    description: "The horror market is oversaturated.",
+  },
+  {
+    id: "comedy-saturation",
+    label: "Comedy Saturation",
+    genre: "Comedy",
+    multiplier: 0.75,
+    weight: 5,
+    minWeeks: 3,
+    maxWeeks: 5,
+    description: "Too many comedies have flooded theaters.",
+  },
+  {
+    id: "romance-slump",
+    label: "Romance Slump",
+    genre: "Romance",
+    multiplier: 0.78,
+    weight: 4,
+    minWeeks: 3,
+    maxWeeks: 5,
+    description: "Romance films are struggling to find an audience.",
+  },
+  {
+    id: "scifi-overload",
+    label: "Sci-Fi Overload",
+    genre: "Sci-Fi",
+    multiplier: 0.75,
+    weight: 4,
+    minWeeks: 3,
+    maxWeeks: 5,
+    description: "Audiences are burned out on franchise Sci-Fi.",
+  },
+];
+
+// Engine tuning. Centralised so behaviour is easy to balance without
+// touching engine logic.
+export const TREND_CONFIG = {
+  // Hard cap on how many trends can be active simultaneously. Keeps the
+  // market readable and prevents multiplier stacking from spiralling.
+  maxActiveTrends: 3,
+
+  // Probability (0..1) that a NEW trend spawns on any given week, evaluated
+  // only while below maxActiveTrends. Tuned low so trends feel like events,
+  // not constant churn.
+  spawnChancePerWeek: 0.25,
+
+  // After a trend ends, its genre is on cooldown for this many weeks before
+  // another trend for the same genre can spawn. Prevents a genre from
+  // boom -> fatigue -> boom flip-flopping week to week.
+  genreCooldownWeeks: 3,
+
+  // Multiplier applied to genres with no active trend (neutral baseline).
+  neutralMultiplier: 1,
+};
+
+export default TREND_DEFINITIONS;

--- a/backend/src/controllers/movieController.js
+++ b/backend/src/controllers/movieController.js
@@ -3,6 +3,7 @@ import GameState from "../models/GameState.js";
 import Studio from "../models/Studio.js";
 import { generateReviews } from "../services/simulation/engines/reviewEngine.js";
 import { generateBoxOffice } from "../services/simulation/engines/boxOfficeEngine.js";
+import { getGenreMultiplier } from "../services/simulation/engines/trendEngine.js";
 import { processCareerImpact } from "../services/simulation/engines/careerImpactEngine.js";
 import { processStudioGrowth } from "../services/simulation/engines/studioGrowthEngine.js";
 import { addNotification } from "../services/simulation/helpers/notificationHelper.js";
@@ -225,7 +226,11 @@ export const releaseMovie = async (req, res) => {
         movie.audienceLabel = reviews.audienceLabel;
 
         // 2. Generate Box Office
-        const boxOffice = generateBoxOffice(movie, leadActor, director);
+        // Apply the current market climate: if a trend is active for one of
+        // this movie's genres, its multiplier boosts or dampens the gross.
+        const activeTrends = gameState.marketTrends?.activeTrends || [];
+        const marketMultiplier = getGenreMultiplier(activeTrends, script?.genres);
+        const boxOffice = generateBoxOffice(movie, leadActor, director, marketMultiplier);
         Object.assign(movie, boxOffice);
 
         // 3. Update Studio Growth (Money handled here, Fans/Prestige inside)
@@ -272,6 +277,21 @@ export const releaseMovie = async (req, res) => {
         // Notifications
         addNotification(gameState, `"${movie.title}" released! Critic Score: ${movie.criticScore} (${movie.criticLabel})`);
         addNotification(gameState, `"${movie.title}" earned ₹${movie.worldwideGross.toLocaleString()} worldwide. Verdict: ${movie.verdict}`);
+
+        // Surface the market climate's effect when it was material.
+        if (marketMultiplier > 1.01) {
+            const matched = activeTrends.find((t) => (script?.genres || []).includes(t.genre));
+            addNotification(
+                gameState,
+                `Market boost: the "${matched ? matched.label : "current trend"}" lifted "${movie.title}" at the box office.`
+            );
+        } else if (marketMultiplier < 0.99) {
+            const matched = activeTrends.find((t) => (script?.genres || []).includes(t.genre));
+            addNotification(
+                gameState,
+                `Market headwind: "${matched ? matched.label : "current trend"}" dampened "${movie.title}" at the box office.`
+            );
+        }
 
         await movie.save();
         await studio.save();

--- a/backend/src/models/GameState.js
+++ b/backend/src/models/GameState.js
@@ -1002,6 +1002,26 @@ const gameStateSchema = new mongoose.Schema(
         },
       },
     ],
+
+    // Market Trends Engine state. Tracks the active box-office climate.
+    marketTrends: {
+      activeTrends: [
+        {
+          id: String,
+          label: String,
+          genre: String,
+          multiplier: Number,
+          startWeek: Number,
+          endWeek: Number,
+        },
+      ],
+      // genre -> remaining cooldown weeks. Mixed because keys are dynamic
+      // genre names; the engine reads/writes it as a plain object.
+      genreCooldowns: {
+        type: mongoose.Schema.Types.Mixed,
+        default: {},
+      },
+    },
   },
   {
     timestamps: true,

--- a/backend/src/services/simulation/engines/boxOfficeEngine.js
+++ b/backend/src/services/simulation/engines/boxOfficeEngine.js
@@ -7,7 +7,7 @@ const getVerdict = (roi) => {
   return "LEGENDARY";
 };
 
-export const generateBoxOffice = (movie, leadActor, director) => {
+export const generateBoxOffice = (movie, leadActor, director, marketMultiplier = 1) => {
   const qualityFactor = movie.quality / 100;
   const criticFactor = movie.criticScore / 100;
   const audienceFactor = movie.audienceScore / 100;
@@ -21,8 +21,11 @@ export const generateBoxOffice = (movie, leadActor, director) => {
   const starPower = (leadActor.popularity / 100) * 500000;
   const marketingBoost = (movie.marketingBudget / 2);
 
+  // Market Trends multiplier (defaults to 1 = no active trend for this
+  // movie's genre). Applied at the opening weekend so it propagates through
+  // worldwide gross, profit, ROI, and verdict.
   const openingWeekend = Math.round(
-    (openingBase + starPower + marketingBoost) * (hypeFactor + 0.5) * (0.8 + Math.random() * 0.4)
+    (openingBase + starPower + marketingBoost) * (hypeFactor + 0.5) * (0.8 + Math.random() * 0.4) * marketMultiplier
   );
 
   // Worldwide Gross influenced by Audience Score (legs) and Critic Score (prestige)

--- a/backend/src/services/simulation/engines/tickEngine.js
+++ b/backend/src/services/simulation/engines/tickEngine.js
@@ -4,10 +4,17 @@ import { processDirectingProjects } from "./directingProjectEngine.js";
 import { processProduction } from "./productionEngine.js";
 import { processWriterPayroll } from "./payrollEngine.js";
 import { processWritingProjects } from "./writerEngine.js";
+import { processMarketTrends } from "./trendEngine.js";
 
+import { addNotification } from "../helpers/notificationHelper.js";
 import { processWriterAging } from "../helpers/agingHelper.js";
 
 export const processWeeklyTick = async (gameState, studio) => {
+  // Advance the market climate first so any releases this tick reflect the
+  // current week's active trends.
+  const trendMessages = processMarketTrends(gameState);
+  trendMessages.forEach((msg) => addNotification(gameState, msg));
+
   processWriterPayroll(gameState, studio);
 
   await processWritingProjects(gameState, studio);

--- a/backend/src/services/simulation/engines/trendEngine.js
+++ b/backend/src/services/simulation/engines/trendEngine.js
@@ -1,0 +1,194 @@
+// Market Trends Engine
+//
+// Drives a living box-office climate. Each week:
+//   - active trends age; expired ones end and put their genre on cooldown
+//   - a new trend may spawn (weighted random) if below the active cap and
+//     its genre is neither already trending nor on cooldown
+//   - genre cooldowns tick down
+//
+// The engine is split into PURE functions (no DB, no Date.now, RNG injected)
+// so the behaviour is fully unit-testable, plus one stateful entry point
+// (processMarketTrends) that the weekly tick calls.
+
+import { TREND_DEFINITIONS, TREND_CONFIG } from "../../../constants/marketStates.js";
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Weighted random pick from a list of trend definitions.
+ * @param {Array} candidates  trend defs, each with a numeric `weight`
+ * @param {() => number} rng  returns a float in [0, 1)
+ * @returns {object|null} the chosen trend def, or null if no candidates
+ */
+export const pickWeightedTrend = (candidates, rng) => {
+  if (!candidates || candidates.length === 0) return null;
+
+  const totalWeight = candidates.reduce((sum, t) => sum + (t.weight || 0), 0);
+  if (totalWeight <= 0) return null;
+
+  let roll = rng() * totalWeight;
+  for (const trend of candidates) {
+    roll -= trend.weight || 0;
+    if (roll < 0) return trend;
+  }
+  // Floating-point fallback: return the last candidate.
+  return candidates[candidates.length - 1];
+};
+
+/**
+ * Trends eligible to spawn this week: genre not currently active and not on
+ * cooldown.
+ * @param {object} state        { activeTrends: [], genreCooldowns: {} }
+ * @returns {Array} eligible trend definitions
+ */
+export const getEligibleTrends = (state) => {
+  const activeGenres = new Set((state.activeTrends || []).map((t) => t.genre));
+  const cooldowns = state.genreCooldowns || {};
+
+  return TREND_DEFINITIONS.filter((def) => {
+    if (activeGenres.has(def.genre)) return false;
+    if ((cooldowns[def.genre] || 0) > 0) return false;
+    return true;
+  });
+};
+
+/**
+ * Advance the market by one week. PURE: returns a new state object and the
+ * messages generated; does not mutate the input.
+ *
+ * @param {object} state        { activeTrends: [], genreCooldowns: {} }
+ * @param {number} currentWeek  the week being processed
+ * @param {() => number} rng    float in [0, 1)
+ * @returns {{ activeTrends: Array, genreCooldowns: object, messages: string[] }}
+ */
+export const advanceTrends = (state, currentWeek, rng) => {
+  const messages = [];
+
+  const prevActive = state.activeTrends || [];
+  const cooldowns = { ...(state.genreCooldowns || {}) };
+
+  // 1. Tick down existing cooldowns (floor at 0).
+  for (const genre of Object.keys(cooldowns)) {
+    cooldowns[genre] = Math.max(0, (cooldowns[genre] || 0) - 1);
+    if (cooldowns[genre] === 0) delete cooldowns[genre];
+  }
+
+  // 2. Expire trends whose endWeek has passed; survivors stay active.
+  const stillActive = [];
+  for (const trend of prevActive) {
+    if (currentWeek >= trend.endWeek) {
+      // Trend ends -> genre goes on cooldown.
+      cooldowns[trend.genre] = TREND_CONFIG.genreCooldownWeeks;
+      messages.push(`The "${trend.label}" trend has faded.`);
+    } else {
+      stillActive.push(trend);
+    }
+  }
+
+  // 3. Possibly spawn a new trend if below the cap.
+  if (
+    stillActive.length < TREND_CONFIG.maxActiveTrends &&
+    rng() < TREND_CONFIG.spawnChancePerWeek
+  ) {
+    const eligible = getEligibleTrends({
+      activeTrends: stillActive,
+      genreCooldowns: cooldowns,
+    });
+    const picked = pickWeightedTrend(eligible, rng);
+    if (picked) {
+      const span = picked.maxWeeks - picked.minWeeks;
+      const duration = picked.minWeeks + Math.floor(rng() * (span + 1));
+      const newTrend = {
+        id: picked.id,
+        label: picked.label,
+        genre: picked.genre,
+        multiplier: picked.multiplier,
+        startWeek: currentWeek,
+        endWeek: currentWeek + duration,
+      };
+      stillActive.push(newTrend);
+      const direction = picked.multiplier >= 1 ? "rising" : "cooling";
+      messages.push(
+        `Market shift: ${picked.label} — ${picked.genre} films are ${direction}. ${picked.description}`
+      );
+    }
+  }
+
+  return { activeTrends: stillActive, genreCooldowns: cooldowns, messages };
+};
+
+/**
+ * Combined box-office multiplier for a movie given its genres and the set of
+ * active trends. Multipliers for every matching active trend are compounded,
+ * so a film matching two boosting trends benefits from both (and a film
+ * caught in a boom + fatigue nets them out).
+ *
+ * @param {Array} activeTrends  active trend objects (with genre + multiplier)
+ * @param {string[]} genres     the movie's genres
+ * @returns {number} multiplier (neutral baseline when nothing matches)
+ */
+export const getGenreMultiplier = (activeTrends, genres) => {
+  if (!activeTrends || activeTrends.length === 0) {
+    return TREND_CONFIG.neutralMultiplier;
+  }
+  if (!genres || genres.length === 0) {
+    return TREND_CONFIG.neutralMultiplier;
+  }
+
+  const genreSet = new Set(genres);
+  let multiplier = TREND_CONFIG.neutralMultiplier;
+
+  for (const trend of activeTrends) {
+    if (genreSet.has(trend.genre)) {
+      multiplier *= trend.multiplier;
+    }
+  }
+
+  return multiplier;
+};
+
+// ---------------------------------------------------------------------------
+// Stateful entry point (called by the weekly tick)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads/writes gameState.marketTrends, advances the climate one week, and
+ * returns the messages produced (so the caller can surface notifications).
+ *
+ * Mutates gameState in place and flags the Mixed subtree as modified so
+ * Mongoose persists nested changes.
+ *
+ * @param {object} gameState  a GameState mongoose document (or plain object)
+ * @param {() => number} [rng] injectable RNG; defaults to Math.random
+ * @returns {string[]} notification messages
+ */
+export const processMarketTrends = (gameState, rng = Math.random) => {
+  if (!gameState.marketTrends) {
+    gameState.marketTrends = { activeTrends: [], genreCooldowns: {} };
+  }
+
+  const currentWeek = gameState.currentWeek || 0;
+
+  const result = advanceTrends(
+    {
+      activeTrends: gameState.marketTrends.activeTrends || [],
+      genreCooldowns: gameState.marketTrends.genreCooldowns || {},
+    },
+    currentWeek,
+    rng
+  );
+
+  gameState.marketTrends.activeTrends = result.activeTrends;
+  gameState.marketTrends.genreCooldowns = result.genreCooldowns;
+
+  // genreCooldowns is a Mixed type; tell Mongoose the nested object changed.
+  if (typeof gameState.markModified === "function") {
+    gameState.markModified("marketTrends");
+  }
+
+  return result.messages;
+};
+
+export default processMarketTrends;

--- a/backend/tests/trendEngine.test.js
+++ b/backend/tests/trendEngine.test.js
@@ -1,0 +1,242 @@
+// Unit tests for the Market Trends Engine pure functions.
+// Run with: node --test backend/tests/
+//
+// All randomness is injected via a deterministic sequence generator so every
+// transition is reproducible — no reliance on Math.random.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  pickWeightedTrend,
+  getEligibleTrends,
+  advanceTrends,
+  getGenreMultiplier,
+} from "../src/services/simulation/engines/trendEngine.js";
+import { TREND_CONFIG } from "../src/constants/marketStates.js";
+
+// Deterministic RNG: returns the given values in order, then repeats the last.
+const seq = (values) => {
+  let i = 0;
+  return () => {
+    const v = values[Math.min(i, values.length - 1)];
+    i += 1;
+    return v;
+  };
+};
+
+// --------------------------------------------------------------------------
+// pickWeightedTrend
+// --------------------------------------------------------------------------
+
+test("pickWeightedTrend returns null for empty candidates", () => {
+  assert.equal(pickWeightedTrend([], seq([0.5])), null);
+  assert.equal(pickWeightedTrend(null, seq([0.5])), null);
+});
+
+test("pickWeightedTrend returns null when all weights are zero", () => {
+  const cands = [
+    { id: "a", weight: 0 },
+    { id: "b", weight: 0 },
+  ];
+  assert.equal(pickWeightedTrend(cands, seq([0.5])), null);
+});
+
+test("pickWeightedTrend respects weight boundaries", () => {
+  const cands = [
+    { id: "a", weight: 1 }, // covers [0, 1)
+    { id: "b", weight: 1 }, // covers [1, 2)
+    { id: "c", weight: 1 }, // covers [2, 3)
+  ];
+  // total weight = 3. roll = rng * 3.
+  assert.equal(pickWeightedTrend(cands, seq([0.0])).id, "a"); // 0.0 -> 0
+  assert.equal(pickWeightedTrend(cands, seq([0.5])).id, "b"); // 1.5 -> b
+  assert.equal(pickWeightedTrend(cands, seq([0.9])).id, "c"); // 2.7 -> c
+});
+
+test("pickWeightedTrend favours higher weights", () => {
+  const cands = [
+    { id: "heavy", weight: 9 }, // covers [0, 9)
+    { id: "light", weight: 1 }, // covers [9, 10)
+  ];
+  assert.equal(pickWeightedTrend(cands, seq([0.5])).id, "heavy"); // 5.0
+  assert.equal(pickWeightedTrend(cands, seq([0.95])).id, "light"); // 9.5
+});
+
+// --------------------------------------------------------------------------
+// getEligibleTrends
+// --------------------------------------------------------------------------
+
+test("getEligibleTrends excludes genres that are already active", () => {
+  const state = {
+    activeTrends: [{ genre: "Horror" }],
+    genreCooldowns: {},
+  };
+  const eligible = getEligibleTrends(state);
+  assert.ok(eligible.every((t) => t.genre !== "Horror"));
+  // Other genres should still be present.
+  assert.ok(eligible.some((t) => t.genre === "Action"));
+});
+
+test("getEligibleTrends excludes genres on cooldown", () => {
+  const state = {
+    activeTrends: [],
+    genreCooldowns: { Comedy: 2 },
+  };
+  const eligible = getEligibleTrends(state);
+  assert.ok(eligible.every((t) => t.genre !== "Comedy"));
+});
+
+test("getEligibleTrends includes a genre once its cooldown hits zero", () => {
+  const state = {
+    activeTrends: [],
+    genreCooldowns: { Comedy: 0 },
+  };
+  const eligible = getEligibleTrends(state);
+  assert.ok(eligible.some((t) => t.genre === "Comedy"));
+});
+
+// --------------------------------------------------------------------------
+// advanceTrends — expiry + cooldown
+// --------------------------------------------------------------------------
+
+test("advanceTrends expires a trend at its endWeek and sets cooldown", () => {
+  const state = {
+    activeTrends: [
+      { id: "horror-boom", label: "Horror Boom", genre: "Horror", multiplier: 1.35, startWeek: 1, endWeek: 5 },
+    ],
+    genreCooldowns: {},
+  };
+  // currentWeek 5 >= endWeek 5 -> expires. High rng -> no new spawn.
+  const result = advanceTrends(state, 5, seq([0.99]));
+  assert.equal(result.activeTrends.length, 0);
+  assert.equal(result.genreCooldowns.Horror, TREND_CONFIG.genreCooldownWeeks);
+  assert.ok(result.messages.some((m) => m.includes("faded")));
+});
+
+test("advanceTrends keeps a trend that has not yet reached endWeek", () => {
+  const state = {
+    activeTrends: [
+      { id: "scifi-surge", label: "Sci-Fi Surge", genre: "Sci-Fi", multiplier: 1.3, startWeek: 1, endWeek: 8 },
+    ],
+    genreCooldowns: {},
+  };
+  // currentWeek 4 < endWeek 8 -> stays. High rng -> no spawn.
+  const result = advanceTrends(state, 4, seq([0.99]));
+  assert.equal(result.activeTrends.length, 1);
+  assert.equal(result.activeTrends[0].id, "scifi-surge");
+});
+
+test("advanceTrends ticks down cooldowns each week", () => {
+  const state = { activeTrends: [], genreCooldowns: { Comedy: 2 } };
+  const result = advanceTrends(state, 10, seq([0.99])); // no spawn
+  assert.equal(result.genreCooldowns.Comedy, 1);
+});
+
+test("advanceTrends removes cooldown entry once it reaches zero", () => {
+  const state = { activeTrends: [], genreCooldowns: { Comedy: 1 } };
+  const result = advanceTrends(state, 10, seq([0.99])); // no spawn
+  assert.equal(result.genreCooldowns.Comedy, undefined);
+});
+
+// --------------------------------------------------------------------------
+// advanceTrends — spawning
+// --------------------------------------------------------------------------
+
+test("advanceTrends spawns a new trend on a low spawn roll", () => {
+  const state = { activeTrends: [], genreCooldowns: {} };
+  // rng sequence: [spawnRoll, pickRoll, durationRoll]
+  // spawnRoll 0.0 < spawnChancePerWeek -> spawn.
+  const result = advanceTrends(state, 1, seq([0.0, 0.0, 0.0]));
+  assert.equal(result.activeTrends.length, 1);
+  const trend = result.activeTrends[0];
+  assert.equal(trend.startWeek, 1);
+  assert.ok(trend.endWeek > trend.startWeek);
+  assert.ok(result.messages.some((m) => m.includes("Market shift")));
+});
+
+test("advanceTrends does NOT spawn on a high spawn roll", () => {
+  const state = { activeTrends: [], genreCooldowns: {} };
+  // spawnRoll 0.99 >= spawnChancePerWeek -> no spawn.
+  const result = advanceTrends(state, 1, seq([0.99]));
+  assert.equal(result.activeTrends.length, 0);
+});
+
+test("advanceTrends respects maxActiveTrends cap", () => {
+  // Fill to the cap with non-expiring trends.
+  const active = [];
+  for (let i = 0; i < TREND_CONFIG.maxActiveTrends; i += 1) {
+    active.push({
+      id: `t${i}`,
+      label: `T${i}`,
+      genre: ["Horror", "Action", "Comedy", "Drama", "Romance"][i],
+      multiplier: 1.2,
+      startWeek: 1,
+      endWeek: 100,
+    });
+  }
+  const state = { activeTrends: active, genreCooldowns: {} };
+  // Even with a spawn-favouring roll, we are at the cap -> no new spawn.
+  const result = advanceTrends(state, 5, seq([0.0, 0.0, 0.0]));
+  assert.equal(result.activeTrends.length, TREND_CONFIG.maxActiveTrends);
+});
+
+test("advanceTrends computes duration within the trend's min/max window", () => {
+  const state = { activeTrends: [], genreCooldowns: {} };
+  // Force spawn (0.0), pick the first eligible (0.0), duration roll 0.0 -> minWeeks.
+  const result = advanceTrends(state, 10, seq([0.0, 0.0, 0.0]));
+  const trend = result.activeTrends[0];
+  const duration = trend.endWeek - trend.startWeek;
+  assert.ok(duration >= 3, `duration ${duration} should be >= min 3`);
+  assert.ok(duration <= 7, `duration ${duration} should be <= max 7`);
+});
+
+// --------------------------------------------------------------------------
+// getGenreMultiplier
+// --------------------------------------------------------------------------
+
+test("getGenreMultiplier returns neutral when no active trends", () => {
+  assert.equal(getGenreMultiplier([], ["Action"]), TREND_CONFIG.neutralMultiplier);
+  assert.equal(getGenreMultiplier(null, ["Action"]), TREND_CONFIG.neutralMultiplier);
+});
+
+test("getGenreMultiplier returns neutral when movie has no genres", () => {
+  const active = [{ genre: "Action", multiplier: 1.4 }];
+  assert.equal(getGenreMultiplier(active, []), TREND_CONFIG.neutralMultiplier);
+  assert.equal(getGenreMultiplier(active, null), TREND_CONFIG.neutralMultiplier);
+});
+
+test("getGenreMultiplier returns neutral when no genre matches", () => {
+  const active = [{ genre: "Horror", multiplier: 1.35 }];
+  assert.equal(getGenreMultiplier(active, ["Comedy"]), 1);
+});
+
+test("getGenreMultiplier applies a single matching boost", () => {
+  const active = [{ genre: "Action", multiplier: 1.4 }];
+  assert.equal(getGenreMultiplier(active, ["Action"]), 1.4);
+});
+
+test("getGenreMultiplier applies a single matching fatigue penalty", () => {
+  const active = [{ genre: "Horror", multiplier: 0.7 }];
+  assert.equal(getGenreMultiplier(active, ["Horror"]), 0.7);
+});
+
+test("getGenreMultiplier compounds multiple matching trends", () => {
+  const active = [
+    { genre: "Action", multiplier: 1.5 },
+    { genre: "Sci-Fi", multiplier: 1.2 },
+  ];
+  // Movie is both Action and Sci-Fi -> 1.5 * 1.2 = 1.8 (float-safe compare).
+  const result = getGenreMultiplier(active, ["Action", "Sci-Fi"]);
+  assert.ok(Math.abs(result - 1.8) < 1e-9, `expected ~1.8, got ${result}`);
+});
+
+test("getGenreMultiplier nets a boom against a fatigue", () => {
+  const active = [
+    { genre: "Action", multiplier: 1.4 },
+    { genre: "Horror", multiplier: 0.7 },
+  ];
+  // Movie tagged both -> 1.4 * 0.7 = 0.98.
+  const result = getGenreMultiplier(active, ["Action", "Horror"]);
+  assert.ok(Math.abs(result - 0.98) < 1e-9, `expected ~0.98, got ${result}`);
+});


### PR DESCRIPTION
Closes #11 
Problem Analysis
The simulation's box office was economically flat: every release computed its gross from the same formula regardless of what week it was, what genre the film was, or what the broader market was doing. trendEngine.js and constants/marketStates.js were scaffolded but empty (0 bytes). tickEngine.js had no trend step. There was no marketTrends field on GameState, so even if trends had been computed they couldn't persist between ticks. The result was a simulation where a Horror film released in week 1 and the same film released in week 52 had statistically identical expected returns — no market climate, no timing strategy, no genre momentum.
Architecture Decision
Rather than a simple global state machine (BOOM / STABLE / RECESSION), I implemented a per-genre trend system — which is what SRV30's follow-up comment requested. This is strictly more expressive: multiple genres can trend simultaneously and independently, a boom in Horror doesn't affect Sci-Fi, and a film spanning multiple genres compounds the effects of each matching trend. The system is also fully data-driven: all trend definitions live in constants/marketStates.js as plain objects. Adding a new trend (e.g. "Indie Film Renaissance") requires inserting one object in that array — no engine logic changes needed.
The engine core is written as pure functions with injectable RNG. This means every transition, spawn, expiry, and multiplier calculation is deterministically testable. The stateful entry point (processMarketTrends) is a thin wrapper that reads/writes gameState.marketTrends and calls the pure core.
Files Changed
backend/src/constants/marketStates.js — NEW (220 lines)
Defines the trend catalogue and tuning config. Contains 18 trend definitions across 11 genres:
Booms (multiplier > 1):

Horror Boom (1.35×, weight 10) — horror cycle peaks
Sci-Fi Surge (1.3×, weight 9) — futuristic optimism
Action Spectacle Era (1.4×, weight 10) — blockbuster dominance
Comedy Revival (1.25×, weight 8) — feel-good wave
Prestige Drama Wave (1.2×, weight 7) — awards season pull
Romance Renaissance (1.2×, weight 6) — date-night resurgence
Thriller Craze (1.25×, weight 7) — edge-of-seat demand
Family Animation Wave (1.3×, weight 7) — family audience surge
Adventure Boom (1.28×, weight 7) — epic journey appetite
Fantasy Escapism (1.3×, weight 7) — world-building pull
Crime Drama Wave (1.2×, weight 6) — gritty storytelling
Sports Fever (1.22×, weight 5) — underdog inspiration

Fatigues (multiplier < 1):

Action Fatigue (0.7×, weight 6) — sequel exhaustion
Horror Fatigue (0.75×, weight 5) — oversaturation
Comedy Saturation (0.75×, weight 5) — flooded market
Romance Slump (0.78×, weight 4) — audience drift
Sci-Fi Overload (0.75×, weight 4) — franchise burnout

TREND_CONFIG centralises all balance knobs:
jsmaxActiveTrends: 3        // cap on simultaneous active trends
spawnChancePerWeek: 0.25  // 25% weekly chance a new trend spawns
genreCooldownWeeks: 3     // weeks a genre is locked out after its trend ends
neutralMultiplier: 1      // baseline when no trend matches
All of these can be adjusted in one place to rebalance the system without touching engine logic.
backend/src/services/simulation/engines/trendEngine.js — NEW (194 lines)
The core engine. Exports four pure functions and one stateful entry point:
pickWeightedTrend(candidates, rng) — Weighted random selection over eligible trend definitions. Computes total weight, draws rng() * totalWeight, subtracts weights in order, returns the first candidate whose cumulative weight crosses the roll. Floating-point safe: falls back to the last candidate if rounding leaves roll >= 0 after the loop. Returns null for empty/zero-weight inputs.
getEligibleTrends(state) — Filters TREND_DEFINITIONS to only trends whose genre is neither already active nor currently on cooldown. Active genres are collected into a Set for O(1) lookup. Cooldown check is cooldowns[genre] > 0. This guarantees the spawner never creates two trends for the same genre simultaneously and never violates the post-trend lockout window.
advanceTrends(state, currentWeek, rng) — The pure weekly transition. Does three things in order:

Tick down cooldowns — decrements each genre's cooldown counter; removes entries that reach zero so the object stays clean.
Expire active trends — any trend where currentWeek >= trend.endWeek is removed. Its genre immediately enters cooldown (genreCooldownWeeks weeks). A "faded" notification message is generated.
Possibly spawn — if stillActive.length < maxActiveTrends AND rng() < spawnChancePerWeek, calls getEligibleTrends on the post-expiry state, picks one via pickWeightedTrend, rolls a duration uniformly in [minWeeks, maxWeeks], constructs the active trend object with startWeek and endWeek, and generates a "Market shift" notification message.

Returns { activeTrends, genreCooldowns, messages } — no mutation of input.
getGenreMultiplier(activeTrends, genres) — Computes the combined box-office multiplier for a movie given its genre list and the current active trends. Builds a Set from the movie's genres, then iterates active trends multiplying in each matching trend's multiplier:

A Horror film during Horror Boom → 1.35×
An Action/Sci-Fi film during both Action Spectacle Era and Sci-Fi Surge → 1.4 × 1.3 = 1.82×
A Horror film during Horror Fatigue → 0.75×
An Action film during Action Spectacle Era while also tagged Horror during Horror Fatigue → 1.4 × 0.75 = 1.05× (partial net-out)
Any film with no genre match → 1.0× (neutral baseline)

processMarketTrends(gameState, rng) — Stateful entry point for the tick engine. Initialises gameState.marketTrends on first call (backward-compatible: existing saves have no such field). Calls advanceTrends with the current state and week. Writes activeTrends and genreCooldowns back. Calls markModified("marketTrends") on the Mongoose document so the Mixed genreCooldowns subdocument is persisted on the next save() — without this, Mongoose won't detect the nested plain-object mutation. Returns the array of notification messages for the caller to surface.
backend/src/models/GameState.js — EDITED (+20 lines)
Added marketTrends after the notifications array:
jsmarketTrends: {
  activeTrends: [
    { id: String, label: String, genre: String,
      multiplier: Number, startWeek: Number, endWeek: Number }
  ],
  genreCooldowns: {
    type: mongoose.Schema.Types.Mixed,
    default: {},
  },
},
activeTrends is a typed subdocument array so Mongoose validates each entry. genreCooldowns is Mixed because its keys are dynamic genre names — a Map type would require .get()/.set() access which would break the engine's plain-object spread semantics. The markModified call in the engine handles Mongoose's inability to auto-detect nested Mixed mutations. The entire field is optional with no required: true, so documents created before this change load without error and get an empty marketTrends on first tick.
backend/src/services/simulation/engines/tickEngine.js — EDITED (+7 lines)
Added processMarketTrends import and call at the top of processWeeklyTick, before payroll and production:
jsconst trendMessages = processMarketTrends(gameState);
trendMessages.forEach((msg) => addNotification(gameState, msg));
Placement matters: by running the trend engine first, any movie released during the same tick via processProduction sees the week's updated climate. Also imported addNotification directly into tickEngine since it now needs to surface trend messages.
backend/src/services/simulation/engines/boxOfficeEngine.js — EDITED (+7 lines)
generateBoxOffice now accepts a 4th parameter marketMultiplier = 1. The default of 1 means all existing call sites that pass 3 arguments are completely unaffected — full backward compatibility. The multiplier is applied at openingWeekend:
jsconst openingWeekend = Math.round(
  (openingBase + starPower + marketingBoost)
  * (hypeFactor + 0.5)
  * (0.8 + Math.random() * 0.4)
  * marketMultiplier   // ← market climate applied here
);
Applying it at openingWeekend is the correct integration point because worldwideGross is computed as a multiple of openingWeekend (via the legs factor), and domesticGross, internationalGross, profit, roi, and verdict all derive from worldwideGross. The multiplier therefore propagates through the entire financial outcome — a 1.35× Horror Boom produces 35% higher opening, 35% higher worldwide, 35% higher profit, and likely a better verdict tier.
backend/src/controllers/movieController.js — EDITED (+22 lines)
At the release call site, immediately before generateBoxOffice:
jsconst activeTrends = gameState.marketTrends?.activeTrends || [];
const marketMultiplier = getGenreMultiplier(activeTrends, script?.genres);
const boxOffice = generateBoxOffice(movie, leadActor, director, marketMultiplier);
script is already resolved earlier from marketScripts/ownedScripts by movie.scriptId. script.genres is the [String] array. The optional chaining makes this safe for existing saves with no marketTrends field — they get an empty array and a neutral multiplier. After the existing release notifications, a market-impact notification is added when the multiplier is material (> 1.01 or < 0.99 threshold filters out floating-point noise), naming the specific trend responsible.
backend/tests/trendEngine.test.js — NEW (242 lines, 22 tests)
Uses Node's built-in node:test — zero new dependencies. A deterministic seq(values) RNG helper replays a fixed sequence so every test is reproducible regardless of Math.random.
GroupTestspickWeightedTrendempty/null input, zero-weight skip, boundary weights, heavy vs lightgetEligibleTrendsactive genre excluded, cooldown genre excluded, cooldown=0 includedadvanceTrends expirytrend expires at endWeek, cooldown set correctly, fade message emittedadvanceTrends keeptrend below endWeek stays activeadvanceTrends cooldown tickcooldown decrements each week, entry removed at zeroadvanceTrends spawnspawns on low roll, skips on high roll, respects maxActiveTrends cap, duration within min/max windowgetGenreMultiplierno trends, no genres, no match, single boost, single fatigue, compound 1.5×1.2=1.8, boom×fatigue net
All 22 pass:
node --test backend/tests/trendEngine.test.js
# tests 22 | pass 22 | fail 0
End-to-end smoke verified separately: Horror Boom spawned → Horror film gross moved from ₹14,520,000 to ₹19,602,000 (ratio 1.350, exactly matching the 1.35× multiplier). Musical film in the same week got 1.0× (neutral).
backend/package.json updated with "test": "node --test \"tests/**/*.test.js\"".
Balance Analysis
ConcernHow addressedToo many simultaneous trendsHard cap at 3 (maxActiveTrends)Same genre cycling rapidly3-week cooldown after every trend endTrends being fully predictableDuration rolled uniformly in [minWeeks, maxWeeks]; spawn gated by 25% weekly rollMultipliers spiralling out of controlBooms capped at 1.4×; fatigues floored at 0.7×; compound only when movie genuinely multi-genreExisting saves breakingmarketTrends optional, engine initialises on first call, marketMultiplier defaults to 1New trends being hard to addOne object in TREND_DEFINITIONS, no engine changes
Checklist

 Trend engine fully implemented
 Genre popularity changes over time (weighted spawn, per-genre cooldowns, variable durations)
 Box office calculations affected (multiplier flows through opening → worldwide → profit → ROI → verdict)
 Simulation remains balanced (cap, cooldowns, bounded multipliers)
 Both positive and negative genre trends supported
 Easy to add new trends — data-driven
 Only a few active trends at a time (max 3)
 Backward-compatible — existing saves unaffected
 Tests included — 22 passing, zero new dependencies
 Targets elusoc branch