### PR TITLE
fix: resolve failing tests in box office, engines, and gameplay e2e

### DIFF
--- a/backend/tests/boxOfficeEngine.test.js
+++ b/backend/tests/boxOfficeEngine.test.js
@@ -31,7 +31,7 @@ test('Box Office Engine - balanced distribution over 1000 trials', () => {
     AVERAGE: 0,
     HIT: 0,
     BLOCKBUSTER: 0,
-    LEGENDARY: 0
+    ALL_TIME_BLOCKBUSTER: 0
   };
 
   const NUM_TRIALS = 1000;

--- a/backend/tests/engines.test.js
+++ b/backend/tests/engines.test.js
@@ -100,13 +100,13 @@ test("careerImpactEngine: a HIT raises stats, salary, earnings and history", () 
     title: "The Big One",
   };
   const leadActor = {
+    id: "actor-1",
     popularity: 50,
     salary: 1000,
     fanbase: 0,
     hitMovies: 0,
-    careerHistory: [],
   };
-  const director = { reputation: 50, salary: 1000, careerHistory: [] };
+  const director = { id: "director-1", reputation: 50, salary: 1000 };
 
   processCareerImpact(gameState, movie, null, director, leadActor, null);
 
@@ -116,8 +116,12 @@ test("careerImpactEngine: a HIT raises stats, salary, earnings and history", () 
   assert.strictEqual(leadActor.hitMovies, 1);
   assert.strictEqual(leadActor.fanbase, 5000); // 5 * 1_000_000 * 0.001
   assert.strictEqual(leadActor.careerEarnings, 1000); // 1_000_000 * 0.001
-  assert.strictEqual(leadActor.careerHistory.length, 1);
-  assert.strictEqual(leadActor.careerHistory[0].verdict, VERDICTS.HIT);
+  
+  assert.strictEqual(gameState._pendingTalentHistories.length, 2);
+  assert.strictEqual(gameState._pendingTalentHistories[0].talentId, "director-1");
+  assert.strictEqual(gameState._pendingTalentHistories[0].data.verdict, VERDICTS.HIT);
+  assert.strictEqual(gameState._pendingTalentHistories[1].talentId, "actor-1");
+  assert.strictEqual(gameState._pendingTalentHistories[1].data.verdict, VERDICTS.HIT);
 
   assert.strictEqual(director.reputation, 55);
   assert.strictEqual(director.salary, 1100);

--- a/backend/tests/gameplay.api.test.js
+++ b/backend/tests/gameplay.api.test.js
@@ -3,7 +3,7 @@ import "./helpers/testEnv.js";
 import test, { before, after } from "node:test";
 import assert from "node:assert";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoMemoryReplSet } from "mongodb-memory-server";
 
 // ---------------------------------------------------------------------------
 // End-to-end gameplay flow over HTTP: register a studio, browse the actor
@@ -24,8 +24,11 @@ let server;
 let baseUrl;
 
 before(async () => {
-  mongod = await MongoMemoryServer.create();
-  await mongoose.connect(mongod.getUri());
+  mongod = await MongoMemoryReplSet.create({
+    replSet: { count: 1 }
+  });
+  let uri = mongod.getUri();
+  await mongoose.connect(uri);
 
   const { default: app } = await import("../src/app.js");
   await new Promise((resolve) => {
@@ -46,15 +49,15 @@ after(async () => {
 // credential literal (nothing sensitive — registers a user in the in-memory DB).
 const TEST_PASSWORD = ["test", "Pw", "8842"].join("-");
 
-const registerStudio = async () => {
+const registerStudio = async (id = Math.random().toString(36).substring(7)) => {
   const res = await fetch(`${baseUrl}/api/auth/register`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      username: "player_one",
-      email: "p1@example.com",
+      username: `player_${id}`,
+      email: `p1_${id}@example.com`,
       password: TEST_PASSWORD,
-      studioName: "P1 Studios",
+      studioName: `P1 Studios_${id}`,
     }),
   });
   return res.json(); // { success, token, user, studio }


### PR DESCRIPTION
# Related Issue
Resolves #114

# Summary
Fixes the three failing tests in the backend suite to bring the project to a 100% test-pass rate.

# Changes Made
- Changed `LEGENDARY` verdict assertion to `ALL_TIME_BLOCKBUSTER` in `boxOfficeEngine.test.js`.
- Switched career history assertions to check `gameState._pendingTalentHistories` in `engines.test.js`.
- Configured `MongoMemoryReplSet` and unique usernames/emails in `gameplay.api.test.js`.

# Testing
Ran `npm test` inside `backend/` and verified all 109 tests passed.

# Checklist
- [x] Independent mergeable branch
- [x] Code conforms to repository styles
- [x] All tests pass successfully