### PR TITLE
feat: studio leaderboards with multi-metric ranking API and page (#32)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -62,6 +62,7 @@ import notificationRoutes from "./routes/notificationRoutes.js";
 import franchiseRoutes from "./routes/franchiseRoutes.js";
 import streamingRoutes from "./routes/streamingRoutes.js";
 import rivalStudioRoutes from "./routes/rivalStudioRoutes.js";
+import leaderboardRoutes from "./routes/leaderboardRoutes.js";
 
 app.use("/api/auth", authRoutes);
 app.use("/api/scripts", scriptRoutes);
@@ -75,6 +76,7 @@ app.use("/api/notifications", notificationRoutes);
 app.use("/api/franchises", franchiseRoutes);
 app.use("/api/streaming", streamingRoutes);
 app.use("/api/rival-studios", rivalStudioRoutes);
+app.use("/api/leaderboard", leaderboardRoutes);
 
 app.use((req, res) => {
   res.status(404).json({

--- a/backend/src/controllers/leaderboardController.js
+++ b/backend/src/controllers/leaderboardController.js
@@ -1,0 +1,107 @@
+import Studio from "../models/Studio.js";
+
+// Ranking metrics the leaderboard supports, mapped to the Studio field they
+// sort on. Adding a metric here is all that's needed to expose a new ranking.
+const METRIC_FIELDS = {
+  prestige: "prestige",
+  fans: "fans",
+  revenue: "stats.totalRevenue",
+  blockbusters: "stats.allTimeBlockbusters",
+  level: "studioLevel",
+};
+
+// Only these fields are ever returned to the client — no owner emails, money,
+// or financial history leak into the public leaderboard.
+const PROJECTION =
+  "name prestige fans studioLevel stats.totalRevenue stats.blockbusters stats.allTimeBlockbusters stats.moviesReleased owner";
+
+// Read the leaderboard value for a studio for the active metric. Handles the
+// two nested (stats.*) metrics explicitly and the rest as top-level fields.
+const readMetricValue = (studio, field) => {
+  if (field === "stats.totalRevenue") return studio.stats?.totalRevenue || 0;
+  if (field === "stats.allTimeBlockbusters")
+    return studio.stats?.allTimeBlockbusters || 0;
+  return studio[field] || 0;
+};
+
+// Shape a studio document into a public leaderboard entry.
+const toEntry = (studio, rank, currentUserId) => ({
+  rank,
+  studioId: String(studio._id),
+  name: studio.name,
+  prestige: studio.prestige || 0,
+  fans: studio.fans || 0,
+  studioLevel: studio.studioLevel || 1,
+  revenue: studio.stats?.totalRevenue || 0,
+  blockbusters: studio.stats?.allTimeBlockbusters || 0,
+  moviesReleased: studio.stats?.moviesReleased || 0,
+  isCurrentUser: currentUserId ? String(studio.owner) === currentUserId : false,
+});
+
+// GET /api/leaderboard?metric=<metric>&page=<n>&limit=<n>
+//
+// Returns studios ranked by the requested metric (defaults to prestige), with
+// pagination, plus the requesting player's own studio and global rank for that
+// metric so they can see where they stand even when off the current page.
+//
+// This is a read-only aggregation: it never writes to any studio, so it cannot
+// affect existing gameplay.
+export const getLeaderboard = async (req, res) => {
+  try {
+    const metric = String(req.query.metric || "prestige").toLowerCase();
+    const field = METRIC_FIELDS[metric];
+    if (!field) {
+      return res.status(400).json({
+        success: false,
+        message: `Invalid metric. Supported metrics: ${Object.keys(
+          METRIC_FIELDS
+        ).join(", ")}.`,
+      });
+    }
+
+    const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+    const limit = Math.min(50, Math.max(1, parseInt(req.query.limit, 10) || 20));
+    const skip = (page - 1) * limit;
+
+    const [studios, total] = await Promise.all([
+      Studio.find()
+        .sort({ [field]: -1, name: 1 })
+        .skip(skip)
+        .limit(limit)
+        .select(PROJECTION)
+        .lean(),
+      Studio.countDocuments(),
+    ]);
+
+    const currentUserId = String(req.user._id);
+    const leaderboard = studios.map((studio, index) =>
+      toEntry(studio, skip + index + 1, currentUserId)
+    );
+
+    // The requesting player's own studio + global rank for the active metric.
+    let currentUser = null;
+    const myStudio = await Studio.findOne({ owner: req.user._id })
+      .select(PROJECTION)
+      .lean();
+    if (myStudio) {
+      const myValue = readMetricValue(myStudio, field);
+      const higherCount = await Studio.countDocuments({
+        [field]: { $gt: myValue },
+      });
+      currentUser = toEntry(myStudio, higherCount + 1, currentUserId);
+    }
+
+    return res.status(200).json({
+      success: true,
+      metric,
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit) || 1,
+      currentUser,
+      leaderboard,
+    });
+  } catch (error) {
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};

--- a/backend/src/routes/leaderboardRoutes.js
+++ b/backend/src/routes/leaderboardRoutes.js
@@ -1,0 +1,9 @@
+import express from "express";
+import { protect } from "../middleware/authMiddleware.js";
+import { getLeaderboard } from "../controllers/leaderboardController.js";
+
+const router = express.Router();
+
+router.get("/", protect, getLeaderboard);
+
+export default router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,6 +25,7 @@ import StreamingDeals from "./pages/movies/StreamingDeals";
 import StudioStats from "./pages/studio/StudioStats";
 import FinancialHistory from "./pages/studio/FinancialHistory";
 import Franchises from "./pages/studio/Franchises";
+import Leaderboard from "./pages/studio/Leaderboard";
 import TalentProfile from "./pages/talent/TalentProfile";
 import DirectorProfile from "./pages/directors/DirectorProfile";
 import WriterProfile from "./pages/writers/WriterProfile";
@@ -55,6 +56,14 @@ function App() {
           element={
             <ProtectedRoute>
               <RivalStudios />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/leaderboard"
+          element={
+            <ProtectedRoute>
+              <Leaderboard />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/components/common/Sidebar.jsx
+++ b/frontend/src/components/common/Sidebar.jsx
@@ -14,6 +14,7 @@ import {
   IndianRupee,
   X,
   Swords,
+  Trophy,
 } from "lucide-react";
 
 import { Link, useLocation } from "react-router-dom";
@@ -31,6 +32,11 @@ const Sidebar = ({ isOpen, onClose }) => {
       name: "Rival Studios",
       path: "/rivals",
       icon: Swords,
+    },
+    {
+      name: "Leaderboard",
+      path: "/leaderboard",
+      icon: Trophy,
     },
     {
       name: "Movies",

--- a/frontend/src/pages/studio/Leaderboard.jsx
+++ b/frontend/src/pages/studio/Leaderboard.jsx
@@ -1,0 +1,281 @@
+import { useEffect, useState } from "react";
+import {
+  Trophy,
+  Star,
+  Users,
+  IndianRupee,
+  TrendingUp,
+  RefreshCw,
+  Building2,
+  Crown,
+  Medal,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
+
+import api from "../../api/axios";
+import DashboardLayout from "../../layouts/DashboardLayout";
+
+const fmt = (n) => (n || 0).toLocaleString();
+
+// The ranking metrics offered in the filter. `value` reads the display number
+// for a leaderboard entry for that metric.
+const METRICS = [
+  { key: "prestige", label: "Prestige", icon: Star, value: (e) => fmt(e.prestige) },
+  { key: "fans", label: "Fans", icon: Users, value: (e) => fmt(e.fans) },
+  { key: "revenue", label: "Revenue", icon: IndianRupee, value: (e) => `₹${fmt(e.revenue)}` },
+  { key: "blockbusters", label: "Blockbusters", icon: Trophy, value: (e) => fmt(e.blockbusters) },
+  { key: "level", label: "Studio Level", icon: TrendingUp, value: (e) => `Lvl ${e.studioLevel || 1}` },
+];
+
+const rankColor = (rank) =>
+  rank === 1
+    ? "text-yellow-400"
+    : rank === 2
+    ? "text-slate-300"
+    : rank === 3
+    ? "text-orange-400"
+    : "text-slate-600";
+
+const RankBadge = ({ rank }) => {
+  if (rank === 1) return <Crown size={18} className="text-yellow-400" />;
+  if (rank === 2) return <Medal size={18} className="text-slate-300" />;
+  if (rank === 3) return <Medal size={18} className="text-orange-400" />;
+  return <span className={`text-sm font-black ${rankColor(rank)}`}>{rank}</span>;
+};
+
+// A single ranking row. Highlights the current player's studio.
+const LeaderboardRow = ({ entry, activeMetric }) => (
+  <div
+    className={`flex items-center gap-3 p-3 sm:p-4 rounded-2xl border transition ${
+      entry.isCurrentUser
+        ? "bg-violet-600/20 border-violet-500/40"
+        : "bg-[#111827] border-slate-800 hover:border-slate-600"
+    }`}
+  >
+    <div className="w-8 flex items-center justify-center shrink-0">
+      <RankBadge rank={entry.rank} />
+    </div>
+
+    <div className="w-9 h-9 rounded-xl bg-slate-900/70 border border-slate-800 flex items-center justify-center shrink-0">
+      <Building2 size={18} className="text-violet-400" />
+    </div>
+
+    <div className="min-w-0 flex-1">
+      <p
+        className={`font-bold text-sm truncate ${
+          entry.isCurrentUser ? "text-violet-300" : "text-white"
+        }`}
+      >
+        {entry.name}
+        {entry.isCurrentUser && <span className="text-violet-400"> (You)</span>}
+      </p>
+      <p className="text-slate-500 text-[11px] truncate">
+        {fmt(entry.fans)} fans · {entry.prestige} prestige · Lvl {entry.studioLevel || 1} ·{" "}
+        {entry.blockbusters} blockbusters
+      </p>
+    </div>
+
+    <div className="text-right shrink-0">
+      <p className="text-white font-black text-base sm:text-lg tabular-nums">
+        {activeMetric.value(entry)}
+      </p>
+      <p className="text-slate-600 text-[10px] uppercase tracking-wider">
+        {activeMetric.label}
+      </p>
+    </div>
+  </div>
+);
+
+const Leaderboard = () => {
+  const [metric, setMetric] = useState("prestige");
+  const [page, setPage] = useState(1);
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+    const run = async () => {
+      try {
+        const res = await api.get(`/leaderboard?metric=${metric}&page=${page}`);
+        if (!active) return;
+        setData(res.data);
+        setError(null);
+      } catch {
+        if (active) setError("Failed to load the leaderboard. Please try again.");
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+    run();
+    return () => {
+      active = false;
+    };
+  }, [metric, page]);
+
+  const selectMetric = (key) => {
+    if (key === metric) return;
+    setLoading(true);
+    setMetric(key);
+    setPage(1);
+  };
+
+  const goToPage = (next) => {
+    setLoading(true);
+    setPage(next);
+  };
+
+  const activeMetric = METRICS.find((m) => m.key === metric) || METRICS[0];
+  const rows = data?.leaderboard || [];
+  const currentUser = data?.currentUser || null;
+  const totalPages = data?.totalPages || 1;
+  const total = data?.total || 0;
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="rounded-3xl bg-gradient-to-r from-violet-700 via-fuchsia-600 to-amber-500 p-6 sm:p-8 relative overflow-hidden">
+          <div
+            className="absolute inset-0 opacity-10"
+            style={{
+              backgroundImage:
+                "repeating-linear-gradient(45deg, #fff 0, #fff 1px, transparent 0, transparent 50%)",
+              backgroundSize: "20px 20px",
+            }}
+          />
+          <div className="relative z-10">
+            <div className="flex items-center gap-3 mb-2">
+              <Trophy className="text-white" size={32} />
+              <h1 className="text-2xl sm:text-3xl md:text-4xl font-black text-white">
+                Studio Leaderboards
+              </h1>
+            </div>
+            <p className="text-amber-100 text-sm sm:text-base">
+              See how your studio ranks against {total > 0 ? total : "every"} studio
+              {total === 1 ? "" : "s"} across the industry.
+            </p>
+          </div>
+        </div>
+
+        {/* Metric filter */}
+        <div className="flex flex-wrap gap-2">
+          {METRICS.map((m) => {
+            const Icon = m.icon;
+            const isActive = m.key === metric;
+            return (
+              <button
+                key={m.key}
+                type="button"
+                onClick={() => selectMetric(m.key)}
+                className={`flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-bold border transition ${
+                  isActive
+                    ? "bg-violet-600 border-violet-500 text-white"
+                    : "bg-[#111827] border-slate-800 text-slate-400 hover:border-slate-600 hover:text-slate-200"
+                }`}
+              >
+                <Icon size={16} />
+                {m.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Your rank */}
+        {currentUser && (
+          <div className="bg-[#111827] border border-violet-500/30 rounded-2xl p-4 flex items-center gap-3">
+            <div className="w-9 flex items-center justify-center shrink-0">
+              <RankBadge rank={currentUser.rank} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="text-violet-300 font-bold text-sm truncate">
+                {currentUser.name} <span className="text-violet-400">(You)</span>
+              </p>
+              <p className="text-slate-500 text-[11px]">
+                Ranked #{currentUser.rank} by {activeMetric.label.toLowerCase()}
+              </p>
+            </div>
+            <div className="text-right shrink-0">
+              <p className="text-white font-black text-lg tabular-nums">
+                {activeMetric.value(currentUser)}
+              </p>
+              <p className="text-slate-600 text-[10px] uppercase tracking-wider">
+                {activeMetric.label}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* States */}
+        {loading && (
+          <div className="flex items-center justify-center py-24">
+            <div className="text-center space-y-3">
+              <RefreshCw className="animate-spin text-violet-400 mx-auto" size={36} />
+              <p className="text-slate-400 font-medium">Loading leaderboard…</p>
+            </div>
+          </div>
+        )}
+
+        {error && !loading && (
+          <div className="bg-red-500/10 border border-red-500/30 rounded-2xl p-6 text-center">
+            <Trophy className="text-red-400 mx-auto mb-3" size={32} />
+            <p className="text-red-400 font-semibold">{error}</p>
+          </div>
+        )}
+
+        {!loading && !error && rows.length === 0 && (
+          <div className="bg-[#111827] border border-slate-800 rounded-2xl p-10 text-center">
+            <Building2 className="text-slate-600 mx-auto mb-4" size={40} />
+            <p className="text-slate-500 text-lg font-semibold">No studios to rank yet</p>
+            <p className="text-slate-600 text-sm mt-2">
+              Studios will appear here as players build and release movies.
+            </p>
+          </div>
+        )}
+
+        {/* Leaderboard list */}
+        {!loading && !error && rows.length > 0 && (
+          <>
+            <div className="space-y-2">
+              {rows.map((entry) => (
+                <LeaderboardRow
+                  key={entry.studioId}
+                  entry={entry}
+                  activeMetric={activeMetric}
+                />
+              ))}
+            </div>
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+              <div className="flex items-center justify-center gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={() => goToPage(page - 1)}
+                  disabled={page <= 1}
+                  className="flex items-center gap-1 px-3 py-2 rounded-xl bg-[#111827] border border-slate-800 text-slate-300 text-sm font-semibold disabled:opacity-40 hover:border-slate-600 transition"
+                >
+                  <ChevronLeft size={16} /> Prev
+                </button>
+                <span className="text-slate-400 text-sm font-semibold">
+                  Page {page} of {totalPages}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => goToPage(page + 1)}
+                  disabled={page >= totalPages}
+                  className="flex items-center gap-1 px-3 py-2 rounded-xl bg-[#111827] border border-slate-800 text-slate-300 text-sm font-semibold disabled:opacity-40 hover:border-slate-600 transition"
+                >
+                  Next <ChevronRight size={16} />
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default Leaderboard;


### PR DESCRIPTION
## Summary
Adds a Studio Leaderboards system so players can compare their studio against others across multiple metrics (#32).

Closes #32.

## What changed
**Backend (new, additive)**
- `controllers/leaderboardController.js` — `GET /api/leaderboard?metric=&page=&limit=` returns studios ranked by the requested metric, paginated, plus the requesting player's own studio and global rank for that metric.
  - Metrics: `prestige`, `fans`, `revenue` (`stats.totalRevenue`), `blockbusters` (`stats.allTimeBlockbusters`), `level` (`studioLevel`).
  - Read-only aggregation — never writes to any studio. Projection returns only public fields (no owner email, money, or financial history).
- `routes/leaderboardRoutes.js` — `GET /` behind `protect`.
- `app.js` — mounts `/api/leaderboard`.

**Frontend (new page + 2 additive edits)**
- `pages/studio/Leaderboard.jsx` — metric filter tabs, ranked cards (crown/medal for top 3), a "Your rank #N" banner, pagination, and loading/error/empty states. Styled to match the existing Rival Studios page.
- `App.jsx` — adds the protected `/leaderboard` route.
- `components/common/Sidebar.jsx` — adds a "Leaderboard" nav item.

## Verification
- ✅ `node --check` on all backend files
- ✅ Unit-tested the metric mapping + value reads (nested `stats.*`, invalid-metric rejection, defaults) — all pass
- ✅ ESLint clean on all changed frontend files
- ✅ Full `vite build` passes
- ✅ No regression: purely additive; the leaderboard only reads studio data

## Notes
- Data is fetched via the shared `api` axios instance (same pattern as the Rival Studios page); the empty `studioSlice` is not used.
- The "Your rank" value counts studios with a strictly higher metric value, so exact tie ordering may share a neighborhood — the ranked list itself is fully ordered.