### PR TITLE
Add awardsSlice with fetchAwards async action

### DIFF
--- a/frontend/src/features/awards/awardsSlice.js
+++ b/frontend/src/features/awards/awardsSlice.js
@@ -1,0 +1,42 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import api from '../../api/axios';
+
+// Async action to fetch awards
+export const fetchAwards = createAsyncThunk(
+  'awards/fetchAwards',
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await api.get('/awards'); 
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || 'Failed to fetch awards');
+    }
+  }
+);
+
+const awardsSlice = createSlice({
+  name: 'awards',
+  initialState: {
+    data: [],
+    loading: false,
+    error: null,
+  },
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchAwards.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchAwards.fulfilled, (state, action) => {
+        state.loading = false;
+        state.data = action.payload;
+      })
+      .addCase(fetchAwards.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload;
+      });
+  },
+});
+
+export default awardsSlice.reducer;


### PR DESCRIPTION
## 📝 Description
This PR addresses the frontend state management requirements for **[Issue #73](https://github.com/SRV30/Box_Office_Inc-Movie_Sim/issues/73)** (Awards Season Feature). 

### 🛠️ Technical Implementation
- **`frontend/src/features/awards/awardsSlice.js`**: Created a new Redux slice to manage awards data.
- Implemented `fetchAwards` using `createAsyncThunk` to call the `/awards` backend endpoint.
- Handled `pending`, `fulfilled`, and `rejected` states to ensure smooth loading and error handling in the UI.

### 🚀 Next Steps
With the backend schema and Redux state complete, the final step will be building the `TrophyRoom.jsx` UI component and adding this slice to the main Redux store.

Partially addresses #73

