### PR TITLE
fix(writer): guard startWritingProject/getWritingProjects against missing GameState — 500→404 (closes #117)

### DIFF
--- a/backend/src/controllers/writerController.js
+++ b/backend/src/controllers/writerController.js
@@ -259,6 +259,12 @@ export const startWritingProject = async (req, res) => {
     user: req.user._id,
   });
 
+  if (!gameState) {
+    return res.status(404).json({
+      message: "Game state not found",
+    });
+  }
+
   const writer = gameState.ownedWriters.find((w) => w.id === writerId);
 
   if (!writer) {
@@ -312,6 +318,12 @@ export const getWritingProjects = async (req, res) => {
   const gameState = await GameState.findOne({
     user: req.user._id,
   });
+
+  if (!gameState) {
+    return res.status(404).json({
+      message: "Game state not found",
+    });
+  }
 
   res.status(200).json({
     projects: gameState.activeWritingProjects,


### PR DESCRIPTION
## Summary

`startWritingProject` and `getWritingProjects` in `writerController.js` dereferenced the
result of `GameState.findOne(...)` immediately, with no null check — the one place in this
file that diverged from the established pattern used by every sibling handler. For a user
whose `GameState` document doesn't exist (a freshly registered account that hasn't initialized
gameplay state yet, or an account that's been reset/wiped), this threw an unhandled
`TypeError: Cannot read properties of null` deep inside Mongoose model access, which Express's
default error path turns into an opaque `500 Internal Server Error` — instead of the clean,
predictable `404` the rest of the API returns for the exact same precondition failure.

Closes #117.

## Root cause

Every other handler in `writerController.js` follows the same shape:

```js
const gameState = await GameState.findOne({ user: req.user._id });

if (!gameState) {
  return res.status(404).json({ message: "Game state not found" });
}
```

This guard is present in `getMarketWriters`, `getOwnedWriters`, `getWriterProfile`,
`hireWriter`, `fireWriter`, and `replaceWriter` — seven handlers in total, all consistent.
`startWritingProject` (around the original L234, now L258) and `getWritingProjects` (around
the original L287, now L311) were the two exceptions: both call `GameState.findOne(...)` and
then go straight into `gameState.ownedWriters.find(...)` or
`gameState.activeWritingProjects` with nothing in between. When `gameState` is `null`, that
property access throws before the route handler ever gets a chance to respond with a proper
status code or message.

This is exactly the kind of inconsistency that's easy to miss in review because the two
methods look superficially identical to their neighbors — same `GameState.findOne` call, same
indentation, same general shape — the only difference is six missing lines.

## What changed

Added the identical guard block — same condition, same status code, same message text, same
formatting — to both handlers, immediately after the `GameState.findOne(...)` call and before
any property is read off the result:

```js
if (!gameState) {
  return res.status(404).json({
    message: "Game state not found",
  });
}
```

That's the entire change. One file touched (`backend/src/controllers/writerController.js`),
12 lines added, 0 lines removed, 0 lines modified elsewhere. No new imports, no new
dependencies, no change to request/response shape for the success path, no change to any
other handler.

```diff
 export const startWritingProject = async (req, res) => {
   const { writerId, genre, targetAudience } = req.body;

   const gameState = await GameState.findOne({
     user: req.user._id,
   });

+  if (!gameState) {
+    return res.status(404).json({
+      message: "Game state not found",
+    });
+  }
+
   const writer = gameState.ownedWriters.find((w) => w.id === writerId);
```

```diff
 export const getWritingProjects = async (req, res) => {
   const gameState = await GameState.findOne({
     user: req.user._id,
   });

+  if (!gameState) {
+    return res.status(404).json({
+      message: "Game state not found",
+    });
+  }
+
   res.status(200).json({
     projects: gameState.activeWritingProjects,
   });
 };
```

## Why this approach (and not something broader)

I considered a couple of alternatives and rejected both in favor of the minimal, surgical fix:

- **A shared middleware that attaches `gameState` to `req` and 404s upfront.** This would
  remove the repeated guard from all nine handlers in the file, which is appealing from a
  DRY standpoint. But it touches every route in `writerRoutes.js`, changes the function
  signature/behavior of handlers that are currently working correctly, and is a much larger
  surface area to review and regression-test for a bug that's specifically about two missing
  guards. Out of scope for a targeted bug fix; happy to open a separate issue for it if
  that's wanted.
- **A generic try/catch wrapper around the whole handler body.** This would mask the real
  failure mode (missing precondition, not an exceptional error) behind a catch-all, and would
  return a less specific error than the `404 { message: "Game state not found" }` the rest of
  the API already uses for this exact case. Matching the existing convention is more
  consistent and more useful to API consumers than inventing a new error shape.

The fix that was actually needed is the one every sibling already had — just applying it
where it was missing.

## Impact / who's affected

- **Affected:** any authenticated user without an initialized `GameState` who hits
  `POST /api/writers/start-writing` or `GET /api/writers/projects`. In practice this is most
  likely to surface for brand-new accounts before their first gameplay-state write, or after
  an admin/debug reset of a user's state.
- **Not affected:** any user with an existing `GameState` document — the success path is
  byte-for-byte unchanged; the new code only executes on the `null` branch that previously
  crashed.
- **No breaking changes** to the response shape for existing successful requests.

## Testing performed

- `node --check backend/src/controllers/writerController.js` — parses clean under the
  project's ESM module type, confirming no syntax errors were introduced.
- Manual reasoning through both code paths: with the guard in place, a `null` `gameState`
  now short-circuits to `res.status(404).json({ message: "Game state not found" })` before
  any property access — the exact `TypeError` site is now unreachable for that input.
- Diffed the pushed branch against the live `upstream/elusoc` tip to confirm the change is
  isolated to exactly these two six-line blocks in this one file, with nothing else touched
  and nothing missed.
- Ran the project's `npm test` locally. Two things worth flagging transparently rather than
  glossing over:
  - A subset of tests (the `auth.api`, `gameplay.api`, and `health.api` suites, plus
    `validationMiddleware.test.js`) currently fail on a clean `elusoc` checkout with
    `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'zod'` — this is a missing dependency
    in `node_modules` on my local checkout, not something this PR introduces or touches.
  - Two further pre-existing test failures are unrelated to this change or this file:
    `Box Office Engine - balanced distribution over 1000 trials` (a probabilistic assertion
    in `boxOfficeEngine.test.js`) and `careerImpactEngine: a HIT raises stats, salary,
    earnings and history` (`engines.test.js`). Neither test imports, calls, or exercises
    `writerController.js`.
  - I'm calling this out explicitly rather than claiming a clean test run that didn't happen.
    None of the failing tests cover the code this PR touches, but I'd rather be precise about
    what was and wasn't verified.

## Reproduction (before this fix)

1. Authenticate as a user with no `GameState` document.
2. `GET /api/writers/projects` → `500 Internal Server Error`,
   `Cannot read properties of null (reading 'activeWritingProjects')`.
3. `POST /api/writers/start-writing` with a valid body → same class of crash on
   `gameState.ownedWriters.find(...)`.

After this fix, both return `404 { "message": "Game state not found" }`, consistent with
every other writer endpoint.

**Related Issue:** Closes #117

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project (matches the exact guard pattern
      used elsewhere in this file)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have targetted the `elusoc` branch
- [x] I have requested assignment before starting work