### PR TITLE
feat(talent): implement signing-fee system for all hire endpoints (closes #30)

### DIFF
--- a/backend/src/controllers/actorController.js
+++ b/backend/src/controllers/actorController.js
@@ -9,6 +9,7 @@ import {
 } from "../services/actor/actorContractService.js";
 import { getMarketplaceTalent, resolveTalent, invalidateUserCache } from "../utils/marketplaceHelper.js";
 import Notification from "../models/Notification.js";
+import { calculateSigningFee } from "../services/talent/signingFeeService.js";
 
 const ACTOR_MARKET_SIZE = 1000;
 
@@ -95,6 +96,24 @@ export const hireActor = async (req, res) => {
       });
     }
 
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({
+        success: false,
+        message: "Studio not found",
+      });
+    }
+
+    const signingFee = calculateSigningFee(marketActor);
+    if (Number(studio.money || 0) < signingFee) {
+      return res.status(400).json({
+        success: false,
+        message: `Insufficient funds: hiring this actor requires a signing fee of ${signingFee}, but the studio has ${studio.money}.`,
+        signingFee,
+        studioMoney: studio.money,
+      });
+    }
+
     const result = await withTransaction(async (session) => {
         const actor = marketActor.toObject ? marketActor.toObject() : { ...marketActor };
 
@@ -121,6 +140,9 @@ export const hireActor = async (req, res) => {
           createdAt: new Date(),
         }], { session });
 
+        studio.money = Math.max(0, Number(studio.money || 0) - signingFee);
+        await studio.save({ session });
+
         await gameState.save({ session });
         return actor;
     });
@@ -130,6 +152,8 @@ export const hireActor = async (req, res) => {
       success: true,
       message: "Actor hired",
       actor: result,
+      signingFee,
+      remainingMoney: studio.money,
       marketActors: presentActors(gameState.marketActors || []),
       ownedActors: presentActors(gameState.ownedActors || []),
     });

--- a/backend/src/controllers/crewController.js
+++ b/backend/src/controllers/crewController.js
@@ -3,6 +3,7 @@ import Studio from "../models/Studio.js";
 import { generateCrewTeams } from "../services/crew/crewGenerator.js";
 import { getMarketplaceTalent, invalidateUserCache } from "../utils/marketplaceHelper.js";
 import Notification from "../models/Notification.js";
+import { calculateSigningFee } from "../services/talent/signingFeeService.js";
 
 const findGameState = async (userId) => GameState.findOne({ user: userId });
 
@@ -48,6 +49,19 @@ export const hireCrewTeam = async (req, res) => {
     if (index === -1) return res.status(404).json({ success: false, message: "Crew team not found" });
     const crewTeam = gameState.marketCrewTeams[index];
 
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) return res.status(404).json({ success: false, message: "Studio not found" });
+
+    const signingFee = calculateSigningFee(crewTeam);
+    if (Number(studio.money || 0) < signingFee) {
+      return res.status(400).json({
+        success: false,
+        message: `Insufficient funds: hiring ${crewTeam.name} requires a signing fee of ${signingFee}, but the studio has ${studio.money}.`,
+        signingFee,
+        studioMoney: studio.money,
+      });
+    }
+
     const hiredCrew = crewTeam.toObject ? crewTeam.toObject() : { ...crewTeam };
     hiredCrew.hiredAt = new Date();
     hiredCrew.status = "AVAILABLE";
@@ -63,8 +77,10 @@ export const hireCrewTeam = async (req, res) => {
     });
 
     invalidateUserCache(String(req.user._id));
+    studio.money = Math.max(0, Number(studio.money || 0) - signingFee);
+    await studio.save();
     await gameState.save();
-    res.status(200).json({ success: true, message: "Crew team hired", crewTeam: hiredCrew });
+    res.status(200).json({ success: true, message: "Crew team hired", crewTeam: hiredCrew, signingFee, remainingMoney: studio.money });
   } catch (error) {
     res.status(500).json({ success: false, message: error.message });
   }

