### PR TITLE
Refine index validation with maximum limit

### DIFF
--- a/backend/src/validators/scriptValidator.js
+++ b/backend/src/validators/scriptValidator.js
@@ -1,9 +1,6 @@
-import { z } from "zod";
-
-export const scriptIndexSchema = {
-  params: z.object({
-    index: z.string()
-      .regex(/^\d+$/, "Index must be a non-negative integer")
-      .transform((val) => parseInt(val, 10)),
-  }),
-};
+index: z.string()
+  .regex(/^\d+$/, "Index must be a non-negative integer")
+  .refine((val) => parseInt(val, 10) <= 999999, { // Set a safe maximum limit
+    message: "Index is too large",
+  })
+  .transform((val) => parseInt(val, 10)),


### PR DESCRIPTION
## Title: bug: Prevent Infinity evaluation in scriptIndexSchema by adding a maximum limit (#80)

## 📝 Description
This PR addresses **[Issue #80](https://github.com/SRV30/Box_Office_Inc-Movie_Sim/issues/80)** by adding a maximum limit to the `index` parameter in `scriptIndexSchema`. Previously, the validator lacked an upper bound, which could lead to `Infinity` evaluation or overflow issues when parsing large input strings.

### 🛠️ Technical Implementation
- Added a `.refine()` method to the Zod schema for `index` to ensure the parsed integer does not exceed a safe maximum limit (set to 999,999) before transformation.

Closes #80

