### PR TITLE
Refactor caching functions for user-specific handling

### DIFF
--- a/backend/src/utils/marketplaceHelper.js
+++ b/backend/src/utils/marketplaceHelper.js
@@ -21,10 +21,19 @@ const CACHE_TTL_MS = 5_000; // 5 seconds
  * @param {string} key
  */
 const cacheGet = (key) => {
-  const entry = _cache.get(key);
+  const underscoreIdx = key.indexOf('_');
+  const userId = underscoreIdx !== -1 ? key.slice(0, underscoreIdx) : key;
+  const subKey = underscoreIdx !== -1 ? key.slice(underscoreIdx + 1) : 'default';
+  
+  const userCache = _cache.get(userId);
+  if (!userCache) return undefined;
+  
+  const entry = userCache.get(subKey);
   if (!entry) return undefined;
+
   if (Date.now() - entry.ts > CACHE_TTL_MS) {
-    _cache.delete(key);
+    userCache.delete(subKey);
+    if (userCache.size === 0) _cache.delete(userId);
     return undefined;
   }
   return entry.value;
@@ -36,21 +45,25 @@ const cacheGet = (key) => {
  * @param {*} value
  */
 const cacheSet = (key, value) => {
-  _cache.set(key, { value, ts: Date.now() });
+  const underscoreIdx = key.indexOf('_');
+  const userId = underscoreIdx !== -1 ? key.slice(0, underscoreIdx) : key;
+  const subKey = underscoreIdx !== -1 ? key.slice(underscoreIdx + 1) : 'default';
+
+  if (!_cache.has(userId)) {
+    _cache.set(userId, new Map());
+  }
+  _cache.get(userId).set(subKey, { value, ts: Date.now() });
 };
 
 /**
- * Invalidates all cache entries for a given user.
+ * Invalidates all cache entries for a given user instantly O(1).
  * Call this after any mutation (hire / fire).
  * @param {string} userId
  */
 export const invalidateUserCache = (userId) => {
-  for (const key of _cache.keys()) {
-    if (key.startsWith(userId)) {
-      _cache.delete(key);
-    }
-  }
+  _cache.delete(userId);
 };
+
 
 // ---------------------------------------------------------------------------
 // Filter / Sort / Paginate


### PR DESCRIPTION
Refactor cacheGet and cacheSet functions to handle user-specific caching. Update invalidateUserCache to delete user cache in O(1) time.

### 🚀 Description
This PR addresses a critical performance bottleneck in the marketplace helper utilities by restructuring the in-memory TTL cache (`_cache`). By moving from a flat key-value structure to a nested `Map`, we reduce the time complexity of user cache invalidation from $O(N)$ to $O(1)$.

### 🐛 The Problem
Previously, the `_cache` utilized a flat structure (e.g., `user123_inventory`, `user123_history`). When a user mutation occurred (such as hiring or firing talent), the `invalidateUserCache` function was forced to iterate over the entire cache using a `for...of` loop to check if keys started with the specific `userId`. 
As the active player base scales and the cache grows in size, this $O(N)$ iteration risks blocking the Node.js event loop, severely degrading performance during high-frequency mutation events.

### 🛠️ The Solution
This PR refactors the caching mechanism to utilize a nested `Map` structure: `Map<userId, Map<subKey, { value, ts }>>`.
* **`cacheSet`:** Automatically extracts the `userId` and `subKey` from the requested key. It creates a parent `userId` Map if one does not exist, and nests the specific data underneath it.
* **`cacheGet`:** Retrieves data using the two-level lookup. It also cleans up empty parent Maps if a TTL expiration wipes out the last remaining child key.
* **`invalidateUserCache`:** Completely rewritten to execute `_cache.delete(userId)`. This instantly drops all cached data for the user in true $O(1)$ time, eliminating the need to loop through unrelated cache entries.

### 📈 Impact
* Prevents Node.js event loop blocking during bulk operations.
* Safely supports a highly scaled, concurrent user base without degrading API response times.
* Maintains existing TTL cleanup logic without introducing memory leaks.

Fixes #[Insert Issue Number Here]