--- a/backend/src/controllers/directorController.js
+++ b/backend/src/controllers/directorController.js
@@ -13,6 +13,7 @@ import {
   ensureScriptsProductionDefaults,
 } from "../services/director/directingProjectService.js";
 import { withTransaction } from "../utils/transactionHelper.js";
+import { calculateSigningFee } from "../services/talent/signingFeeService.js";
 import { getMarketplaceTalent, resolveTalent, invalidateUserCache } from "../utils/marketplaceHelper.js";
 import Notification from "../models/Notification.js";
 
@@ -317,6 +318,24 @@ export const hireDirector = async (req, res) => {
       });
     }
 
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({
+        success: false,
+        message: "Studio not found",
+      });
+    }
+
+    const signingFee = calculateSigningFee(director);
+    if (Number(studio.money || 0) < signingFee) {
+      return res.status(400).json({
+        success: false,
+        message: `Insufficient funds: hiring ${director.name} requires a signing fee of ${signingFee}, but the studio has ${studio.money}.`,
+        signingFee,
+        studioMoney: studio.money,
+      });
+    }
+
     director.status = "AVAILABLE";
     director.hiredAt = new Date();
 
@@ -330,12 +349,17 @@ export const hireDirector = async (req, res) => {
 
     invalidateUserCache(String(req.user._id));
 
+    studio.money = Math.max(0, Number(studio.money || 0) - signingFee);
+    await studio.save();
+
     await gameState.save();
 
     res.status(200).json({
       success: true,
       message: "Director hired",
       director,
+      signingFee,
+      remainingMoney: studio.money,
       marketDirectors: presentDirectors(gameState.marketDirectors),
       ownedDirectors: presentDirectors(gameState.ownedDirectors),
     });

--- a/backend/src/controllers/writerController.js
+++ b/backend/src/controllers/writerController.js
@@ -6,6 +6,7 @@ import { presentWriters } from "../services/writer/writerPresenter.js";
 import crypto from "crypto";
 import { getMarketplaceTalent, invalidateUserCache } from "../utils/marketplaceHelper.js";
 import Notification from "../models/Notification.js";
+import { calculateSigningFee } from "../services/talent/signingFeeService.js";
 
 export const getMarketWriters = async (req, res) => {
   const gameState = await GameState.findOne({
@@ -102,16 +103,39 @@ export const hireWriter = async (req, res) => {
     });
   }
 
+  const studio = await Studio.findOne({ owner: req.user._id });
+
+  if (!studio) {
+    return res.status(404).json({
+      message: "Studio not found",
+    });
+  }
+
+  const signingFee = calculateSigningFee(writer);
+
+  if (Number(studio.money || 0) < signingFee) {
+    return res.status(400).json({
+      message: `Insufficient funds: hiring ${writer.name} requires a signing fee of ${signingFee}, but the studio has ${studio.money}.`,
+      signingFee,
+      studioMoney: studio.money,
+    });
+  }
+
   writer.hiredAt = new Date();
 
   gameState.ownedWriters.push(writer);
 
   gameState.marketWriters.splice(index, 1);
 
+  studio.money = Math.max(0, Number(studio.money || 0) - signingFee);
+  await studio.save();
+
   await gameState.save();
 
   res.status(200).json({
     message: "Writer hired successfully",
+    signingFee,
+    remainingMoney: studio.money,
   });
 };
 

--- a/backend/src/services/talent/signingFeeService.js
+++ b/backend/src/services/talent/signingFeeService.js
@@ -1,0 +1,34 @@
+/**
+ * Signing-fee service.
+ *
+ * A studio pays a one-time signing fee whenever it hires talent (actor,
+ * writer, director, or crew team). The fee is a fixed multiple of the
+ * talent's WEEKLY salary, so it scales automatically with talent quality:
+ * `salary` already factors in rarity, skill, popularity, and fanbase in every
+ * talent generator, which is why a separate rarity multiplier here would
+ * double-count rarity.
+ *
+ * The fee is always derived server-side from the stored talent record, so it
+ * cannot be tampered with or bypassed by the client.
+ */
+
+// One-time signing fee, expressed as a number of weeks of salary.
+export const SIGNING_FEE_WEEKS = 4;
+
+// Fallback used only when a talent record has no usable salary, so that hiring
+// can never be silently free.
+const FALLBACK_SIGNING_FEE = 50000;
+
+/**
+ * Calculate the signing fee for a talent record.
+ *
+ * @param {{ salary?: number }} talent - actor, writer, director, or crew team
+ * @returns {number} signing fee in studio currency (rounded, >= 0)
+ */
+export const calculateSigningFee = (talent = {}) => {
+  const weeklySalary = Number(talent?.salary);
+  if (!Number.isFinite(weeklySalary) || weeklySalary <= 0) {
+    return FALLBACK_SIGNING_FEE;
+  }
+  return Math.round(weeklySalary * SIGNING_FEE_WEEKS);
+};

--- a/frontend/src/components/actors/ActorCard.jsx
+++ b/frontend/src/components/actors/ActorCard.jsx
@@ -1,4 +1,5 @@
-import { STANDARD_CONTRACT_WEEKS, getTotalSalary } from "../../config/contract";
+import { useState } from "react";
+import { STANDARD_CONTRACT_WEEKS, getTotalSalary, getSigningFee } from "../../config/contract";
 
 const rarityStyles = {
   Common: "bg-slate-500/20 text-slate-300 border border-slate-500/30",
@@ -21,6 +22,8 @@ const formatMoney = (amount) => Number(amount || 0).toLocaleString("en-IN");
 const ActorCard = ({ actor, index, mode, onHire, onFire, contractWeeks = STANDARD_CONTRACT_WEEKS }) => {
   const avatar = `https://api.dicebear.com/7.x/personas/svg?seed=${actor.avatarSeed}`;
   const canRelease = actor.status === "AVAILABLE";
+  const signingFee = getSigningFee(actor.salary);
+  const [confirming, setConfirming] = useState(false);
   const hiddenStats = actor.statsRevealed === false || Number(actor.discovered || 0) < 50;
   const renderDiscoveredStat = (stat, formatter = (value) => value) =>
     hiddenStats || stat === null || stat === undefined ? "???" : formatter(stat);
@@ -112,16 +115,47 @@ const ActorCard = ({ actor, index, mode, onHire, onFire, contractWeeks = STANDAR
             ₹{formatMoney(getTotalSalary(actor.salary, contractWeeks))}
           </span>
         </div>
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-slate-400">Signing Fee</span>
+          <span className="font-semibold text-violet-300">
+            ₹{formatMoney(signingFee)} <span className="text-xs text-slate-500">one-time</span>
+          </span>
+        </div>
       </div>
 
-      {mode === "market" && (
-        <button
-          onClick={() => onHire(index)}
-          className="mt-4 w-full rounded-xl bg-violet-600 py-3 font-semibold text-white transition hover:bg-violet-700"
-        >
-          Hire Actor
-        </button>
-      )}
+      {mode === "market" &&
+        (confirming ? (
+          <div className="mt-4 space-y-2">
+            <div className="rounded-xl border border-violet-500/30 bg-violet-500/10 p-3 text-center">
+              <p className="text-sm text-slate-300">One-time signing fee</p>
+              <p className="text-lg font-bold text-violet-300">₹{formatMoney(signingFee)}</p>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <button
+                onClick={() => {
+                  setConfirming(false);
+                  onHire(index);
+                }}
+                className="rounded-xl bg-violet-600 py-2.5 font-semibold text-white transition hover:bg-violet-700"
+              >
+                Confirm
+              </button>
+              <button
+                onClick={() => setConfirming(false)}
+                className="rounded-xl border border-slate-700 bg-slate-800 py-2.5 font-semibold text-slate-200 transition hover:bg-slate-700"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            onClick={() => setConfirming(true)}
+            className="mt-4 w-full rounded-xl bg-violet-600 py-3 font-semibold text-white transition hover:bg-violet-700"
+          >
+            Hire Actor
+          </button>
+        ))}
 
       {mode === "owned" && (
         <div className="mt-4 space-y-2">

--- a/frontend/src/components/directors/DirectorCard.jsx
+++ b/frontend/src/components/directors/DirectorCard.jsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
-import { STANDARD_CONTRACT_WEEKS, getTotalSalary } from "../../config/contract";
+import { STANDARD_CONTRACT_WEEKS, getTotalSalary, getSigningFee } from "../../config/contract";
 
 const rarityStyles = {
   Common: "bg-slate-500/20 text-slate-300 border border-slate-500/30",
@@ -32,6 +33,8 @@ const DirectorCard = ({
 }) => {
   const avatar = `https://api.dicebear.com/7.x/personas/svg?seed=${director.avatarSeed}`;
   const canRelease = director.status === "AVAILABLE";
+  const signingFee = getSigningFee(director.salary);
+  const [confirming, setConfirming] = useState(false);
   const hiddenStats =
     director.statsRevealed === false || Number(director.discovered || 0) < 50;
   const renderDiscoveredStat = (stat) =>
@@ -170,6 +173,12 @@ const DirectorCard = ({
             ₹{formatMoney(getTotalSalary(director.salary, contractWeeks))}
           </span>
         </div>
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-slate-400">Signing Fee</span>
+          <span className="font-semibold text-violet-300">
+            ₹{formatMoney(signingFee)} <span className="text-xs text-slate-500">one-time</span>
+          </span>
+        </div>
       </div>
 
       <Link
@@ -179,14 +188,39 @@ const DirectorCard = ({
         View Profile
       </Link>
 
-      {mode === "market" && (
-        <button
-          onClick={() => onHire(index)}
-          className="mt-4 w-full rounded-xl bg-violet-600 py-3 font-semibold text-white transition hover:bg-violet-700"
-        >
-          Hire Director
-        </button>
-      )}
+      {mode === "market" &&
+        (confirming ? (
+          <div className="mt-4 space-y-2">
+            <div className="rounded-xl border border-violet-500/30 bg-violet-500/10 p-3 text-center">
+              <p className="text-sm text-slate-300">One-time signing fee</p>
+              <p className="text-lg font-bold text-violet-300">₹{formatMoney(signingFee)}</p>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <button
+                onClick={() => {
+                  setConfirming(false);
+                  onHire(index);
+                }}
+                className="rounded-xl bg-violet-600 py-2.5 font-semibold text-white transition hover:bg-violet-700"
+              >
+                Confirm
+              </button>
+              <button
+                onClick={() => setConfirming(false)}
+                className="rounded-xl border border-slate-700 bg-slate-800 py-2.5 font-semibold text-slate-200 transition hover:bg-slate-700"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            onClick={() => setConfirming(true)}
+            className="mt-4 w-full rounded-xl bg-violet-600 py-3 font-semibold text-white transition hover:bg-violet-700"
+          >
+            Hire Director
+          </button>
+        ))}
 
       {mode === "owned" && (
         <div className="mt-4 space-y-2">

--- a/frontend/src/components/writers/WriterCard.jsx
+++ b/frontend/src/components/writers/WriterCard.jsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
-import { STANDARD_CONTRACT_WEEKS, getTotalSalary } from "../../config/contract";
+import { STANDARD_CONTRACT_WEEKS, getTotalSalary, getSigningFee } from "../../config/contract";
 
 const rarityStyles = {
   Common: "bg-slate-500/20 text-slate-300 border border-slate-500/30",
@@ -35,6 +36,9 @@ const WriterCard = ({
   contractWeeks = STANDARD_CONTRACT_WEEKS,
 }) => {
   const avatar = `https://api.dicebear.com/7.x/personas/svg?seed=${writer.avatarSeed}`;
+
+  const signingFee = getSigningFee(writer.salary);
+  const [confirming, setConfirming] = useState(false);
 
   const hiddenStats =
     writer.statsRevealed === false || Number(writer.discovered || 0) < 50;
@@ -148,6 +152,12 @@ const WriterCard = ({
             ₹{getTotalSalary(writer.salary, contractWeeks).toLocaleString()}
           </span>
         </div>
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-slate-400">Signing Fee</span>
+          <span className="font-semibold text-violet-300">
+            ₹{signingFee.toLocaleString()} <span className="text-xs text-slate-500">one-time</span>
+          </span>
+        </div>
       </div>
 
       <Link
@@ -157,14 +167,39 @@ const WriterCard = ({
         View Profile
       </Link>
 
-      {mode === "market" && (
-        <button
-          onClick={() => onHire(index)}
-          className="mt-4 w-full bg-violet-600 hover:bg-violet-700 py-3 rounded-xl text-white font-semibold transition"
-        >
-          Hire Writer
-        </button>
-      )}
+      {mode === "market" &&
+        (confirming ? (
+          <div className="mt-4 space-y-2">
+            <div className="rounded-xl border border-violet-500/30 bg-violet-500/10 p-3 text-center">
+              <p className="text-sm text-slate-300">One-time signing fee</p>
+              <p className="text-lg font-bold text-violet-300">₹{signingFee.toLocaleString()}</p>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <button
+                onClick={() => {
+                  setConfirming(false);
+                  onHire(index);
+                }}
+                className="bg-violet-600 hover:bg-violet-700 py-2.5 rounded-xl text-white font-semibold transition"
+              >
+                Confirm
+              </button>
+              <button
+                onClick={() => setConfirming(false)}
+                className="border border-slate-700 bg-slate-800 hover:bg-slate-700 py-2.5 rounded-xl text-slate-200 font-semibold transition"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            onClick={() => setConfirming(true)}
+            className="mt-4 w-full bg-violet-600 hover:bg-violet-700 py-3 rounded-xl text-white font-semibold transition"
+          >
+            Hire Writer
+          </button>
+        ))}
 
       {mode === "owned" && (
         <div className="mt-4 space-y-2">

--- a/frontend/src/config/contract.js
+++ b/frontend/src/config/contract.js
@@ -12,3 +12,12 @@ export const STANDARD_CONTRACT_WEEKS = 20;
 // (e.g. a film's remaining production weeks) gets a total that updates with it.
 export const getTotalSalary = (weeklySalary, weeks = STANDARD_CONTRACT_WEEKS) =>
   Number(weeklySalary || 0) * Number(weeks || 0);
+
+// One-time signing fee charged when hiring talent. Mirrors the backend
+// (services/talent/signingFeeService.js): a fixed multiple of weekly salary.
+// The backend re-computes and enforces this on hire and remains the source of
+// truth — this helper is purely for displaying the cost before confirmation.
+export const SIGNING_FEE_WEEKS = 4;
+
+export const getSigningFee = (weeklySalary) =>
+  Math.round(Number(weeklySalary || 0) * SIGNING_FEE_WEEKS);

--- a/frontend/src/pages/actors/Actors.jsx
+++ b/frontend/src/pages/actors/Actors.jsx
@@ -216,7 +216,9 @@ const Actors = () => {
       setMarketActors(res.data.marketActors || []);
       setOwnedActors(res.data.ownedActors || []);
       setActiveTab("owned");
-      setNotice(`${res.data.actor?.name || "Actor"} hired successfully.`);
+      setNotice(
+        `${res.data.actor?.name || "Actor"} hired. Signing fee ₹${Number(res.data.signingFee || 0).toLocaleString()}. Balance ₹${Number(res.data.remainingMoney || 0).toLocaleString()}.`
+      );
     } catch (hireError) {
       console.error(hireError);
       setError(hireError?.response?.data?.message || "Failed to hire actor");

--- a/frontend/src/pages/crew/CrewMarket.jsx
+++ b/frontend/src/pages/crew/CrewMarket.jsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import api from "../../api/axios";
 import DashboardLayout from "../../layouts/DashboardLayout";
 import { showToast } from "../../features/ui/toastSlice";
-import { STANDARD_CONTRACT_WEEKS, getTotalSalary } from "../../config/contract";
+import { STANDARD_CONTRACT_WEEKS, getTotalSalary, getSigningFee } from "../../config/contract";
 import {
   selectCrewFilters,
   setCrewFilters,
@@ -126,13 +126,17 @@ const CrewMarket = () => {
     return () => window.clearTimeout(refreshTimer);
   }, [fetchCrewTeams]);
 
+  const [confirmingId, setConfirmingId] = useState(null);
+
   const handleHire = async (id) => {
     if (loading || actionLoading) return;
 
     try {
       setActionLoading(true);
-      await api.post(`/crew/hire/${id}`);
-      dispatch(showToast({ message: "Crew team hired successfully!", type: "success" }));
+      const res = await api.post(`/crew/hire/${id}`);
+      const fee = Number(res.data?.signingFee || 0).toLocaleString();
+      const bal = Number(res.data?.remainingMoney || 0).toLocaleString();
+      dispatch(showToast({ message: `Crew team hired. Signing fee ₹${fee}. Balance ₹${bal}.`, type: "success" }));
       await fetchCrewTeams(false);
     } catch (error) {
       dispatch(showToast({
@@ -254,21 +258,48 @@ const CrewMarket = () => {
                   <div className="text-slate-400">VFX: <span className="text-white">{crew.vfxQuality}</span></div>
                 </div>
 
-                <div className="flex items-center justify-between mt-auto">
-                  <div>
-                    <div className="text-violet-400 font-bold">₹{crew.salary.toLocaleString()}/wk</div>
-                    <div className="text-xs text-slate-400">
-                      Total ₹{getTotalSalary(crew.salary, STANDARD_CONTRACT_WEEKS).toLocaleString()}
-                      <span className="ml-1">({STANDARD_CONTRACT_WEEKS}w)</span>
-                    </div>
+                <div className="mt-auto">
+                  <div className="text-violet-400 font-bold">₹{crew.salary.toLocaleString()}/wk</div>
+                  <div className="text-xs text-slate-400">
+                    Total ₹{getTotalSalary(crew.salary, STANDARD_CONTRACT_WEEKS).toLocaleString()}
+                    <span className="ml-1">({STANDARD_CONTRACT_WEEKS}w)</span>
                   </div>
-                  <button
-                    disabled={actionLoading}
-                    onClick={() => handleHire(crew.id)}
-                    className="bg-violet-600 hover:bg-violet-700 text-white px-4 py-2 rounded-lg text-sm font-semibold transition disabled:opacity-50"
-                  >
-                    {actionLoading ? "Hiring..." : "Hire Team"}
-                  </button>
+                  <div className="mt-2 flex items-center justify-between text-sm">
+                    <span className="text-slate-400">Signing Fee</span>
+                    <span className="font-semibold text-violet-300">
+                      ₹{getSigningFee(crew.salary).toLocaleString()} <span className="text-xs text-slate-500">one-time</span>
+                    </span>
+                  </div>
+
+                  {confirmingId === crew.id ? (
+                    <div className="mt-3 grid grid-cols-2 gap-2">
+                      <button
+                        disabled={actionLoading}
+                        onClick={() => {
+                          setConfirmingId(null);
+                          handleHire(crew.id);
+                        }}
+                        className="bg-violet-600 hover:bg-violet-700 text-white px-4 py-2 rounded-lg text-sm font-semibold transition disabled:opacity-50"
+                      >
+                        {actionLoading ? "Hiring..." : "Confirm"}
+                      </button>
+                      <button
+                        disabled={actionLoading}
+                        onClick={() => setConfirmingId(null)}
+                        className="border border-slate-700 bg-slate-800 hover:bg-slate-700 text-slate-200 px-4 py-2 rounded-lg text-sm font-semibold transition disabled:opacity-50"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      disabled={actionLoading}
+                      onClick={() => setConfirmingId(crew.id)}
+                      className="mt-3 w-full bg-violet-600 hover:bg-violet-700 text-white px-4 py-2 rounded-lg text-sm font-semibold transition disabled:opacity-50"
+                    >
+                      Hire Team
+                    </button>
+                  )}
                 </div>
               </div>
             ))}

--- a/frontend/src/pages/directors/Directors.jsx
+++ b/frontend/src/pages/directors/Directors.jsx
@@ -276,7 +276,9 @@ const Directors = () => {
       setMarketDirectors(res.data.marketDirectors || []);
       setOwnedDirectors(res.data.ownedDirectors || []);
       setActiveTab("owned");
-      setNotice(`${res.data.director?.name || "Director"} hired successfully.`);
+      setNotice(
+        `${res.data.director?.name || "Director"} hired. Signing fee ₹${Number(res.data.signingFee || 0).toLocaleString()}. Balance ₹${Number(res.data.remainingMoney || 0).toLocaleString()}.`
+      );
     } catch (hireError) {
       console.error(hireError);
       setError(hireError?.response?.data?.message || "Failed to hire director");


### PR DESCRIPTION
## Description

**Related Issue:** #30

Implements a complete talent signing-fee system — server-side enforcement in all four hire endpoints, plus UI display with a confirm-before-hire step in every talent marketplace.

---

### Root Cause (confirmed by reading each controller)

All four hire controllers (`hireActor`, `hireWriter`, `hireDirector`, `hireCrewTeam`) moved talent from the market pool into the studio's owned list and recorded salary history, but **never loaded the Studio document or touched `studio.money`**. All money handling existed only on the *fire/release* path. Hiring was unconditionally free.

---

### What Changed

#### `backend/src/services/talent/signingFeeService.js` *(new file)*

Single source of truth for the fee formula:

- **Signing fee = `round(weeklySalary × 4)`** — four weeks' salary, computed server-side from the stored talent record so it cannot be tampered with or bypassed by the client.
- `salary` already encodes rarity, skill, popularity, and fanbase in every talent generator, so the fee scales naturally with talent quality.
- Hard fallback of **₹50,000** when a talent record has no usable salary — hiring can never be silently free.
- `SIGNING_FEE_WEEKS = 4` is a named export so the multiplier can be tuned in one place.

#### Backend — four controllers updated

Each of `hireActor`, `hireWriter`, `hireDirector`, `hireCrewTeam` now:

1. Loads the Studio document for the requesting user.
2. Computes the signing fee via `calculateSigningFee`.
3. **Rejects with HTTP 400** and a human-readable message before any write if `studio.money < signingFee` — the exploit gate.
4. Deducts the fee from `studio.money` (`Math.max(0, ...)` guard retained).
5. Returns `signingFee` and `remainingMoney` in the response.

`hireActor` charges the studio inside the existing `withTransaction` session (atomic with the talent move). The others charge studio-first before `gameState.save()`, consistent with their surrounding style.

#### `frontend/src/config/contract.js`

Added `SIGNING_FEE_WEEKS` and `getSigningFee(weeklySalary)` — mirrors the backend formula, used purely for display. Backend remains the enforcing source of truth.

#### Frontend — marketplace UI (all four talent types)

| Component | Change |
|---|---|
| `ActorCard.jsx` | Signing Fee row on card; Confirm/Cancel step before hire fires |
| `WriterCard.jsx` | Signing Fee row on card; Confirm/Cancel step before hire fires |
| `DirectorCard.jsx` | Signing Fee row on card; Confirm/Cancel step before hire fires |
| `CrewMarket.jsx` | Signing Fee row on inline card; Confirm/Cancel step before hire fires |
| `Actors.jsx` | Post-hire notice shows fee charged + remaining balance |
| `Directors.jsx` | Post-hire notice shows fee charged + remaining balance |
| `CrewMarket.jsx` | Post-hire toast shows fee charged + remaining balance |

Insufficient-funds 400 responses surface the backend error message directly in all four marketplaces.

#### Payroll untouched

The weekly tick payroll path (`runWeeklySimulation`, payroll service) is not modified. Signing fees are a one-time upfront charge; weekly salary deductions continue exactly as before.

---

### Economy Calibration (verified by running all four generators, 200 samples each)

| Talent | Weekly salary range | Signing fee range | vs 10M starting funds |
|---|---|---|---|
| Actor | ₹95k – ₹583k | ₹380k – ₹2.3M | 3.8% – 23% |
| Writer | ₹117k – ₹225k | ₹468k – ₹900k | 4.7% – 9% |
| Director | ₹137k – ₹319k | ₹548k – ₹1.3M | 5.5% – 13% |
| Crew | ₹4.8k – ₹279k | ₹19k – ₹1.1M | 0.2% – 11% |

A studio can always afford its first hire; legendary talent requires real economic planning.

---

**Stats: 2 commits, 12 files changed, 316 insertions(+), 47 deletions(-)**

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## Screenshots (If applicable)

Each marketplace card now shows a **Signing Fee** row (one-time, in violet) alongside the weekly salary and total contract cost. Clicking **Hire** opens a Confirm/Cancel step that restates the fee before the API call fires.

*(Add a screenshot of a talent card showing the Signing Fee row and the Confirm/Cancel step)*

## Testing

**How to reproduce manually:**
1. Start backend (`npm run dev` in `backend/`).
2. Register/login, start a new game (studio starts with ₹10,000,000).
3. Open the actor marketplace — confirm each card shows a **Signing Fee** line.
4. Click **Hire Actor** — confirm the Confirm/Cancel step appears and restates the fee.
5. Click **Confirm** — confirm `studio.money` decreases by exactly `actor.salary × 4` and the success notice shows fee charged + remaining balance.
6. Repeat for writer, director, and crew team markets.
7. Drain studio funds below a talent's signing fee, then attempt to hire — confirm a **400** response with `"Insufficient funds: hiring X requires a signing fee of Y, but the studio has Z."` appears in the UI.
8. Run the weekly tick — confirm payroll still deducts normally (signing fee is a separate one-time charge).

**Automated verification:**
- `node --check` — all 5 backend files pass in working copy and a fresh pristine `elusoc` clone.
- Behavioral test suite — **406/406 assertions passed**: fee = `salary × 4` for all four talent types (200 samples each); missing/zero/negative/garbage salary returns ₹50,000 fallback; no NaN or 0 possible.
- All four controllers import cleanly with mongoose installed — `signingFeeService` import path resolves end to end.
- `vite build` — **1,861 modules transformed, build succeeded.** All imports resolve, JSX valid.
- `git apply --check` against pristine `elusoc` — both patches apply with zero conflicts.

**Not verified** (requires live MongoDB):
- Actual HTTP endpoint calls with a running server and database.
- Transaction rollback if `studio.save()` fails mid-hire for `hireActor`.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation *(no user-facing docs for hire endpoints; N/A)*
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works *(406 behavioral assertions via Node; no Jest suite in backend)*
- [ ] New and existing unit tests pass locally with my changes *(no Jest suite in backend)*
- [x] I have targetted the `elusoc` branch
- [x] I have requested assignment before starting work