### PR TITLE
Enhance studio name validation with .trim()

### DIFF
--- a/backend/src/validators/studioValidator.js
+++ b/backend/src/validators/studioValidator.js
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const studioUpdateSchema = {
   body: z.object({
     name: z.string()
+      .trim() // Added .trim() to remove leading/trailing whitespace
       .min(3, "Studio name must be at least 3 characters")
       .max(50, "Studio name must not exceed 50 characters"),
   }),


### PR DESCRIPTION
Added .trim() method to studio name validation to remove leading and trailing whitespace. ## Title: bug: Add .trim() to studioUpdateSchema to prevent whitespace-only names (#81)

## 📝 Description
This PR addresses **[Issue #81](https://github.com/SRV30/Box_Office_Inc-Movie_Sim/issues/81)** by adding the `.trim()` method to the `name` field validation in `studioUpdateSchema`.

Previously, whitespace-only strings could bypass the length validation, leading to improperly formatted studio names being persisted in the database. This change ensures that only valid, non-whitespace characters are counted towards the name length requirements.

### 🛠️ Technical Implementation
- Updated the Zod schema for `name` in `backend/src/validators/studioValidator.js` to chain `.trim()` before `.min()` and `.max()` validations.

Closes #81


