### PR TITLE
feat: genre-specific marketing campaign effectiveness (#13)

### DIFF
--- a/backend/src/constants/marketingCampaigns.js
+++ b/backend/src/constants/marketingCampaigns.js
@@ -9,3 +9,54 @@ export const MARKETING_CAMPAIGNS = [
   { id: "influencer", name: "Influencer Campaign", cost: 300000, hypeBoost: 18 },
   { id: "billboards", name: "Billboards", cost: 200000, hypeBoost: 10 },
 ];
+
+// Genre-specific marketing effectiveness.
+//
+// Different genres respond to different promotional channels, so the same
+// campaign produces more hype when it matches a movie's genre. This maps a
+// genre (must match constants/genres.js) to the campaigns it amplifies and the
+// multiplier applied to that campaign's base hypeBoost.
+//
+// The archetypes below follow the real-world matchups from the feature spec:
+//   Horror     -> viral social media          (social / influencer / digital)
+//   Action     -> trailer-focused promotion    (trailer / teaser / tv)
+//   Drama      -> critics & festival / press    (pr / newspaper)
+//   Sci-Fi     -> fan & convention buzz online  (digital / social / influencer)
+//   Animation  -> television & community        (tv / billboards / social)
+// plus a few additional sensible pairings. Any genre/campaign pair not listed
+// here defaults to a neutral x1 multiplier, so existing behaviour is unchanged
+// for unlisted combinations (no regression).
+export const CAMPAIGN_GENRE_EFFECTIVENESS = {
+  Horror: { social: 1.5, influencer: 1.4, digital: 1.2 },
+  Action: { trailer: 1.5, teaser: 1.3, tv: 1.3 },
+  Drama: { pr: 1.5, newspaper: 1.3 },
+  "Sci-Fi": { digital: 1.4, social: 1.3, influencer: 1.3 },
+  Animation: { tv: 1.5, billboards: 1.3, social: 1.2 },
+  Comedy: { social: 1.4, digital: 1.3 },
+  Romance: { social: 1.3, pr: 1.3 },
+  Thriller: { trailer: 1.4, digital: 1.3 },
+  Adventure: { trailer: 1.3, tv: 1.3 },
+  Fantasy: { trailer: 1.3, digital: 1.3 },
+};
+
+// Effectiveness multiplier for a campaign given a movie's genres. A movie can
+// have several genres; we take the best (highest) multiplier across them, so a
+// campaign that strongly matches any one of the movie's genres gets the bonus.
+// Returns 1 (neutral) when no genre amplifies the campaign.
+export const getCampaignEffectiveness = (campaignId, genres) => {
+  if (!Array.isArray(genres) || genres.length === 0) return 1;
+  let best = 1;
+  for (const genre of genres) {
+    const multiplier = CAMPAIGN_GENRE_EFFECTIVENESS[genre]?.[campaignId];
+    if (typeof multiplier === "number" && multiplier > best) {
+      best = multiplier;
+    }
+  }
+  return best;
+};
+
+// The genre-adjusted hype a campaign contributes, rounded to a whole number so
+// the value matches what the movie-creation UI previews. Falls back to the base
+// hypeBoost when the genre/campaign pair is neutral.
+export const getEffectiveHypeBoost = (campaign, genres) =>
+  Math.round(campaign.hypeBoost * getCampaignEffectiveness(campaign.id, genres));

--- a/backend/src/controllers/movieController.js
+++ b/backend/src/controllers/movieController.js
@@ -8,7 +8,7 @@ import { getGenreMultiplier } from "../services/simulation/engines/trendEngine.j
 import { processCareerImpact } from "../services/simulation/engines/careerImpactEngine.js";
 import { processStudioGrowth } from "../services/simulation/engines/studioGrowthEngine.js";
 import { addNotification } from "../services/simulation/helpers/notificationHelper.js";
-import { MARKETING_CAMPAIGNS } from "../constants/marketingCampaigns.js";
+import { MARKETING_CAMPAIGNS, getEffectiveHypeBoost } from "../constants/marketingCampaigns.js";
 import { generateMovieTitle } from "../services/movie/movieService.js";
 import { withTransaction } from "../utils/transactionHelper.js";
 import Notification from "../models/Notification.js";
@@ -130,7 +130,10 @@ export const createMovie = async (req, res) => {
             const campaign = MARKETING_CAMPAIGNS.find(c => c.id === cid);
             if (campaign) {
                 marketingBudget += campaign.cost;
-                marketingHypeBoost += campaign.hypeBoost;
+                // Genre-specific effectiveness: a campaign that matches the
+                // script's genres yields more hype. Neutral (x1) for unlisted
+                // genre/campaign pairs, so existing behaviour is preserved.
+                marketingHypeBoost += getEffectiveHypeBoost(campaign, script.genres);
                 selectedCampaigns.push(cid);
             }
         });

