### PR TITLE
feat(talent): show contract duration and total salary on talent cards (Closes #24)

### DIFF
--- a/frontend/src/components/actors/ActorCard.jsx
+++ b/frontend/src/components/actors/ActorCard.jsx
@@ -1,3 +1,5 @@
+import { STANDARD_CONTRACT_WEEKS, getTotalSalary } from "../../config/contract";
+
 const rarityStyles = {
   Common: "bg-slate-500/20 text-slate-300 border border-slate-500/30",
   Uncommon: "bg-emerald-500/20 text-emerald-300 border border-emerald-500/30",
@@ -16,7 +18,7 @@ const cardStyles = {
 
 const formatMoney = (amount) => Number(amount || 0).toLocaleString("en-IN");
 
-const ActorCard = ({ actor, index, mode, onHire, onFire }) => {
+const ActorCard = ({ actor, index, mode, onHire, onFire, contractWeeks = STANDARD_CONTRACT_WEEKS }) => {
   const avatar = `https://api.dicebear.com/7.x/personas/svg?seed=${actor.avatarSeed}`;
   const canRelease = actor.status === "AVAILABLE";
   const hiddenStats = actor.statsRevealed === false || Number(actor.discovered || 0) < 50;
@@ -95,11 +97,21 @@ const ActorCard = ({ actor, index, mode, onHire, onFire }) => {
         </div>
       </div>
 
-      <div className="mt-5">
+      <div className="mt-5 space-y-1">
         <p className="text-lg font-bold text-green-400">
           ₹{formatMoney(actor.salary)}
           <span className="ml-1 text-xs text-slate-400">/week</span>
         </p>
+        <div className="flex items-center justify-between text-xs text-slate-400">
+          <span>Contract Duration</span>
+          <span>{contractWeeks} weeks</span>
+        </div>
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-slate-400">Total Salary</span>
+          <span className="font-semibold text-green-400">
+            ₹{formatMoney(getTotalSalary(actor.salary, contractWeeks))}
+          </span>
+        </div>
       </div>
 
       {mode === "market" && (

--- a/frontend/src/components/directors/DirectorCard.jsx
+++ b/frontend/src/components/directors/DirectorCard.jsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { STANDARD_CONTRACT_WEEKS, getTotalSalary } from "../../config/contract";
 
 const rarityStyles = {
   Common: "bg-slate-500/20 text-slate-300 border border-slate-500/30",
@@ -27,6 +28,7 @@ const DirectorCard = ({
   onStartDirecting,
   hitRate = 0,
   averageRating = 0,
+  contractWeeks = STANDARD_CONTRACT_WEEKS,
 }) => {
   const avatar = `https://api.dicebear.com/7.x/personas/svg?seed=${director.avatarSeed}`;
   const canRelease = director.status === "AVAILABLE";
@@ -153,11 +155,21 @@ const DirectorCard = ({
         </div>
       </div>
 
-      <div className="mt-5">
+      <div className="mt-5 space-y-1">
         <p className="text-lg font-bold text-green-400">
           ₹{formatMoney(director.salary)}
           <span className="ml-1 text-xs text-slate-400">/week</span>
         </p>
+        <div className="flex items-center justify-between text-xs text-slate-400">
+          <span>Contract Duration</span>
+          <span>{contractWeeks} weeks</span>
+        </div>
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-slate-400">Total Salary</span>
+          <span className="font-semibold text-green-400">
+            ₹{formatMoney(getTotalSalary(director.salary, contractWeeks))}
+          </span>
+        </div>
       </div>
 
       <Link

--- a/frontend/src/components/writers/WriterCard.jsx
+++ b/frontend/src/components/writers/WriterCard.jsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { STANDARD_CONTRACT_WEEKS, getTotalSalary } from "../../config/contract";
 
 const rarityStyles = {
   Common: "bg-slate-500/20 text-slate-300 border border-slate-500/30",
@@ -31,6 +32,7 @@ const WriterCard = ({
   onHire,
   onFire,
   onStartWriting,
+  contractWeeks = STANDARD_CONTRACT_WEEKS,
 }) => {
   const avatar = `https://api.dicebear.com/7.x/personas/svg?seed=${writer.avatarSeed}`;
 
@@ -131,11 +133,21 @@ const WriterCard = ({
         ))}
       </div>
 
-      <div className="mt-5">
+      <div className="mt-5 space-y-1">
         <p className="text-green-400 text-lg font-bold">
           ₹{writer.salary?.toLocaleString()}
           <span className="text-xs text-slate-400 ml-1">/week</span>
         </p>
+        <div className="flex items-center justify-between text-xs text-slate-400">
+          <span>Contract Duration</span>
+          <span>{contractWeeks} weeks</span>
+        </div>
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-slate-400">Total Salary</span>
+          <span className="text-green-400 font-semibold">
+            ₹{getTotalSalary(writer.salary, contractWeeks).toLocaleString()}
+          </span>
+        </div>
       </div>
 
       <Link

--- a/frontend/src/config/contract.js
+++ b/frontend/src/config/contract.js
@@ -1,0 +1,14 @@
+// Standard talent contract length used across the studio, in weeks.
+//
+// This mirrors the production cost model in the backend (movieController.js),
+// where talent is paid for the full production cycle:
+//   4 weeks pre-production + 10 weeks production + 6 weeks post-production = 20.
+// Keeping a single constant here means the marketplace "Total Salary" figure
+// matches what a studio is actually charged when the talent is put on a film.
+export const STANDARD_CONTRACT_WEEKS = 20;
+
+// Total salary paid to a talent over a contract of `weeks` weeks.
+// Pure function of its inputs, so any view that passes a specific duration
+// (e.g. a film's remaining production weeks) gets a total that updates with it.
+export const getTotalSalary = (weeklySalary, weeks = STANDARD_CONTRACT_WEEKS) =>
+  Number(weeklySalary || 0) * Number(weeks || 0);

--- a/frontend/src/pages/crew/CrewMarket.jsx
+++ b/frontend/src/pages/crew/CrewMarket.jsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import api from "../../api/axios";
 import DashboardLayout from "../../layouts/DashboardLayout";
 import { showToast } from "../../features/ui/toastSlice";
+import { STANDARD_CONTRACT_WEEKS, getTotalSalary } from "../../config/contract";
 import {
   selectCrewFilters,
   setCrewFilters,
@@ -254,7 +255,13 @@ const CrewMarket = () => {
                 </div>
 
                 <div className="flex items-center justify-between mt-auto">
-                  <div className="text-violet-400 font-bold">₹{crew.salary.toLocaleString()}/wk</div>
+                  <div>
+                    <div className="text-violet-400 font-bold">₹{crew.salary.toLocaleString()}/wk</div>
+                    <div className="text-xs text-slate-400">
+                      Total ₹{getTotalSalary(crew.salary, STANDARD_CONTRACT_WEEKS).toLocaleString()}
+                      <span className="ml-1">({STANDARD_CONTRACT_WEEKS}w)</span>
+                    </div>
+                  </div>
                   <button
                     disabled={actionLoading}
                     onClick={() => handleHire(crew.id)}


### PR DESCRIPTION
## Summary

Adds total contract salary alongside the existing weekly figure on every talent
card in the marketplace, so players can see the full financial impact of a hire
without manual calculation. Closes #24.

Each talent card now shows:

  Weekly Salary:     ₹X /week
  Contract Duration: 20 weeks
  Total Salary:      ₹(X × 20)

## Why 20 weeks

The standard contract duration matches the backend's existing production cost model
in `movieController.js`, where talent is charged for the full production cycle:
`totalProductionWeeks = 20` (4 pre-production + 10 production + 6 post-production),
e.g. `leadActorCost = salary * totalProductionWeeks`. So the "Total Salary" shown in
the marketplace is exactly what a studio pays when the talent is put on a film.

Duration is a `contractWeeks` prop defaulting to 20, so the total recalculates
dynamically if a specific production duration is ever passed in from a movie context.

## Files changed

- `frontend/src/config/contract.js` *(new)* — `STANDARD_CONTRACT_WEEKS = 20` and
  a pure `getTotalSalary(weekly, weeks)` helper as a single source of truth.
- `ActorCard.jsx`, `WriterCard.jsx`, `DirectorCard.jsx` — each card now shows
  Contract Duration and Total Salary beneath the weekly rate, using existing
  currency formatting and card styling.
- `CrewMarket.jsx` — inline total salary shown beneath the `/wk` figure.

## Verification

- `npm run lint` on the 5 changed files: exit 0, 0 new errors introduced.
  (The repo has 47 pre-existing lint errors in unrelated movie/talent pages —
  none are caused by this PR.)
- `npm run build`: passes — 1859 modules transformed.
- No change to hiring, firing, or payroll logic.