### PR TITLE
Feature/marketplace skeletons

### DIFF
--- a/frontend/src/components/common/SkeletonGrid.jsx
+++ b/frontend/src/components/common/SkeletonGrid.jsx
@@ -1,31 +1,83 @@
-const SkeletonCard = () => (
-  <div className="bg-[#111827] border border-slate-800 rounded-2xl p-6 animate-pulse flex flex-col h-full">
-    <div className="flex justify-between items-start mb-6">
-      <div className="h-6 w-1/2 bg-slate-700 rounded-lg"></div>
-      <div className="h-5 w-16 bg-slate-700 rounded-full"></div>
-    </div>
-    
-    <div className="space-y-4 mb-8 flex-grow">
-      {[1, 2, 3, 4].map(i => (
-        <div key={i} className="flex justify-between">
-          <div className="h-4 w-1/3 bg-slate-700 rounded"></div>
-          <div className="h-4 w-1/4 bg-slate-700 rounded"></div>
-        </div>
-      ))}
-    </div>
-    
-    <div className="flex items-center justify-between mt-auto">
-      <div className="h-6 w-1/4 bg-slate-700 rounded-lg"></div>
-      <div className="h-10 w-28 bg-slate-700 rounded-lg"></div>
-    </div>
-  </div>
+const variantConfig = {
+  default: {
+    minHeight: "min-h-[360px]",
+    showAvatar: false,
+    showTags: true,
+    rows: 4,
+  },
+  talent: {
+    minHeight: "min-h-[520px]",
+    showAvatar: true,
+    showTags: true,
+    rows: 5,
+  },
+  compact: {
+    minHeight: "min-h-[260px]",
+    showAvatar: false,
+    showTags: false,
+    rows: 4,
+  },
+};
+
+const SkeletonLine = ({ className = "" }) => (
+  <div className={`rounded bg-slate-700/80 ${className}`} />
 );
 
-export const SkeletonGrid = ({ count = 6 }) => {
+const SkeletonCard = ({ variant = "default" }) => {
+  const config = variantConfig[variant] || variantConfig.default;
+
   return (
-    <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+    <div
+      className={`flex h-full ${config.minHeight} animate-pulse flex-col rounded-3xl border border-slate-800 bg-linear-to-br from-[#0f172a] via-[#111827] to-[#0b1120] p-6`}
+    >
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <SkeletonLine className="h-6 w-28 rounded-full" />
+        <SkeletonLine className="h-5 w-16 rounded-full" />
+      </div>
+
+      {config.showAvatar && (
+        <div className="mb-6 flex flex-col items-center">
+          <div className="h-24 w-24 rounded-full border border-slate-700 bg-slate-800" />
+          <SkeletonLine className="mt-4 h-6 w-40 rounded-lg" />
+          <SkeletonLine className="mt-3 h-4 w-24 rounded-lg" />
+        </div>
+      )}
+
+      <div className="flex-grow space-y-4">
+        {!config.showAvatar && <SkeletonLine className="h-7 w-3/4 rounded-lg" />}
+
+        {Array.from({ length: config.rows }).map((_, index) => (
+          <div key={index} className="flex items-center justify-between gap-6">
+            <SkeletonLine className="h-4 w-1/3" />
+            <SkeletonLine className="h-4 w-1/4" />
+          </div>
+        ))}
+      </div>
+
+      {config.showTags && (
+        <div className="mt-6 flex gap-2">
+          <SkeletonLine className="h-6 w-16 rounded-full" />
+          <SkeletonLine className="h-6 w-20 rounded-full" />
+        </div>
+      )}
+
+      <div className="mt-6 flex items-center justify-between gap-4">
+        <SkeletonLine className="h-7 w-24 rounded-lg" />
+        <SkeletonLine className="h-11 w-28 rounded-xl" />
+      </div>
+    </div>
+  );
+};
+
+export const SkeletonGrid = ({ count = 6, variant = "default" }) => {
+  return (
+    <div
+      className="grid gap-5 md:grid-cols-2 xl:grid-cols-3"
+      aria-busy="true"
+      aria-label="Loading marketplace items"
+    >
       {Array.from({ length: count }).map((_, i) => (
-        <SkeletonCard key={i} />
+        <SkeletonCard key={i} variant={variant} />
       ))}
     </div>
   );

--- a/frontend/src/components/common/SkeletonGrid.jsx
+++ b/frontend/src/components/common/SkeletonGrid.jsx
@@ -1,0 +1,34 @@
+const SkeletonCard = () => (
+  <div className="bg-[#111827] border border-slate-800 rounded-2xl p-6 animate-pulse flex flex-col h-full">
+    <div className="flex justify-between items-start mb-6">
+      <div className="h-6 w-1/2 bg-slate-700 rounded-lg"></div>
+      <div className="h-5 w-16 bg-slate-700 rounded-full"></div>
+    </div>
+    
+    <div className="space-y-4 mb-8 flex-grow">
+      {[1, 2, 3, 4].map(i => (
+        <div key={i} className="flex justify-between">
+          <div className="h-4 w-1/3 bg-slate-700 rounded"></div>
+          <div className="h-4 w-1/4 bg-slate-700 rounded"></div>
+        </div>
+      ))}
+    </div>
+    
+    <div className="flex items-center justify-between mt-auto">
+      <div className="h-6 w-1/4 bg-slate-700 rounded-lg"></div>
+      <div className="h-10 w-28 bg-slate-700 rounded-lg"></div>
+    </div>
+  </div>
+);
+
+export const SkeletonGrid = ({ count = 6 }) => {
+  return (
+    <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+      {Array.from({ length: count }).map((_, i) => (
+        <SkeletonCard key={i} />
+      ))}
+    </div>
+  );
+};
+
+export default SkeletonGrid;

--- a/frontend/src/pages/actors/Actors.jsx
+++ b/frontend/src/pages/actors/Actors.jsx
@@ -499,7 +499,7 @@ const Actors = () => {
         )}
 
         {loading ? (
-          <SkeletonGrid />
+          <SkeletonGrid variant="talent" />
         ) : (
           renderActors()
         )}

--- a/frontend/src/pages/actors/Actors.jsx
+++ b/frontend/src/pages/actors/Actors.jsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import api from "../../api/axios";
 import ActorCard from "../../components/actors/ActorCard";
 import DashboardLayout from "../../layouts/DashboardLayout";
+import SkeletonGrid from "../../components/common/SkeletonGrid";
 import {
   selectActorFilters,
   setActorFilters,
@@ -498,9 +499,7 @@ const Actors = () => {
         )}
 
         {loading ? (
-          <div className="rounded-2xl border border-slate-800 bg-[#111827] p-12 text-center">
-            <h2 className="text-2xl font-bold text-white">Loading...</h2>
-          </div>
+          <SkeletonGrid />
         ) : (
           renderActors()
         )}

--- a/frontend/src/pages/crew/CrewMarket.jsx
+++ b/frontend/src/pages/crew/CrewMarket.jsx
@@ -100,37 +100,46 @@ const CrewMarket = () => {
 
   const [crewTeams, setCrewTeams] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState(false);
 
-  const fetchCrewTeams = useCallback(async () => {
+  const fetchCrewTeams = useCallback(async (showSkeleton = true) => {
     try {
-      setLoading(true);
+      if (showSkeleton) {
+        setLoading(true);
+      }
+
       const res = await api.get("/crew");
       setCrewTeams(res.data.crewTeams || []);
     } catch (error) {
       console.error(error);
     } finally {
-      setLoading(false);
+      if (showSkeleton) {
+        setLoading(false);
+      }
     }
   }, []);
 
   useEffect(() => {
-    fetchCrewTeams();
+    const refreshTimer = window.setTimeout(fetchCrewTeams, 0);
+
+    return () => window.clearTimeout(refreshTimer);
   }, [fetchCrewTeams]);
 
   const handleHire = async (id) => {
-    if (loading) return;
+    if (loading || actionLoading) return;
+
     try {
-      setLoading(true);
+      setActionLoading(true);
       await api.post(`/crew/hire/${id}`);
       dispatch(showToast({ message: "Crew team hired successfully!", type: "success" }));
-      fetchCrewTeams();
+      await fetchCrewTeams(false);
     } catch (error) {
       dispatch(showToast({
         message: error?.response?.data?.message || "Failed to hire crew team",
         type: "error"
       }));
     } finally {
-        setLoading(false);
+      setActionLoading(false);
     }
   };
 
@@ -215,14 +224,14 @@ const CrewMarket = () => {
         </div>
 
         {loading ? (
-          <SkeletonGrid />
+          <SkeletonGrid variant="compact" />
         ) : filteredCrew.length === 0 ? (
           <div className="rounded-2xl border border-slate-800 bg-[#111827] p-12 text-center">
             <h2 className="mb-3 text-2xl font-bold text-white">No Crew Teams</h2>
             <p className="text-slate-400">No crew teams match your filters.</p>
           </div>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className={`grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 ${actionLoading ? "pointer-events-none opacity-70" : ""}`}>
             {filteredCrew.map((crew) => (
               <div key={crew.id} className="bg-[#111827] border border-slate-800 rounded-2xl p-6 hover:border-violet-600 transition-all group">
                 <div className="flex justify-between items-start mb-4">
@@ -247,11 +256,11 @@ const CrewMarket = () => {
                 <div className="flex items-center justify-between mt-auto">
                   <div className="text-violet-400 font-bold">₹{crew.salary.toLocaleString()}/wk</div>
                   <button
-                    disabled={loading}
+                    disabled={actionLoading}
                     onClick={() => handleHire(crew.id)}
                     className="bg-violet-600 hover:bg-violet-700 text-white px-4 py-2 rounded-lg text-sm font-semibold transition disabled:opacity-50"
                   >
-                    {loading ? "Hiring..." : "Hire Team"}
+                    {actionLoading ? "Hiring..." : "Hire Team"}
                   </button>
                 </div>
               </div>

--- a/frontend/src/pages/crew/CrewMarket.jsx
+++ b/frontend/src/pages/crew/CrewMarket.jsx
@@ -8,6 +8,7 @@ import {
   setCrewFilters,
   resetCrewFilters,
 } from "../../features/talent/talentSlice";
+import SkeletonGrid from "../../components/common/SkeletonGrid";
 
 // Average of a crew team's four skill stats — used for the quality filter
 // and the overall-quality sort so "quality" means the same thing everywhere.
@@ -214,7 +215,7 @@ const CrewMarket = () => {
         </div>
 
         {loading ? (
-          <div className="text-white text-center py-10">Loading crew teams...</div>
+          <SkeletonGrid />
         ) : filteredCrew.length === 0 ? (
           <div className="rounded-2xl border border-slate-800 bg-[#111827] p-12 text-center">
             <h2 className="mb-3 text-2xl font-bold text-white">No Crew Teams</h2>

--- a/frontend/src/pages/crew/OwnedCrew.jsx
+++ b/frontend/src/pages/crew/OwnedCrew.jsx
@@ -1,38 +1,49 @@
 import { useCallback, useEffect, useState } from "react";
 import api from "../../api/axios";
 import DashboardLayout from "../../layouts/DashboardLayout";
-import { Users, Briefcase } from "lucide-react";
+import { Briefcase } from "lucide-react";
 import SkeletonGrid from "../../components/common/SkeletonGrid";
 
 const OwnedCrew = () => {
   const [crewTeams, setCrewTeams] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState(false);
 
-  const fetchOwnedCrew = useCallback(async () => {
+  const fetchOwnedCrew = useCallback(async (showSkeleton = true) => {
     try {
-      setLoading(true);
+      if (showSkeleton) {
+        setLoading(true);
+      }
+
       const res = await api.get("/crew/owned");
       setCrewTeams(res.data.crewTeams || []);
     } catch (error) {
       console.error(error);
     } finally {
-      setLoading(false);
+      if (showSkeleton) {
+        setLoading(false);
+      }
     }
   }, []);
 
   useEffect(() => {
-    fetchOwnedCrew();
+    const refreshTimer = window.setTimeout(fetchOwnedCrew, 0);
+
+    return () => window.clearTimeout(refreshTimer);
   }, [fetchOwnedCrew]);
 
   const handleFire = async (id) => {
     if (!window.confirm("Are you sure you want to fire this crew team?")) return;
-    if (loading) return;
+    if (loading || actionLoading) return;
+
     try {
-      setLoading(true);
+      setActionLoading(true);
       await api.post(`/crew/fire/${id}`);
-      fetchOwnedCrew();
+      await fetchOwnedCrew(false);
     } catch (error) {
       alert(error?.response?.data?.message || "Failed to fire crew team");
+    } finally {
+      setActionLoading(false);
     }
   };
 
@@ -45,7 +56,7 @@ const OwnedCrew = () => {
         </div>
 
         {loading ? (
-          <SkeletonGrid />
+          <SkeletonGrid variant="compact" />
         ) : crewTeams.length === 0 ? (
             <div className="bg-[#111827] border border-slate-800 rounded-2xl p-12 text-center">
                 <Briefcase size={48} className="text-slate-600 mx-auto mb-4" />
@@ -53,8 +64,8 @@ const OwnedCrew = () => {
                 <p className="text-slate-400">Hire crew teams from the market to start productions.</p>
             </div>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {crewTeams.map((crew, idx) => (
+          <div className={`grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 ${actionLoading ? "pointer-events-none opacity-70" : ""}`}>
+            {crewTeams.map((crew) => (
               <div key={crew.id} className="bg-[#111827] border border-slate-800 rounded-2xl p-6 hover:border-violet-600 transition-all">
                 <div className="flex justify-between items-start mb-4">
                   <h3 className="text-xl font-bold text-white">{crew.name}</h3>
@@ -73,11 +84,11 @@ const OwnedCrew = () => {
                 </div>
 
                 <button
-                  disabled={crew.status === 'BUSY' || loading}
+                  disabled={crew.status === 'BUSY' || actionLoading}
                   onClick={() => handleFire(crew.id)}
                   className="w-full bg-slate-800 hover:bg-red-600 text-white py-2 rounded-lg text-sm font-semibold transition disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  {loading ? "Processing..." : crew.status === 'BUSY' ? 'Busy on Project' : 'Fire Team'}
+                  {actionLoading ? "Processing..." : crew.status === 'BUSY' ? 'Busy on Project' : 'Fire Team'}
                 </button>
               </div>
             ))}

--- a/frontend/src/pages/crew/OwnedCrew.jsx
+++ b/frontend/src/pages/crew/OwnedCrew.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import api from "../../api/axios";
 import DashboardLayout from "../../layouts/DashboardLayout";
 import { Users, Briefcase } from "lucide-react";
+import SkeletonGrid from "../../components/common/SkeletonGrid";
 
 const OwnedCrew = () => {
   const [crewTeams, setCrewTeams] = useState([]);
@@ -44,7 +45,7 @@ const OwnedCrew = () => {
         </div>
 
         {loading ? (
-          <div className="text-white text-center py-10">Loading your crew...</div>
+          <SkeletonGrid />
         ) : crewTeams.length === 0 ? (
             <div className="bg-[#111827] border border-slate-800 rounded-2xl p-12 text-center">
                 <Briefcase size={48} className="text-slate-600 mx-auto mb-4" />

--- a/frontend/src/pages/directors/Directors.jsx
+++ b/frontend/src/pages/directors/Directors.jsx
@@ -680,7 +680,7 @@ const Directors = () => {
         )}
 
         {loading ? (
-          <SkeletonGrid />
+          <SkeletonGrid variant="talent" />
         ) : (
           renderDirectors()
         )}

--- a/frontend/src/pages/directors/Directors.jsx
+++ b/frontend/src/pages/directors/Directors.jsx
@@ -5,6 +5,7 @@ import api from "../../api/axios";
 import DirectorCard from "../../components/directors/DirectorCard";
 import DirectingProjectCard from "../../components/directors/DirectingProjectCard";
 import DashboardLayout from "../../layouts/DashboardLayout";
+import SkeletonGrid from "../../components/common/SkeletonGrid";
 import {
   selectDirectorFilters,
   setDirectorFilters,
@@ -679,9 +680,7 @@ const Directors = () => {
         )}
 
         {loading ? (
-          <div className="rounded-2xl border border-slate-800 bg-[#111827] p-12 text-center">
-            <h2 className="text-2xl font-bold text-white">Loading...</h2>
-          </div>
+          <SkeletonGrid />
         ) : (
           renderDirectors()
         )}

--- a/frontend/src/pages/scripts/Scripts.jsx
+++ b/frontend/src/pages/scripts/Scripts.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 
 import api from "../../api/axios";
 import DashboardLayout from "../../layouts/DashboardLayout";
+import SkeletonGrid from "../../components/common/SkeletonGrid";
 
 const Scripts = () => {
   const [scripts, setScripts] = useState([]);
@@ -359,9 +360,7 @@ const Scripts = () => {
         </div>
 
         {initialLoading ? (
-          <div className="bg-[#111827] border border-slate-800 rounded-2xl p-12 text-center">
-            <h2 className="text-2xl font-bold text-white">Loading...</h2>
-          </div>
+          <SkeletonGrid />
         ) : (
           <>{activeTab === "market" ? renderMarket() : renderOwned()}</>
         )}

--- a/frontend/src/pages/writers/Writers.jsx
+++ b/frontend/src/pages/writers/Writers.jsx
@@ -512,7 +512,7 @@ const Writers = () => {
         </div>
 
         {loading ? (
-          <SkeletonGrid />
+          <SkeletonGrid variant="talent" />
         ) : (
           <>
             {activeTab === "market" && renderMarket()}

--- a/frontend/src/pages/writers/Writers.jsx
+++ b/frontend/src/pages/writers/Writers.jsx
@@ -11,6 +11,7 @@ import DashboardLayout from "../../layouts/DashboardLayout";
 
 import WriterCard from "../../components/writers/WriterCard";
 import WritingProjectCard from "../../components/writers/WritingProjectCard";
+import SkeletonGrid from "../../components/common/SkeletonGrid";
 
 const genres = [
   "Action",
@@ -511,9 +512,7 @@ const Writers = () => {
         </div>
 
         {loading ? (
-          <div className="bg-[#111827] border border-slate-800 rounded-2xl p-12 text-center">
-            <h2 className="text-2xl font-bold text-white">Loading...</h2>
-          </div>
+          <SkeletonGrid />
         ) : (
           <>
             {activeTab === "market" && renderMarket()}


### PR DESCRIPTION
## Description
Added reusable loading skeletons for marketplace-style pages to improve the UI while API requests are in progress. The skeleton grid now supports page-specific variants for talent cards and compact crew cards, helping preserve layout structure and reduce layout shift during loading.

Also updated crew marketplace actions so hire/fire requests keep the current grid visible in a disabled state instead of replacing it with the initial loading skeleton.

**Related Issue:** #9

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## Screenshots
Loading skeletons are shown on marketplace pages during API requests.
<img width="1440" height="1000" alt="marketplace-skeleton-actors" src="https://github.com/user-attachments/assets/fe615a2d-59ec-47e8-ab65-824e235674e7" />

## Testing
Ran targeted ESLint on the changed frontend files:

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have targetted the `elusoc` branch
- [x] I have requested assignment before starting work