### PR TITLE
feat(simulation): implement Global Random Event Engine (Closes #14)

### DIFF
--- a/backend/src/constants/eventTypes.js
+++ b/backend/src/constants/eventTypes.js
@@ -1,0 +1,219 @@
+// Random Event Types — data-driven catalogue for the Global Random Event Engine.
+//
+// Each event describes an occasional industry occurrence that can affect the
+// studio. The catalogue is intentionally declarative so new events can be added
+// by appending one object here — no engine changes required (issue #14:
+// "New events can be added without major refactoring").
+//
+// Field reference:
+//   id           unique key, used for cooldown tracking and de-duplication
+//   label        human-readable name shown in notifications
+//   category     "positive" | "negative" — the flavour of the event
+//   rarity       "common" | "uncommon" | "rare" — drives base weight tier
+//   weight       relative likelihood within the eligible pool (higher = more
+//                common). Combined with rarity for final selection probability.
+//   cooldownWeeks weeks this event is locked out after it fires (prevents the
+//                same event repeating back-to-back)
+//   effects      array of { target, type, value } applied to the studio:
+//                  target: "money" | "fans" | "prestige"
+//                  type:   "flat"    -> add value directly
+//                          "percent" -> add value% of the current stat
+//                value can be negative (a loss) or positive (a gain)
+//   message      template describing what happened; "{effects}" is replaced at
+//                runtime with a human-readable summary of the applied changes.
+//
+// Effects are deliberately bounded (see EVENT_CONFIG clamps in eventEngine.js)
+// so events stay "noticeable but not game-breaking" per the issue guidance.
+
+export const EVENT_DEFINITIONS = [
+  // ---------------------------------------------------------------- positive
+  {
+    id: "viral-marketing",
+    label: "Viral Marketing Success",
+    category: "positive",
+    rarity: "common",
+    weight: 10,
+    cooldownWeeks: 6,
+    effects: [{ target: "fans", type: "percent", value: 8 }],
+    message: "One of your campaigns went viral! {effects}",
+  },
+  {
+    id: "award-buzz",
+    label: "Award Buzz",
+    category: "positive",
+    rarity: "uncommon",
+    weight: 7,
+    cooldownWeeks: 8,
+    effects: [{ target: "prestige", type: "flat", value: 25 }],
+    message: "Industry insiders are buzzing about your studio's prestige. {effects}",
+  },
+  {
+    id: "market-boom",
+    label: "Market Boom",
+    category: "positive",
+    rarity: "uncommon",
+    weight: 6,
+    cooldownWeeks: 10,
+    effects: [{ target: "money", type: "percent", value: 6 }],
+    message: "A box-office boom lifted the whole industry. {effects}",
+  },
+  {
+    id: "streaming-surge",
+    label: "Streaming Surge",
+    category: "positive",
+    rarity: "common",
+    weight: 8,
+    cooldownWeeks: 6,
+    effects: [
+      { target: "money", type: "flat", value: 750000 },
+      { target: "fans", type: "percent", value: 3 },
+    ],
+    message: "Streaming licensing deals paid off. {effects}",
+  },
+  {
+    id: "franchise-announcement",
+    label: "Major Franchise Announcement",
+    category: "positive",
+    rarity: "rare",
+    weight: 4,
+    cooldownWeeks: 14,
+    effects: [
+      { target: "fans", type: "percent", value: 12 },
+      { target: "prestige", type: "flat", value: 15 },
+    ],
+    message: "Your studio announced a major franchise! {effects}",
+  },
+  {
+    id: "government-incentive",
+    label: "Government Film Incentive",
+    category: "positive",
+    rarity: "uncommon",
+    weight: 6,
+    cooldownWeeks: 12,
+    effects: [{ target: "money", type: "flat", value: 1200000 }],
+    message: "A government film incentive boosted your budget. {effects}",
+  },
+  {
+    id: "intl-expansion",
+    label: "International Market Expansion",
+    category: "positive",
+    rarity: "uncommon",
+    weight: 5,
+    cooldownWeeks: 12,
+    effects: [
+      { target: "fans", type: "percent", value: 6 },
+      { target: "money", type: "percent", value: 4 },
+    ],
+    message: "Your films broke into new international markets. {effects}",
+  },
+  {
+    id: "vfx-breakthrough",
+    label: "Technology Breakthrough in VFX",
+    category: "positive",
+    rarity: "rare",
+    weight: 3,
+    cooldownWeeks: 16,
+    effects: [{ target: "prestige", type: "flat", value: 30 }],
+    message: "A VFX breakthrough at your studio wowed the industry. {effects}",
+  },
+  {
+    id: "celebrity-casting",
+    label: "Celebrity Casting Boost",
+    category: "positive",
+    rarity: "common",
+    weight: 8,
+    cooldownWeeks: 7,
+    effects: [{ target: "fans", type: "percent", value: 5 }],
+    message: "A high-profile casting drew major attention. {effects}",
+  },
+
+  // ---------------------------------------------------------------- negative
+  {
+    id: "actor-scandal",
+    label: "Actor Scandal",
+    category: "negative",
+    rarity: "common",
+    weight: 9,
+    cooldownWeeks: 7,
+    effects: [{ target: "fans", type: "percent", value: -7 }],
+    message: "A scandal involving one of your stars hit the press. {effects}",
+  },
+  {
+    id: "industry-strike",
+    label: "Industry Strike",
+    category: "negative",
+    rarity: "uncommon",
+    weight: 6,
+    cooldownWeeks: 12,
+    effects: [{ target: "money", type: "percent", value: -5 }],
+    message: "An industry-wide strike disrupted production. {effects}",
+  },
+  {
+    id: "economic-recession",
+    label: "Economic Recession",
+    category: "negative",
+    rarity: "rare",
+    weight: 4,
+    cooldownWeeks: 16,
+    effects: [
+      { target: "money", type: "percent", value: -8 },
+      { target: "fans", type: "percent", value: -3 },
+    ],
+    message: "An economic downturn squeezed the entertainment sector. {effects}",
+  },
+  {
+    id: "production-accident",
+    label: "Production Accident",
+    category: "negative",
+    rarity: "uncommon",
+    weight: 5,
+    cooldownWeeks: 10,
+    effects: [{ target: "money", type: "flat", value: -600000 }],
+    message: "An on-set accident led to costly delays. {effects}",
+  },
+  {
+    id: "social-media-backlash",
+    label: "Social Media Backlash",
+    category: "negative",
+    rarity: "common",
+    weight: 8,
+    cooldownWeeks: 6,
+    effects: [{ target: "fans", type: "percent", value: -5 }],
+    message: "A social media backlash hurt your studio's image. {effects}",
+  },
+  {
+    id: "talent-retirement",
+    label: "Talent Retirement",
+    category: "negative",
+    rarity: "uncommon",
+    weight: 5,
+    cooldownWeeks: 12,
+    effects: [{ target: "prestige", type: "flat", value: -15 }],
+    message: "A celebrated talent associated with your studio retired. {effects}",
+  },
+];
+
+// Engine tuning knobs. Centralised so balancing requires no logic changes.
+export const EVENT_CONFIG = {
+  // Probability (0..1) that the engine attempts to fire an event on a tick.
+  baseTriggerChance: 0.3,
+
+  // Maximum number of distinct events that can fire in a single tick.
+  maxEventsPerTick: 1,
+
+  // Safety clamps so no single event can be game-breaking.
+  // Percent effects are capped to this absolute fraction of the stat,
+  // and flat effects are capped to this absolute amount.
+  maxPercentMagnitude: 15, // i.e. no percent effect exceeds +/-15%
+  maxFlatMagnitude: 1500000, // no flat effect exceeds +/- 1.5M
+
+  // Rarity multipliers applied on top of each event's base weight, so rarer
+  // events are meaningfully less likely even if their weight is similar.
+  rarityWeightMultiplier: {
+    common: 1,
+    uncommon: 0.6,
+    rare: 0.3,
+  },
+};
+
+export default EVENT_DEFINITIONS;

--- a/backend/src/models/GameState.js
+++ b/backend/src/models/GameState.js
@@ -14,6 +14,24 @@ const gameStateSchema = new mongoose.Schema(
       default: 1,
     },
 
+    // Global Random Event Engine state. Tracks per-event cooldowns and a
+    // rolling history of fired events. Mixed because event-id keys are
+    // dynamic; the engine reads/writes it as a plain object. Optional with a
+    // sensible default so pre-existing saves load unchanged.
+    randomEvents: {
+      cooldowns: {
+        type: mongoose.Schema.Types.Mixed,
+        default: {},
+      },
+      history: [
+        {
+          id: String,
+          label: String,
+          week: Number,
+        },
+      ],
+    },
+
     ownedScripts: [
       {
         id: String,

--- a/backend/src/services/simulation/engines/eventEngine.js
+++ b/backend/src/services/simulation/engines/eventEngine.js
@@ -1,0 +1,233 @@
+// Global Random Event Engine
+//
+// Each simulation week this engine may fire an occasional industry event that
+// affects the studio (money / fans / prestige), then surfaces a notification
+// describing exactly what happened and what changed.
+//
+// Design (issue #14):
+//   - Data-driven: all events live in constants/eventTypes.js.
+//   - Weighted + rarity-balanced: rarer events are meaningfully less likely.
+//   - Cooldowns: an event that fires is locked out for cooldownWeeks so the
+//     same event can't repeat back-to-back (avoids predictability).
+//   - Bounded: effect magnitudes are clamped so no event is game-breaking.
+//   - Backward-compatible: operates on gameState.randomEvents, which defaults
+//     to empty — existing saves are unaffected and "no event" is a no-op.
+//
+// The core is written as PURE functions (no DB, RNG injected) so selection and
+// effect application are fully unit-testable. processRandomEvents is the thin
+// stateful wrapper the tick engine calls.
+
+import { EVENT_DEFINITIONS, EVENT_CONFIG } from "../../../constants/eventTypes.js";
+import { addNotification } from "../helpers/notificationHelper.js";
+
+/**
+ * Effective selection weight for an event: base weight scaled by its rarity
+ * multiplier. Rarer events get a smaller effective weight.
+ */
+const effectiveWeight = (event) => {
+  const rarityMult = EVENT_CONFIG.rarityWeightMultiplier[event.rarity] ?? 1;
+  return (event.weight || 0) * rarityMult;
+};
+
+/**
+ * Weighted random selection from a list of event definitions.
+ * @param {Array} candidates  event defs
+ * @param {() => number} rng  returns a float in [0, 1)
+ * @returns {object|null} the chosen event def, or null if none.
+ */
+export const pickWeightedEvent = (candidates, rng) => {
+  if (!candidates || candidates.length === 0) return null;
+
+  const totalWeight = candidates.reduce((sum, e) => sum + effectiveWeight(e), 0);
+  if (totalWeight <= 0) return null;
+
+  let roll = rng() * totalWeight;
+  for (const event of candidates) {
+    roll -= effectiveWeight(event);
+    if (roll < 0) return event;
+  }
+  // Floating-point fallback.
+  return candidates[candidates.length - 1];
+};
+
+/**
+ * Events eligible to fire this week: those not currently on cooldown.
+ * @param {object} cooldowns  map of eventId -> remaining cooldown weeks
+ * @returns {Array} eligible event definitions
+ */
+export const getEligibleEvents = (cooldowns) => {
+  const cd = cooldowns || {};
+  return EVENT_DEFINITIONS.filter((def) => (cd[def.id] || 0) <= 0);
+};
+
+/**
+ * Clamp a single effect's magnitude to the configured safety bounds so no
+ * event can be game-breaking.
+ * @param {object} effect  { target, type, value }
+ * @returns {object} a possibly-clamped copy
+ */
+const clampEffect = (effect) => {
+  if (effect.type === "percent") {
+    const capped = Math.max(
+      -EVENT_CONFIG.maxPercentMagnitude,
+      Math.min(EVENT_CONFIG.maxPercentMagnitude, effect.value)
+    );
+    return { ...effect, value: capped };
+  }
+  // flat
+  const capped = Math.max(
+    -EVENT_CONFIG.maxFlatMagnitude,
+    Math.min(EVENT_CONFIG.maxFlatMagnitude, effect.value)
+  );
+  return { ...effect, value: capped };
+};
+
+/**
+ * Apply an event's effects to a snapshot of studio stats. PURE: takes and
+ * returns plain numbers, does not touch the DB. Studio stats have a floor of 0
+ * (mirrors the Studio schema min:0 on money/fans/prestige).
+ *
+ * @param {object} stats  { money, fans, prestige }
+ * @param {object} event  an event definition
+ * @returns {{ stats: object, changes: Array }} new stats + per-effect change log
+ */
+export const applyEventEffects = (stats, event) => {
+  const next = {
+    money: Number(stats.money || 0),
+    fans: Number(stats.fans || 0),
+    prestige: Number(stats.prestige || 0),
+  };
+  const changes = [];
+
+  for (const rawEffect of event.effects || []) {
+    const effect = clampEffect(rawEffect);
+    const target = effect.target;
+    if (next[target] === undefined) continue; // ignore unknown targets safely
+
+    const before = next[target];
+    let delta;
+    if (effect.type === "percent") {
+      delta = Math.round((before * effect.value) / 100);
+    } else {
+      delta = Math.round(effect.value);
+    }
+
+    next[target] = Math.max(0, before + delta);
+    // Record the ACTUAL applied delta (after the 0-floor), so notifications
+    // never overstate a loss that was clamped by the floor.
+    const appliedDelta = next[target] - before;
+    changes.push({ target, delta: appliedDelta });
+  }
+
+  return { stats: next, changes };
+};
+
+/**
+ * Build a human-readable summary of stat changes for the notification.
+ * e.g. "+8,000 fans, -₹500,000".
+ */
+const describeChanges = (changes) => {
+  if (!changes || changes.length === 0) return "No measurable impact.";
+  const parts = changes.map(({ target, delta }) => {
+    const sign = delta >= 0 ? "+" : "-";
+    const magnitude = Math.abs(delta).toLocaleString();
+    if (target === "money") return `${sign}₹${magnitude}`;
+    return `${sign}${magnitude} ${target}`;
+  });
+  return parts.join(", ") + ".";
+};
+
+/**
+ * Pure weekly roll. Decides whether an event fires and which one, applies its
+ * effects to the provided stat snapshot, and returns the new stats, the fired
+ * events (with messages), and the updated cooldown map. No mutation of inputs.
+ *
+ * @param {object} state  { cooldowns: {...} }
+ * @param {object} stats  { money, fans, prestige }
+ * @param {() => number} rng
+ * @returns {{ stats, cooldowns, fired: Array }}
+ */
+export const rollEvents = (state, stats, rng) => {
+  // 1. Tick down cooldowns (floor at 0, drop zeroed entries).
+  const cooldowns = { ...(state.cooldowns || {}) };
+  for (const id of Object.keys(cooldowns)) {
+    cooldowns[id] = Math.max(0, (cooldowns[id] || 0) - 1);
+    if (cooldowns[id] === 0) delete cooldowns[id];
+  }
+
+  let currentStats = { ...stats };
+  const fired = [];
+
+  // 2. Up to maxEventsPerTick, gate each attempt on baseTriggerChance.
+  for (let i = 0; i < EVENT_CONFIG.maxEventsPerTick; i += 1) {
+    if (rng() >= EVENT_CONFIG.baseTriggerChance) break;
+
+    const eligible = getEligibleEvents(cooldowns);
+    const chosen = pickWeightedEvent(eligible, rng);
+    if (!chosen) break;
+
+    const { stats: newStats, changes } = applyEventEffects(currentStats, chosen);
+    currentStats = newStats;
+    cooldowns[chosen.id] = chosen.cooldownWeeks || 0;
+
+    const summary = describeChanges(changes);
+    const message = (chosen.message || "{effects}").replace("{effects}", summary);
+    fired.push({ id: chosen.id, label: chosen.label, category: chosen.category, message, changes });
+  }
+
+  return { stats: currentStats, cooldowns, fired };
+};
+
+/**
+ * Stateful entry point for the tick engine. Reads/writes gameState.randomEvents
+ * and the studio's money/fans/prestige, applies any fired event, and pushes
+ * notifications. Returns the list of fired events (for summaries/tests).
+ *
+ * @param {object} gameState  GameState document (or plain object)
+ * @param {object} studio     Studio document (or plain object)
+ * @param {() => number} [rng] injectable RNG; defaults to Math.random
+ * @returns {Array} fired events
+ */
+export const processRandomEvents = (gameState, studio, rng = Math.random) => {
+  if (!gameState.randomEvents) {
+    gameState.randomEvents = { cooldowns: {}, history: [] };
+  }
+
+  const result = rollEvents(
+    { cooldowns: gameState.randomEvents.cooldowns || {} },
+    {
+      money: studio?.money || 0,
+      fans: studio?.fans || 0,
+      prestige: studio?.prestige || 0,
+    },
+    rng
+  );
+
+  // Write back studio stats (only if a studio was provided).
+  if (studio) {
+    studio.money = result.stats.money;
+    studio.fans = result.stats.fans;
+    studio.prestige = result.stats.prestige;
+  }
+
+  // Persist cooldowns + a capped rolling history.
+  gameState.randomEvents.cooldowns = result.cooldowns;
+  const history = Array.isArray(gameState.randomEvents.history)
+    ? gameState.randomEvents.history
+    : [];
+  for (const ev of result.fired) {
+    history.push({ id: ev.id, label: ev.label, week: gameState.currentWeek || 0 });
+    addNotification(gameState, `Industry Event — ${ev.label}: ${ev.message}`);
+  }
+  // Keep the last 50 events only.
+  gameState.randomEvents.history = history.slice(-50);
+
+  // randomEvents is a Mixed subtree; flag it so Mongoose persists nested writes.
+  if (typeof gameState.markModified === "function") {
+    gameState.markModified("randomEvents");
+  }
+
+  return result.fired;
+};
+
+export default processRandomEvents;

--- a/backend/src/services/simulation/engines/tickEngine.js
+++ b/backend/src/services/simulation/engines/tickEngine.js
@@ -1,10 +1,11 @@
-import { processDirectorAwards } from "../../director/directorAwardsService.js";
+﻿import { processDirectorAwards } from "../../director/directorAwardsService.js";
 import { processDirectorAging } from "./directorEngine.js";
 import { processDirectingProjects } from "./directingProjectEngine.js";
 import { processProduction } from "./productionEngine.js";
 import { processWriterPayroll } from "./payrollEngine.js";
 import { processWritingProjects } from "./writerEngine.js";
 import { processMarketTrends } from "./trendEngine.js";
+import { processRandomEvents } from "./eventEngine.js";
 
 import { addNotification } from "../helpers/notificationHelper.js";
 import { processWriterAging } from "../helpers/agingHelper.js";
@@ -28,6 +29,10 @@ export const processWeeklyTick = async (gameState, studio) => {
   processDirectorAging(gameState);
 
   processDirectorAwards(gameState, studio);
+
+  // Roll for global random industry events last, so they react to the week's
+  // activity and can adjust studio money/fans/prestige before persistence.
+  processRandomEvents(gameState, studio);
 
   return gameState;
 };

--- a/backend/tests/eventEngine.test.js
+++ b/backend/tests/eventEngine.test.js
@@ -1,0 +1,254 @@
+// Unit tests for the Global Random Event Engine.
+// Run with: node --test "tests/**/*.test.js"
+//
+// All randomness is injected via a deterministic sequence generator so every
+// roll, selection, and effect is reproducible — no reliance on Math.random.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  pickWeightedEvent,
+  getEligibleEvents,
+  applyEventEffects,
+  rollEvents,
+  processRandomEvents,
+} from "../src/services/simulation/engines/eventEngine.js";
+import { EVENT_CONFIG } from "../src/constants/eventTypes.js";
+
+// Deterministic RNG: returns the given values in order, then repeats the last.
+const seq = (values) => {
+  let i = 0;
+  return () => {
+    const v = values[Math.min(i, values.length - 1)];
+    i += 1;
+    return v;
+  };
+};
+
+// --------------------------------------------------------------------------
+// pickWeightedEvent
+// --------------------------------------------------------------------------
+
+test("pickWeightedEvent returns null for empty/null candidates", () => {
+  assert.equal(pickWeightedEvent([], seq([0.5])), null);
+  assert.equal(pickWeightedEvent(null, seq([0.5])), null);
+});
+
+test("pickWeightedEvent returns null when all effective weights are zero", () => {
+  const cands = [
+    { id: "a", weight: 0, rarity: "common" },
+    { id: "b", weight: 0, rarity: "common" },
+  ];
+  assert.equal(pickWeightedEvent(cands, seq([0.5])), null);
+});
+
+test("pickWeightedEvent respects weight boundaries (common rarity = x1)", () => {
+  const cands = [
+    { id: "a", weight: 1, rarity: "common" }, // eff 1 -> [0,1)
+    { id: "b", weight: 1, rarity: "common" }, // eff 1 -> [1,2)
+    { id: "c", weight: 1, rarity: "common" }, // eff 1 -> [2,3)
+  ];
+  assert.equal(pickWeightedEvent(cands, seq([0.0])).id, "a");
+  assert.equal(pickWeightedEvent(cands, seq([0.5])).id, "b");
+  assert.equal(pickWeightedEvent(cands, seq([0.9])).id, "c");
+});
+
+test("pickWeightedEvent applies rarity multiplier to effective weight", () => {
+  // common weight 10 -> eff 10; rare weight 10 -> eff 3. Total 13.
+  const cands = [
+    { id: "common", weight: 10, rarity: "common" },
+    { id: "rare", weight: 10, rarity: "rare" },
+  ];
+  assert.equal(pickWeightedEvent(cands, seq([0.0])).id, "common");
+  assert.equal(pickWeightedEvent(cands, seq([0.99])).id, "rare");
+});
+
+// --------------------------------------------------------------------------
+// getEligibleEvents
+// --------------------------------------------------------------------------
+
+test("getEligibleEvents returns the full catalogue when no cooldowns", () => {
+  const eligible = getEligibleEvents({});
+  assert.ok(eligible.length > 0);
+});
+
+test("getEligibleEvents excludes events on active cooldown", () => {
+  const eligible = getEligibleEvents({ "actor-scandal": 3 });
+  assert.ok(eligible.every((e) => e.id !== "actor-scandal"));
+});
+
+test("getEligibleEvents includes an event whose cooldown has reached zero", () => {
+  const eligible = getEligibleEvents({ "actor-scandal": 0 });
+  assert.ok(eligible.some((e) => e.id === "actor-scandal"));
+});
+
+// --------------------------------------------------------------------------
+// applyEventEffects
+// --------------------------------------------------------------------------
+
+test("applyEventEffects applies a flat positive effect", () => {
+  const stats = { money: 1000000, fans: 100, prestige: 10 };
+  const event = { effects: [{ target: "money", type: "flat", value: 500000 }] };
+  const { stats: next, changes } = applyEventEffects(stats, event);
+  assert.equal(next.money, 1500000);
+  assert.deepEqual(changes, [{ target: "money", delta: 500000 }]);
+});
+
+test("applyEventEffects applies a percent effect (rounded)", () => {
+  const stats = { money: 0, fans: 1000, prestige: 0 };
+  const event = { effects: [{ target: "fans", type: "percent", value: 8 }] };
+  const { stats: next, changes } = applyEventEffects(stats, event);
+  assert.equal(next.fans, 1080); // 1000 + 8%
+  assert.deepEqual(changes, [{ target: "fans", delta: 80 }]);
+});
+
+test("applyEventEffects floors a stat at zero and reports the clamped delta", () => {
+  const stats = { money: 100000, fans: 0, prestige: 0 };
+  // -600000 flat would go negative; floor at 0, actual delta is -100000.
+  const event = { effects: [{ target: "money", type: "flat", value: -600000 }] };
+  const { stats: next, changes } = applyEventEffects(stats, event);
+  assert.equal(next.money, 0);
+  assert.deepEqual(changes, [{ target: "money", delta: -100000 }]);
+});
+
+test("applyEventEffects clamps an over-large percent to the configured cap", () => {
+  const stats = { money: 1000000, fans: 0, prestige: 0 };
+  const event = { effects: [{ target: "money", type: "percent", value: 50 }] };
+  const { stats: next } = applyEventEffects(stats, event);
+  const expected = 1000000 + Math.round((1000000 * EVENT_CONFIG.maxPercentMagnitude) / 100);
+  assert.equal(next.money, expected);
+});
+
+test("applyEventEffects clamps an over-large flat amount to the configured cap", () => {
+  const stats = { money: 0, fans: 0, prestige: 0 };
+  const event = { effects: [{ target: "money", type: "flat", value: 9999999 }] };
+  const { stats: next } = applyEventEffects(stats, event);
+  assert.equal(next.money, EVENT_CONFIG.maxFlatMagnitude);
+});
+
+test("applyEventEffects applies multiple effects in one event", () => {
+  const stats = { money: 1000000, fans: 1000, prestige: 10 };
+  const event = {
+    effects: [
+      { target: "money", type: "flat", value: 200000 },
+      { target: "fans", type: "percent", value: 10 },
+    ],
+  };
+  const { stats: next } = applyEventEffects(stats, event);
+  assert.equal(next.money, 1200000);
+  assert.equal(next.fans, 1100);
+});
+
+test("applyEventEffects ignores unknown targets safely", () => {
+  const stats = { money: 100, fans: 100, prestige: 100 };
+  const event = { effects: [{ target: "reputation", type: "flat", value: 50 }] };
+  const { stats: next, changes } = applyEventEffects(stats, event);
+  assert.deepEqual(next, { money: 100, fans: 100, prestige: 100 });
+  assert.equal(changes.length, 0);
+});
+
+// --------------------------------------------------------------------------
+// rollEvents
+// --------------------------------------------------------------------------
+
+test("rollEvents fires nothing when the trigger roll is above baseTriggerChance", () => {
+  const state = { cooldowns: {} };
+  const stats = { money: 1000000, fans: 1000, prestige: 10 };
+  const result = rollEvents(state, stats, seq([0.99]));
+  assert.equal(result.fired.length, 0);
+  assert.deepEqual(result.stats, stats);
+});
+
+test("rollEvents fires an event when the trigger roll is below baseTriggerChance", () => {
+  const state = { cooldowns: {} };
+  const stats = { money: 1000000, fans: 1000, prestige: 10 };
+  const result = rollEvents(state, stats, seq([0.0, 0.0]));
+  assert.equal(result.fired.length, 1);
+  const firedId = result.fired[0].id;
+  assert.ok(result.cooldowns[firedId] > 0);
+});
+
+test("rollEvents ticks down existing cooldowns each week", () => {
+  const state = { cooldowns: { "actor-scandal": 3 } };
+  const stats = { money: 1000000, fans: 1000, prestige: 10 };
+  const result = rollEvents(state, stats, seq([0.99]));
+  assert.equal(result.cooldowns["actor-scandal"], 2);
+});
+
+test("rollEvents drops a cooldown entry once it reaches zero", () => {
+  const state = { cooldowns: { "actor-scandal": 1 } };
+  const stats = { money: 1000000, fans: 1000, prestige: 10 };
+  const result = rollEvents(state, stats, seq([0.99]));
+  assert.equal(result.cooldowns["actor-scandal"], undefined);
+});
+
+test("rollEvents never fires more than maxEventsPerTick", () => {
+  const state = { cooldowns: {} };
+  const stats = { money: 1000000, fans: 1000, prestige: 10 };
+  const result = rollEvents(state, stats, seq([0.0]));
+  assert.ok(result.fired.length <= EVENT_CONFIG.maxEventsPerTick);
+});
+
+test("rollEvents applies the fired event's effect to the returned stats", () => {
+  const state = { cooldowns: {} };
+  const stats = { money: 1000000, fans: 1000, prestige: 10 };
+  const result = rollEvents(state, stats, seq([0.0, 0.0]));
+  if (result.fired.length > 0) {
+    const changed =
+      result.stats.money !== stats.money ||
+      result.stats.fans !== stats.fans ||
+      result.stats.prestige !== stats.prestige;
+    assert.ok(changed, "fired event should change at least one stat");
+  }
+});
+
+// --------------------------------------------------------------------------
+// processRandomEvents (stateful entry point)
+// --------------------------------------------------------------------------
+
+test("processRandomEvents initialises randomEvents on first call (backward-compat)", () => {
+  const gameState = { currentWeek: 5, notifications: [] };
+  const studio = { money: 1000000, fans: 1000, prestige: 10 };
+  processRandomEvents(gameState, studio, seq([0.99]));
+  assert.ok(gameState.randomEvents);
+  assert.deepEqual(gameState.randomEvents.cooldowns, {});
+  assert.deepEqual(gameState.randomEvents.history, []);
+});
+
+test("processRandomEvents writes stat changes back to the studio and notifies", () => {
+  const gameState = { currentWeek: 5, notifications: [] };
+  const studio = { money: 1000000, fans: 1000, prestige: 10 };
+  const fired = processRandomEvents(gameState, studio, seq([0.0, 0.0]));
+  assert.equal(fired.length, 1);
+  assert.equal(gameState.notifications.length, 1);
+  assert.match(gameState.notifications[0].message, /Industry Event/);
+  assert.equal(gameState.randomEvents.history.length, 1);
+  assert.equal(gameState.randomEvents.history[0].week, 5);
+});
+
+test("processRandomEvents is a no-op on the studio when nothing fires", () => {
+  const gameState = { currentWeek: 5, notifications: [] };
+  const studio = { money: 1000000, fans: 1000, prestige: 10 };
+  processRandomEvents(gameState, studio, seq([0.99]));
+  assert.equal(studio.money, 1000000);
+  assert.equal(studio.fans, 1000);
+  assert.equal(studio.prestige, 10);
+  assert.equal(gameState.notifications.length, 0);
+});
+
+test("processRandomEvents caps history at 50 entries", () => {
+  const gameState = {
+    currentWeek: 100,
+    notifications: [],
+    randomEvents: {
+      cooldowns: {},
+      history: Array.from({ length: 50 }, (_, i) => ({ id: `old${i}`, label: "Old", week: i })),
+    },
+  };
+  const studio = { money: 1000000, fans: 1000, prestige: 10 };
+  processRandomEvents(gameState, studio, seq([0.0, 0.0]));
+  assert.ok(gameState.randomEvents.history.length <= 50);
+  const last = gameState.randomEvents.history[gameState.randomEvents.history.length - 1];
+  assert.equal(last.week, 100);
+});


### PR DESCRIPTION
Closes #14 

## Problem Analysis

The simulation progressed in a fully predictable manner — every week was payroll, production updates, and talent aging. No unexpected industry events ever occurred, making every playthrough feel identical. `eventEngine.js` and `constants/eventTypes.js` were scaffolded but empty. The tick loop had no event step. There was no persistence field on `GameState` for event state, so even if events fired they couldn't track cooldowns between weeks.

## Architecture Decision

Rather than a hardcoded switch-case or a single global event, I implemented a **data-driven, weighted random system** where all events live as plain objects in `constants/eventTypes.js`. Adding a new event requires inserting one object in that array — no engine changes needed (acceptance criterion: "New events can be added without major refactoring").

The engine core is written as **pure functions with injectable RNG** so event selection, effect application, and cooldown logic are fully unit-testable. The stateful entry point (`processRandomEvents`) is a thin wrapper that reads/writes `gameState.randomEvents` and mutates `studio` stats before persistence.

## Files Changed

### `backend/src/constants/eventTypes.js` — NEW (219 lines)

Data-driven catalogue of 15 events across 3 rarity tiers:

**Positive (9 events):**
- Viral Marketing Success (common) — +8% fans
- Celebrity Casting Boost (common) — +5% fans
- Streaming Surge (common) — +₹750k + 3% fans
- Award Buzz (uncommon) — +25 prestige
- Market Boom (uncommon) — +6% money
- Government Film Incentive (uncommon) — +₹1.2M
- International Market Expansion (uncommon) — +6% fans + 4% money
- Major Franchise Announcement (rare) — +12% fans + 15 prestige
- Technology Breakthrough in VFX (rare) — +30 prestige

**Negative (6 events):**
- Actor Scandal (common) — -7% fans
- Social Media Backlash (common) — -5% fans
- Industry Strike (uncommon) — -5% money
- Production Accident (uncommon) — -₹600k
- Talent Retirement (uncommon) — -15 prestige
- Economic Recession (rare) — -8% money + -3% fans

`EVENT_CONFIG` centralises all tuning knobs:
```js
baseTriggerChance: 0.3      // 30% chance per week an event attempts to fire
maxEventsPerTick: 1         // max events per week
maxPercentMagnitude: 15     // safety clamp: no percent effect exceeds ±15%
maxFlatMagnitude: 1500000   // safety clamp: no flat effect exceeds ±₹1.5M
rarityWeightMultiplier: { common: 1, uncommon: 0.6, rare: 0.3 }
```

### `backend/src/services/simulation/engines/eventEngine.js` — NEW (233 lines)

Five exports — four pure functions + one stateful entry point:

**`pickWeightedEvent(candidates, rng)`** — Weighted selection with rarity multiplier applied to each candidate's base weight. Floating-point safe (last-candidate fallback). Returns null for empty/zero-weight inputs.

**`getEligibleEvents(cooldowns)`** — Filters the full catalogue to events not currently on cooldown. Cooldown check is `cooldowns[id] > 0`.

**`applyEventEffects(stats, event)`** — PURE. Takes a `{money, fans, prestige}` snapshot and an event definition. Applies each effect (flat or percent), clamps magnitudes to `EVENT_CONFIG` bounds, floors stats at 0 (matching the Studio schema `min: 0`), and returns `{ stats: newStats, changes: [{target, delta}] }`. Reports the *actual* applied delta after the floor clamp so notifications never overstate a loss.

**`rollEvents(state, stats, rng)`** — PURE weekly transition. Ticks down cooldowns (drops zeroed entries). Gates each event attempt on `baseTriggerChance`. Calls `getEligibleEvents` → `pickWeightedEvent` → `applyEventEffects`. Sets the fired event's cooldown. Returns `{ stats, cooldowns, fired }` — no mutation of inputs.

**`processRandomEvents(gameState, studio, rng)`** — Stateful entry point. Initialises `gameState.randomEvents` on first call (backward-compatible). Calls `rollEvents`, writes stat changes back to `studio`, persists cooldowns + rolling history (capped at 50 entries), pushes a notification describing what happened and what changed. Calls `markModified("randomEvents")` so Mongoose persists the Mixed subtree.

### `backend/src/models/GameState.js` — EDITED (+18 lines)

Added `randomEvents` field after `currentWeek` (far from any other PR's additions — ensures clean auto-merge):
```js
randomEvents: {
  cooldowns: { type: mongoose.Schema.Types.Mixed, default: {} },
  history: [{ id: String, label: String, week: Number }],
},
```
`cooldowns` is `Mixed` because keys are dynamic event IDs. `history` is a capped rolling log of fired events (last 50). Field is entirely optional — existing saves load unchanged and get a fresh `randomEvents` on their first tick.

### `backend/src/services/simulation/engines/tickEngine.js` — EDITED (+5 lines)

`processRandomEvents` is called **last** in `processWeeklyTick` (after `processDirectorAwards`), so events react to the week's full activity before studio stats are persisted. Import added at the top.

### `backend/tests/eventEngine.test.js` — NEW (254 lines, 24 tests)

Uses Node's built-in `node:test` — zero new dependencies. Deterministic `seq(values)` RNG makes every test reproducible.

| Group | Tests |
|---|---|
| `pickWeightedEvent` | empty/null, zero-weight, boundary weights, rarity multiplier |
| `getEligibleEvents` | full catalogue when no cooldowns, active cooldown excluded, cooldown=0 included |
| `applyEventEffects` | flat positive, percent, 0-floor + clamped delta report, percent cap, flat cap, multi-effect, unknown target safe |
| `rollEvents` | no fire on high roll, fires on low roll + cooldown set, cooldown tick, cooldown drop at zero, maxEventsPerTick cap, stats changed when event fires |
| `processRandomEvents` | initialises on first call, writes stats + notification + history, no-op when nothing fires, history capped at 50 |

All 24 pass:
```
npm test
# tests 24 | pass 24 | fail 0
```

End-to-end smoke verified: Viral Marketing fired → fans 50,000 → 54,000 (+8% = +4,000 exactly). Week 2 cooldown ticked 6→5. Week 3 picked a different event (Award Buzz) because Viral Marketing was still on cooldown.

`backend/package.json` updated with `"test": "node --test \"tests/**/*.test.js\""`.

## Balance Analysis

| Concern | How addressed |
|---|---|
| Events too frequent | 30% weekly trigger chance — roughly 1 event every 3–4 weeks |
| Same event repeating | Per-event cooldowns (6–16 weeks depending on rarity) |
| Events fully predictable | Weighted random selection + variable trigger timing |
| Game-breaking effects | ±15% / ±1.5M safety clamps in `EVENT_CONFIG` |
| Existing saves breaking | `randomEvents` optional, initialised on first tick |
| Hard to add new events | One object in `EVENT_DEFINITIONS`, zero engine changes |

## Testing

```
npm test
# tests 24 | pass 24 | fail 0
```

## Checklist
- [x] Random events trigger during simulation ticks
- [x] Event probabilities are configurable (`EVENT_CONFIG.baseTriggerChance`)
- [x] Studio statistics modified by events (money / fans / prestige)
- [x] Players receive clear notifications with exact stat changes
- [x] New events can be added without major refactoring (one object in `eventTypes.js`)
- [x] Both positive and negative events supported (9 positive, 6 negative)
- [x] Weighted rarity system (common / uncommon / rare with multipliers)
- [x] Cooldowns prevent predictable repetition
- [x] Backward-compatible — existing saves unaffected
- [x] 24 tests passing, zero new dependencies
- [x] Targets `elusoc` branch
