### PR TITLE
feat: add HTTP client with timeout and retry logic

### DIFF
--- a/frontend/src/utils/httpClient.js
+++ b/frontend/src/utils/httpClient.js
@@ -1,0 +1,67 @@
+import axios from "axios";
+
+const DEFAULT_TIMEOUT = 10000;
+const MAX_RETRIES = 2;
+const RETRY_DELAY_BASE = 1000;
+
+const httpClient = axios.create({
+  baseURL: import.meta.env.VITE_BACKEND_URL || "http://localhost:5000",
+  timeout: DEFAULT_TIMEOUT,
+  headers: { "Content-Type": "application/json" },
+});
+
+httpClient.interceptors.request.use((config) => {
+  const token = localStorage.getItem("token");
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+httpClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const config = error.config;
+
+    if (!config || config._retryCount >= MAX_RETRIES) {
+      return Promise.reject(normalizeError(error));
+    }
+
+    const status = error.response?.status;
+    const isRetryable = !status || status >= 500;
+
+    if (!isRetryable) {
+      return Promise.reject(normalizeError(error));
+    }
+
+    config._retryCount = (config._retryCount || 0) + 1;
+    const delay = RETRY_DELAY_BASE * Math.pow(2, config._retryCount - 1);
+
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    return httpClient(config);
+  }
+);
+
+function normalizeError(error) {
+  if (error.code === "ECONNABORTED") {
+    return {
+      message: "Request timed out. Please check your connection and try again.",
+      code: "TIMEOUT",
+      status: 0,
+    };
+  }
+  if (!error.response) {
+    return {
+      message: "Network error. The server may be unreachable.",
+      code: "NETWORK",
+      status: 0,
+    };
+  }
+  return {
+    message: error.response.data?.message || error.response.data?.error || "Something went wrong.",
+    code: "API_ERROR",
+    status: error.response.status,
+  };
+}
+
+export default httpClient;


### PR DESCRIPTION
## Summary

Adds a configured HTTP client wrapper with timeout and automatic retry for transient failures.

## Related Issue

Closes #70

## Changes

**New:** `frontend/src/utils/httpClient.js`
- Wraps axios with 10-second timeout (configurable)
- Retry interceptor: retries up to 2 times on 5xx/network errors with exponential backoff (1s, 2s)
- Request interceptor: attaches auth token from localStorage
- `normalizeError()` returns consistent `{ message, code, status }` objects for UI consumption
- Only retries transient failures (5xx, timeouts, network errors). 4xx errors fail immediately.

## How to use

```js
import httpClient from "../utils/httpClient";

// Replaces direct axios/fetch calls
const { data } = await httpClient.get("/api/movies");
const { data } = await httpClient.post("/api/studio", payload);
```

Error handling in components:
```js
try {
  const { data } = await httpClient.get("/api/movies");
} catch (err) {
  // err.message = "Request timed out..." or "Network error..." or API message
  // err.code = "TIMEOUT" | "NETWORK" | "API_ERROR"
  // err.status = HTTP status or 0
}
```

## AI disclosure

Used Cursor with Claude. The retry logic uses axios interceptors with a `_retryCount` property on the config object to track attempts. Exponential backoff uses `Math.pow(2, retryCount - 1) * 1000ms`. The normalizeError function handles three cases: timeout (ECONNABORTED), no response (network), and error response (API).
