### PR TITLE
Add max limit for salary history records

### DIFF
--- a/backend/src/services/writer/writerSalaryProgressionEngine.js
+++ b/backend/src/services/writer/writerSalaryProgressionEngine.js
@@ -88,7 +88,12 @@ export const applyWriterSalaryProgression = ({
       salary: nextSalary,
       reason: reasons.join(" + ") || "Career Adjustment",
     });
-  }
+    const MAX_HISTORY_RECORDS = 20;
+      if (writer.salaryHistory.length > MAX_HISTORY_RECORDS) {
+        writer.salaryHistory.shift();
+      }
+    }
+  
 
   return {
     previousSalary,


### PR DESCRIPTION
Limit salary history records to a maximum of 20.

### Description
This PR caps the `writer.salaryHistory` array to a maximum of 20 records. Previously, the array would grow indefinitely each time a writer's salary was updated, leading to unnecessary database bloat over long simulation runs.

Fixes #88

### Changes Made
* Added a `MAX_HISTORY_RECORDS = 20` constant inside `applyWriterSalaryProgression`.
* Added logic to use `.shift()` to remove the oldest salary record whenever the array length exceeds the maximum limit.