--- a/frontend/src/pages/movies/CreateMovie.jsx
+++ b/frontend/src/pages/movies/CreateMovie.jsx
@@ -16,6 +16,35 @@ const MARKETING_CAMPAIGNS = [
   { id: "billboards", name: "Billboards", cost: 200000, hypeBoost: 10 },
 ];
 
+// Mirror of the server-side genre effectiveness map (backend/src/constants/
+// marketingCampaigns.js). The server is authoritative for the hype actually
+// applied; this copy lets the movie-creation screen preview how effective each
+// campaign is for the selected script's genres. Keep the two in sync.
+const CAMPAIGN_GENRE_EFFECTIVENESS = {
+  Horror: { social: 1.5, influencer: 1.4, digital: 1.2 },
+  Action: { trailer: 1.5, teaser: 1.3, tv: 1.3 },
+  Drama: { pr: 1.5, newspaper: 1.3 },
+  "Sci-Fi": { digital: 1.4, social: 1.3, influencer: 1.3 },
+  Animation: { tv: 1.5, billboards: 1.3, social: 1.2 },
+  Comedy: { social: 1.4, digital: 1.3 },
+  Romance: { social: 1.3, pr: 1.3 },
+  Thriller: { trailer: 1.4, digital: 1.3 },
+  Adventure: { trailer: 1.3, tv: 1.3 },
+  Fantasy: { trailer: 1.3, digital: 1.3 },
+};
+
+const getCampaignEffectiveness = (campaignId, genres) => {
+  if (!Array.isArray(genres) || genres.length === 0) return 1;
+  let best = 1;
+  for (const genre of genres) {
+    const multiplier = CAMPAIGN_GENRE_EFFECTIVENESS[genre]?.[campaignId];
+    if (typeof multiplier === "number" && multiplier > best) {
+      best = multiplier;
+    }
+  }
+  return best;
+};
+
 const CreateMovie = () => {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
@@ -79,6 +108,15 @@ const CreateMovie = () => {
   const totalMarketingBudget = formData.marketingCampaignIds.reduce((sum, id) => {
     const campaign = MARKETING_CAMPAIGNS.find(c => c.id === id);
     return sum + (campaign?.cost || 0);
+  }, 0);
+
+  const selectedScript = scripts.find(s => s.id === formData.scriptId);
+  const selectedGenres = selectedScript?.genres || [];
+
+  const totalEffectiveHype = formData.marketingCampaignIds.reduce((sum, id) => {
+    const campaign = MARKETING_CAMPAIGNS.find(c => c.id === id);
+    if (!campaign) return sum;
+    return sum + Math.round(campaign.hypeBoost * getCampaignEffectiveness(id, selectedGenres));
   }, 0);
 
   const generateTitle = async () => {
@@ -276,6 +314,9 @@ const CreateMovie = () => {
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
                 {MARKETING_CAMPAIGNS.map(campaign => {
                     const active = formData.marketingCampaignIds.includes(campaign.id);
+                    const effectiveness = getCampaignEffectiveness(campaign.id, selectedGenres);
+                    const effectiveHype = Math.round(campaign.hypeBoost * effectiveness);
+                    const boosted = effectiveness > 1;
                     return (
                         <button
                             key={campaign.id}
@@ -290,6 +331,16 @@ const CreateMovie = () => {
                         >
                             <div className="text-white font-bold text-sm mb-1">{campaign.name}</div>
                             <div className="text-violet-400 font-bold text-xs">₹{campaign.cost.toLocaleString()}</div>
+                            <div className="text-xs mt-1 flex flex-wrap items-center gap-1">
+                                <span className={boosted ? 'text-emerald-400 font-bold' : 'text-slate-400'}>
+                                    +{effectiveHype} hype
+                                </span>
+                                {boosted && (
+                                    <span className="text-emerald-400 font-semibold">
+                                        ↑ x{effectiveness.toFixed(1)} genre match
+                                    </span>
+                                )}
+                            </div>
                             {active && <div className="absolute top-2 right-2 bg-violet-500 rounded-full p-0.5"><Check size={12} className="text-white" /></div>}
                         </button>
                     )
@@ -300,6 +351,14 @@ const CreateMovie = () => {
                 <span className="text-slate-400 font-bold uppercase text-xs">Total Marketing Budget</span>
                 <span className="text-white font-black text-xl">₹{totalMarketingBudget.toLocaleString()}</span>
               </div>
+              {formData.marketingCampaignIds.length > 0 && (
+                <div className="mt-3 p-4 bg-slate-950 rounded-xl flex justify-between items-center border border-slate-800">
+                  <span className="text-slate-400 font-bold uppercase text-xs">
+                    Est. Hype from Marketing{selectedGenres.length > 0 ? ` (for ${selectedGenres.join(', ')})` : ''}
+                  </span>
+                  <span className="text-emerald-400 font-black text-xl">+{totalEffectiveHype}</span>
+                </div>
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
Implements genre-specific marketing campaign effectiveness (#13). The same campaign now produces different hype depending on the movie's genres, adding strategic depth to campaign selection.

Closes #13.

## What changed
**`backend/src/constants/marketingCampaigns.js`**
- `MARKETING_CAMPAIGNS` unchanged.
- Added `CAMPAIGN_GENRE_EFFECTIVENESS` — maps a genre to the campaigns it amplifies and the multiplier on that campaign's base `hypeBoost`. Follows the spec's archetypes mapped to existing campaigns:
  - Horror → social / influencer / digital
  - Action → trailer / teaser / tv
  - Drama → pr / newspaper
  - Sci-Fi → digital / social / influencer
  - Animation → tv / billboards / social (all-ages / TV reach)
  - plus a few sensible extras; any unlisted genre/campaign pair stays neutral (×1).
- Added `getCampaignEffectiveness(campaignId, genres)` (best multiplier across a movie's genres) and `getEffectiveHypeBoost(campaign, genres)`.

**`backend/src/controllers/movieController.js`**
- Marketing hype now applies the genre multiplier using the script's `genres`, so effectiveness varies by genre. Flows through the existing `hype` → box-office calculation, so revenue is affected with no change to `boxOfficeEngine`.

**`frontend/src/pages/movies/CreateMovie.jsx`**
- Each campaign card shows its genre-adjusted hype and a "↑ genre match" badge when boosted for the selected script's genres.
- Added an "Est. Hype from Marketing" total that reflects the selected genres.
- The effectiveness map mirrors the server (consistent with the campaign list, which is already mirrored); the server remains authoritative for the hype actually applied.

## Verification
- ✅ `node --check` on both backend files
- ✅ Unit-tested the effectiveness/hype helpers (multi-genre max, neutral defaults, rounding) — all pass
- ✅ ESLint: no new errors introduced (the 2 pre-existing errors in `CreateMovie.jsx` are unchanged from `elusoc`)
- ✅ Full `vite build` passes
- ✅ No regression: `MARKETING_CAMPAIGNS` untouched; unlisted genre/campaign combinations remain neutral (×1)

## Notes
- "Marketing ROI" is surfaced as **effective (genre-adjusted) hype**, since true revenue ROI isn't knowable before release.
- Genre names follow `constants/genres.js` (the spec's "Family" example maps to **Animation**, the all-ages genre in this project).