### PR TITLE
fix(writer): resolve hire/fire by stable id via resolveTalent, matching director/actor controllers — wrong writer hired on paginated/filtered/sorted market (closes #116)

### DIFF
--- a/backend/src/controllers/writerController.js
+++ b/backend/src/controllers/writerController.js
@@ -4,7 +4,7 @@ import { generateWriters } from "../services/writer/writerGenerator.js";
 import { buildWriterProfile } from "../services/writer/writerProfileService.js";
 import { presentWriters } from "../services/writer/writerPresenter.js";
 import crypto from "crypto";
-import { getMarketplaceTalent, invalidateUserCache } from "../utils/marketplaceHelper.js";
+import { getMarketplaceTalent, resolveTalent, invalidateUserCache } from "../utils/marketplaceHelper.js";
 import Notification from "../models/Notification.js";
 import { calculateSigningFee } from "../services/talent/signingFeeService.js";
 import TalentHistory from "../models/TalentHistory.js";
@@ -105,7 +105,10 @@ export const hireWriter = async (req, res) => {
     });
   }
 
-  const writer = gameState.marketWriters[index];
+  const { item: writer, index: realIndex } = resolveTalent(
+    gameState.marketWriters || [],
+    index
+  );
 
   if (!writer) {
     return res.status(404).json({
@@ -135,7 +138,7 @@ export const hireWriter = async (req, res) => {
 
   gameState.ownedWriters.push(writer);
 
-  gameState.marketWriters.splice(index, 1);
+  gameState.marketWriters.splice(realIndex, 1);
 
   studio.money = Math.max(0, Number(studio.money || 0) - signingFee);
   await studio.save();
@@ -172,7 +175,10 @@ export const fireWriter = async (req, res) => {
     });
   }
 
-  const writer = gameState.ownedWriters[index];
+  const { item: writer, index: realIndex } = resolveTalent(
+    gameState.ownedWriters || [],
+    index
+  );
 
   if (!writer) {
     return res.status(404).json({
@@ -231,7 +237,7 @@ export const fireWriter = async (req, res) => {
 
   gameState.marketWriters.push(writer);
 
-  gameState.ownedWriters.splice(index, 1);
+  gameState.ownedWriters.splice(realIndex, 1);
 
   await Notification.create({
     gameStateId: gameState._id,

--- a/frontend/src/pages/writers/Writers.jsx
+++ b/frontend/src/pages/writers/Writers.jsx
@@ -320,7 +320,7 @@ const Writers = () => {
           <WriterCard
             key={writer.id}
             writer={writer}
-            index={marketWriters.findIndex((w) => w.id === writer.id)}
+            index={writer.id}
             mode="market"
             onHire={handleHire}
           />
@@ -347,14 +347,9 @@ const Writers = () => {
           <WriterCard
             key={writer.id}
             writer={writer}
-            index={ownedWriters.findIndex((w) => w.id === writer.id)}
+            index={writer.id}
             mode="owned"
-            onFire={() =>
-              openFireModal(
-                writer,
-                ownedWriters.findIndex((w) => w.id === writer.id),
-              )
-            }
+            onFire={() => openFireModal(writer, writer.id)}
             onStartWriting={openWritingModal}
           />
         ))}


### PR DESCRIPTION
## Summary

`hireWriter` resolved the writer the player clicked by raw numeric position into the
**full, unfiltered, server-side** `marketWriters` array — but the frontend computed that
position against whatever the player was actually looking at: a paginated page, a search
filter, or a sorted view. Whenever those two arrays diverged (any time pagination, search, or
sort was in play — which is most of the time once the market has more than one page of
writers), the index sent to the backend pointed at a *different* writer in the full array than
the one the player clicked. The result was either the wrong writer being hired, or a 404 if
the index fell outside the raw array's bounds. The same structural bug existed in `fireWriter`
against `ownedWriters`.

This wasn't a new or unique problem — `directorController.js` and `actorController.js` hit and
fixed the exact same class of bug previously, by resolving talent through a shared
`resolveTalent(list, key)` helper that accepts either a stable UUID or (for backward
compatibility) a legacy numeric index. The writer controller was the one talent type left
on the old, broken raw-index pattern.

Closes #116.

## Root cause, in detail

The route is `POST /writers/hire/:index` and `POST /writers/fire/:index`. Historically,
`:index` was assumed to be a literal array position, and the frontend computed it with
`marketWriters.findIndex((w) => w.id === writer.id)` / `ownedWriters.findIndex(...)` against
its **local, client-side** `marketWriters` / `ownedWriters` state — which is whatever subset
the current page, filter, and sort have produced. The backend then used that same number
directly as an index into `gameState.marketWriters` / `gameState.ownedWriters` — the **full,
canonical, server-side** arrays, unfiltered and unpaginated.

Concretely: if a player is on page 2 of the writer market, or has a search term active, the
writer they see at local position `0` might be at server-side position `24` (or anywhere
else) in the real array. Clicking "Hire" sent `0`, the backend pulled
`gameState.marketWriters[0]` — a completely different writer — hired *that* one, and spliced
it out of the market. From the player's perspective, they clicked one writer and got a
different one in their roster, with no error or warning. If local position exceeded the
length of the actual array slice being displayed in some edge case, the lookup could miss
entirely and surface as "Writer not found."

`fireWriter` had the identical structural flaw against `ownedWriters` — once a player has any
sort/filter active on their owned-writer view, firing a writer from a filtered list could fire
the wrong one from the canonical array.

## What changed

### Backend (`backend/src/controllers/writerController.js`)

Imported the existing `resolveTalent` helper from `utils/marketplaceHelper.js` (already used
by `directorController.js` and `actorController.js` — no new code, no new logic, reusing a
helper that's already proven in production for two other talent types):

```js
import { getMarketplaceTalent, resolveTalent, invalidateUserCache } from "../utils/marketplaceHelper.js";
```

`resolveTalent(list, key)` tries `key` as a numeric index first (for backward compatibility
with any existing numeric callers), and if that doesn't resolve, falls back to a `findIndex`
lookup by stable `id` (UUID). It returns both the resolved `item` and its real index in the
array that was passed in — so callers get back exactly what they need to both read the item
and correctly splice it out.

**`hireWriter`** — was:
```js
const writer = gameState.marketWriters[index];
// ...
gameState.marketWriters.splice(index, 1);
```
Now:
```js
const { item: writer, index: realIndex } = resolveTalent(
  gameState.marketWriters || [],
  index
);
// ...
gameState.marketWriters.splice(realIndex, 1);
```

**`fireWriter`** — identical migration against `ownedWriters`:
```js
const { item: writer, index: realIndex } = resolveTalent(
  gameState.ownedWriters || [],
  index
);
// ...
gameState.ownedWriters.splice(realIndex, 1);
```

The `if (!writer) return 404 ...` guard immediately after each resolution is unchanged — it
now correctly fires when the *id* genuinely doesn't exist in the list, rather than when a
stale positional index happens not to line up.

The route definitions (`POST /hire/:index`, `POST /fire/:index`) are unchanged — the `:index`
param now simply carries a UUID instead of a raw position, which `resolveTalent` handles
transparently. No route file changes were needed.

### Frontend (`frontend/src/pages/writers/Writers.jsx`)

Three call sites changed so the **stable writer id** is sent instead of a locally-computed
position:

1. **Market card** (drives `handleHire`, which posts to `/writers/hire/${index}`):
```diff
   - index={marketWriters.findIndex((w) => w.id === writer.id)}
   + index={writer.id}
```

2. **Owned card's `index` prop** (drives the card's internal rendering/key usage):
```diff
   - index={ownedWriters.findIndex((w) => w.id === writer.id)}
   + index={writer.id}
```

3. **Owned card's `onFire` binding** — this is the one that actually matters functionally,
   since `confirmFire` reads `fireWriterData.index` and posts it to
   `/writers/fire/${fireWriterData.index}`:
```diff
   - onFire={() =>
   -   openFireModal(
   -     writer,
   -     ownedWriters.findIndex((w) => w.id === writer.id),
   -   )
   - }
   + onFire={() => openFireModal(writer, writer.id)}
```

`WriterCard.jsx` itself needed no changes — it already just forwards whatever `index` value it
receives straight into `onHire(index)` / `onFire(index)`; it has no opinion about whether that
value is a position or an id. Only the call sites in `Writers.jsx` that *computed* the value
needed to change.

I deliberately chose to send the **UUID** rather than mirroring the precedent in
`Directors.jsx` (which passes `index={director.originalIndex}`, a server-computed positional
index preserved through the marketplace pagination response). Both approaches are valid uses
of `resolveTalent`'s dual-mode lookup, but a stable id is more robust against any future change
to how the marketplace response is paginated or ordered — it has no dependency on the server
continuing to expose an `originalIndex` field, and it's self-evidently correct by inspection
(the value you're sending *is* the thing you're identifying).

## Scope discipline

This PR touches exactly two files and nothing else: the writer controller and the one page
component that calls into it. No route files, no other talent controllers, no shared helper
changed (`resolveTalent` itself is untouched — it was already correct and already covered by
its own existing unit tests, which I re-ran against this branch). No unrelated formatting
changes, no incidental refactors. `backend/package-lock.json` was modified locally during
`npm install` (a pre-existing Windows/Linux line-ending normalization artifact, not a real
dependency change) and was deliberately **excluded** from this branch/commit — verified absent
from the pushed diff.

## Impact / who's affected

- **Affected:** any player using the writer marketplace once it spans more than one page, or
  with a search/sort/filter applied — i.e., most players past the early game. Also affects
  firing writers from a filtered/sorted "Owned Writers" view.
- **Not affected:** a player on an unfiltered, unpaginated, default-sorted writer list may
  have happened to get lucky (local index == server index by coincidence), so this bug was
  intermittent/easy to miss in casual testing rather than a hard, always-reproducing failure —
  which is likely why it persisted in `writerController.js` after the same class of bug was
  already fixed for directors and actors.
- **No breaking changes** to the route shape, request method, or response format. The `:index`
  route param is unchanged in name and position — only the value it's expected to carry
  changed, and `resolveTalent`'s numeric-index fallback means any external caller still
  sending a raw numeric index continues to work exactly as before, just without the
  pagination-safety guarantee that the id-based path provides.

## Testing performed

- `node --check` on `writerController.js` — parses clean.
- `esbuild --bundle=false` JSX parse-check on `Writers.jsx` — parses clean.
- Cross-checked the pushed branch against the live `upstream/elusoc` tip with `git diff`:
  confirmed the diff is isolated to exactly these two files, matches what's described above
  line-for-line, and that the file hashes match what was built and tested locally before
  pushing.
- Read through `directorController.js`'s and `actorController.js`'s existing use of
  `resolveTalent` to confirm the writer migration follows the identical, already-proven
  pattern rather than inventing a new approach.
- Ran the project's `npm test` and `npm run build` locally. As with PR #117 (filed just
  before this one, also currently open), a subset of backend tests fail on a clean checkout
  due to missing dependencies in `node_modules` (`zod`/`compression` — environment-only, since
  resolved locally via `npm install`) and two pre-existing flaky/unrelated assertions
  (`Box Office Engine - balanced distribution over 1000 trials`,
  `careerImpactEngine: a HIT raises stats, salary, earnings and history`). None of those
  failing tests import, call, or exercise `writerController.js` or `Writers.jsx` — I'm
  disclosing this rather than claiming a clean test run that didn't happen. `npm run build`
  (frontend, Vite) completed successfully with no errors.
- Manual reproduction reasoning: with the fix in place, the value sent on hire/fire is now the
  exact id of the card the player clicked, which `resolveTalent` resolves via `findIndex` —
  the resolved item and the clicked item are now provably the same object by id-equality,
  independent of pagination, filtering, or sort order on either the client or server.

## Reproduction (before this fix)

1. Open the Writer marketplace with enough writers to span multiple pages (or apply any
   search/filter/sort).
2. Navigate to page 2 (or apply a filter).
3. Click "Hire" on a specific, identifiable writer.
4. Open "Owned Writers."
5. **Before:** a different writer than the one clicked appears in the roster (or "Writer not
   found" if the index was out of range). **After:** the exact writer clicked is the one
   added.
6. Same reproduction shape applies to firing a writer from a filtered/sorted owned view.

**Related Issue:** Closes #116

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots (If applicable)
_Will attach a quick before/after if useful — page 2 of the writer market, clicking Hire on a
specific writer, then showing that writer (not a different one) in Owned Writers._

## Checklist
- [x] My code follows the style guidelines of this project (mirrors the exact pattern already
      established in `directorController.js`/`actorController.js`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have targetted the `elusoc` branch
- [x] I have requested assignment before starting work