### PR TITLE
feat(streaming): add TVShow model & recurring weekly streaming revenue (closes #41)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -19,6 +19,7 @@ import notificationRoutes from "./routes/notificationRoutes.js";
 import newsRoutes from "./routes/newsRoutes.js";
 import franchiseRoutes from "./routes/franchiseRoutes.js";
 import streamingRoutes from "./routes/streamingRoutes.js";
+import tvShowRoutes from "./routes/tvShowRoutes.js";
 import rivalStudioRoutes from "./routes/rivalStudioRoutes.js";
 import leaderboardRoutes from "./routes/leaderboardRoutes.js";
 
@@ -59,6 +60,7 @@ app.use("/api/notifications", notificationRoutes);
 app.use("/api/news", newsRoutes);
 app.use("/api/franchises", franchiseRoutes);
 app.use("/api/streaming", streamingRoutes);
+app.use("/api/tv-shows", tvShowRoutes);
 app.use("/api/rival-studios", rivalStudioRoutes);
 app.use("/api/leaderboard", leaderboardRoutes);
 

--- a/backend/src/controllers/tvShowController.js
+++ b/backend/src/controllers/tvShowController.js
@@ -1,0 +1,152 @@
+import TVShow from "../models/TVShow.js";
+import Studio from "../models/Studio.js";
+import GameState from "../models/GameState.js";
+
+/**
+ * @fileoverview TV Show controller (issue #41).
+ *
+ * Provides studio-scoped create / list / read endpoints for the TVShow model.
+ * Follows the exact studio-ownership pattern already used by
+ * `franchiseController.js` (resolve the studio via `Studio.findOne({ owner })`,
+ * scope all queries by `studioId`), and adds an optional production-budget
+ * mechanic so commissioning a show is a real studio investment when a budget is
+ * supplied. All behaviour is additive and independent of the movie flow.
+ */
+
+/**
+ * Derives an initial 0–100 quality score from a production budget.
+ *
+ * Logarithmic so the first rupees matter most and returns diminish: a token
+ * budget (~₹1M) lands near 38, ₹10M ≈ 56, ₹50M ≈ 73, ₹100M ≈ 80, clamping to
+ * 100 around ₹1B. A zero/negative budget yields a baseline 30.
+ *
+ * @param {number} budget - Production budget in ₹.
+ * @returns {number} Quality score clamped to [0, 100].
+ */
+const deriveQualityFromBudget = (budget) => {
+  if (!budget || budget <= 0) return 30;
+  const score = 30 + Math.round(Math.log10(budget / 1000000 + 1) * 25);
+  return Math.max(0, Math.min(100, score));
+};
+
+/**
+ * GET /api/tv-shows
+ * Lists the authenticated studio's TV shows, newest first.
+ */
+export const getTVShows = async (req, res) => {
+  try {
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({ success: false, message: "Studio not found" });
+    }
+
+    const tvShows = await TVShow.find({ studioId: studio._id })
+      .sort({ createdAt: -1 })
+      .lean();
+
+    res.status(200).json({ success: true, tvShows });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+/**
+ * GET /api/tv-shows/:id
+ * Returns a single TV show, enforcing studio ownership.
+ */
+export const getTVShowById = async (req, res) => {
+  try {
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({ success: false, message: "Studio not found" });
+    }
+
+    const tvShow = await TVShow.findById(req.params.id).lean();
+    if (!tvShow) {
+      return res.status(404).json({ success: false, message: "TV show not found" });
+    }
+
+    if (tvShow.studioId.toString() !== studio._id.toString()) {
+      return res.status(403).json({ success: false, message: "Not authorized to view this TV show" });
+    }
+
+    res.status(200).json({ success: true, tvShow });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+/**
+ * POST /api/tv-shows
+ * Commissions a new TV show for the authenticated studio.
+ *
+ * Body: { title (required), genre?, seasons?, episodesPerSeason?, budget?, platformId? }
+ *
+ * If a positive `budget` is supplied, the studio must have sufficient funds and
+ * the amount is deducted. If `platformId` is supplied it must reference a real
+ * streaming platform in the player's game state.
+ */
+export const createTVShow = async (req, res) => {
+  try {
+    const { title, genre, seasons, episodesPerSeason, budget, platformId } = req.body;
+
+    if (!title || !title.trim()) {
+      return res.status(400).json({ success: false, message: "TV show title is required" });
+    }
+
+    const numericBudget = Number(budget) || 0;
+    if (numericBudget < 0) {
+      return res.status(400).json({ success: false, message: "Budget cannot be negative" });
+    }
+
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({ success: false, message: "Studio not found" });
+    }
+
+    if (studio.money < numericBudget) {
+      return res.status(400).json({
+        success: false,
+        message: `Insufficient funds. Production requires ₹${(numericBudget / 1000000).toFixed(1)}M but the studio only has ₹${(studio.money / 1000000).toFixed(1)}M.`,
+      });
+    }
+
+    // Single game-state fetch, reused for platform validation and the week stamp.
+    const gameState = await GameState.findOne({ user: req.user._id });
+
+    let resolvedPlatformId = null;
+    if (platformId) {
+      const platform = gameState?.streamingPlatforms?.find((p) => p.id === platformId);
+      if (!platform) {
+        return res.status(400).json({ success: false, message: "Streaming platform not found" });
+      }
+      resolvedPlatformId = platform.id;
+    }
+
+    const currentWeek = gameState?.currentWeek || 0;
+
+    // Deduct the production budget (no-op when budget is 0).
+    if (numericBudget > 0) {
+      studio.money -= numericBudget;
+      await studio.save();
+    }
+
+    const tvShow = await TVShow.create({
+      studioId: studio._id,
+      title: title.trim(),
+      genre: (genre && genre.trim()) || "Drama",
+      seasons: Math.max(1, Number(seasons) || 1),
+      episodesPerSeason: Math.max(1, Number(episodesPerSeason) || 8),
+      budget: numericBudget,
+      quality: deriveQualityFromBudget(numericBudget),
+      popularity: 0,
+      platformId: resolvedPlatformId,
+      status: "IN_PRODUCTION",
+      createdWeek: currentWeek,
+    });
+
+    res.status(201).json({ success: true, tvShow });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};

--- a/backend/src/models/TVShow.js
+++ b/backend/src/models/TVShow.js
@@ -1,0 +1,103 @@
+import mongoose from "mongoose";
+
+/**
+ * @fileoverview TV Show model.
+ *
+ * Introduced for issue #41 ("Streaming, TV Shows & Media Expansion") as the
+ * studio-owned foundation for Version 2 entertainment systems. A TV show is a
+ * first-class production owned by a single studio, mirroring how a {@link Movie}
+ * is owned via `studioId`. It deliberately reuses the existing streaming
+ * `platformId` convention (the string id of an entry in
+ * `GameState.streamingPlatforms`) instead of introducing any parallel platform
+ * system, so future V2 features (airing simulation, per-show OTT revenue, etc.)
+ * can build on the same architecture.
+ *
+ * This model is fully additive — nothing in the existing movie production or
+ * release flow references it.
+ */
+const tvShowSchema = new mongoose.Schema(
+  {
+    // The studio that owns and produced this show.
+    studioId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Studio",
+      required: true,
+    },
+
+    title: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+
+    genre: {
+      type: String,
+      default: "Drama",
+      trim: true,
+    },
+
+    seasons: {
+      type: Number,
+      default: 1,
+      min: 1,
+    },
+
+    episodesPerSeason: {
+      type: Number,
+      default: 8,
+      min: 1,
+    },
+
+    // Total production budget invested by the studio (₹). Optional — a show can
+    // be created with no budget, in which case no funds are deducted.
+    budget: {
+      type: Number,
+      default: 0,
+      min: 0,
+    },
+
+    // 0–100 quality score. Derived from the production budget on creation so a
+    // larger investment yields a better show, consistent with how movie quality
+    // scales with budget elsewhere in the game.
+    quality: {
+      type: Number,
+      default: 0,
+      min: 0,
+      max: 100,
+    },
+
+    // OTT performance metric, reserved for future weekly growth simulation.
+    popularity: {
+      type: Number,
+      default: 0,
+      min: 0,
+    },
+
+    // Optional streaming platform association. Stores the string `id` of an
+    // entry in `GameState.streamingPlatforms` (e.g. "flixstream"), reusing the
+    // existing embedded platform model rather than a standalone one.
+    platformId: {
+      type: String,
+      default: null,
+    },
+
+    status: {
+      type: String,
+      enum: ["IN_PRODUCTION", "AIRING", "ENDED", "CANCELLED"],
+      default: "IN_PRODUCTION",
+    },
+
+    // The in-game week the show was commissioned.
+    createdWeek: {
+      type: Number,
+      default: 0,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+const TVShow = mongoose.model("TVShow", tvShowSchema);
+
+export default TVShow;

--- a/backend/src/routes/tvShowRoutes.js
+++ b/backend/src/routes/tvShowRoutes.js
@@ -1,0 +1,15 @@
+import express from "express";
+import { protect } from "../middleware/authMiddleware.js";
+import {
+  getTVShows,
+  getTVShowById,
+  createTVShow,
+} from "../controllers/tvShowController.js";
+
+const router = express.Router();
+
+router.get("/", protect, getTVShows);
+router.post("/", protect, createTVShow);
+router.get("/:id", protect, getTVShowById);
+
+export default router;

--- a/backend/src/services/simulation/engines/streamingEngine.js
+++ b/backend/src/services/simulation/engines/streamingEngine.js
@@ -93,3 +93,87 @@ export const processStreamingPlatformGrowth = async (gameState) => {
     platform.contentBudget += 10000000; 
   });
 };
+
+// Weekly royalty rate applied to a streaming deal's original value, paid each
+// week of the exclusivity window on top of the one-time acceptance lump sum.
+const WEEKLY_STREAMING_ROYALTY_RATE = 0.005; // 0.5% of deal value per week
+
+/**
+ * Accrues recurring weekly streaming revenue for a studio's ACCEPTED deals.
+ *
+ * When a movie's streaming deal is accepted, `acceptStreamingDeal` pays a
+ * one-time lump sum and records `movie.releaseWeek`. This function adds the
+ * missing recurring piece: for every accepted-deal movie still inside its
+ * exclusivity window, the studio earns an ongoing royalty each week, scaled by
+ * the hosting platform's current popularity (a healthier platform pays more for
+ * the same title).
+ *
+ * Royalties begin the week AFTER acceptance (`weeksElapsed >= 1`, so the lump
+ * sum and the first royalty never double up on the same week) and stop once the
+ * deal's `exclusiveWeeks` window has elapsed — so revenue is bounded, not
+ * perpetual. The query is scoped by `studioId`, so it only ever pays the
+ * current studio for its own catalogue.
+ *
+ * Mutates `studio.money` in place; the caller (`runWeeklySimulation` →
+ * `simulationController`) persists the studio after the tick. No movie documents
+ * are written and no schema is changed — this reuses the embedded
+ * `streamingDeal` subdoc exactly as it already exists.
+ *
+ * @async
+ * @param {object} gameState - GameState document (provides currentWeek, platforms).
+ * @param {object} studio    - Studio document, mutated in place.
+ * @returns {Promise<number>} Total royalty paid this week (0 if none).
+ */
+export const processStreamingRevenue = async (gameState, studio) => {
+  if (!gameState || !studio) return 0;
+
+  const acceptedMovies = await Movie.find({
+    studioId: studio._id,
+    "streamingDeal.status": "ACCEPTED",
+  })
+    .select("title streamingDeal releaseWeek")
+    .lean();
+
+  if (!acceptedMovies || acceptedMovies.length === 0) return 0;
+
+  const currentWeek = Number(gameState.currentWeek) || 0;
+  let totalRoyalty = 0;
+  let earningTitles = 0;
+
+  for (const movie of acceptedMovies) {
+    const deal = movie.streamingDeal;
+    if (!deal || deal.status !== "ACCEPTED") continue;
+
+    const dealValue = Number(deal.dealValue) || 0;
+    const exclusiveWeeks = Number(deal.exclusiveWeeks) || 0;
+    const releaseWeek = Number(movie.releaseWeek);
+    if (!dealValue || !exclusiveWeeks || Number.isNaN(releaseWeek)) continue;
+
+    // Only pay during the exclusivity window, starting the week after acceptance.
+    const weeksElapsed = currentWeek - releaseWeek;
+    if (weeksElapsed < 1 || weeksElapsed > exclusiveWeeks) continue;
+
+    const platform = (gameState.streamingPlatforms || []).find(
+      (p) => p.id === deal.platformId
+    );
+    const popularityFactor = platform
+      ? 0.5 + (Number(platform.popularity) || 0) / 100
+      : 1;
+
+    const royalty = Math.round(dealValue * WEEKLY_STREAMING_ROYALTY_RATE * popularityFactor);
+    if (royalty > 0) {
+      totalRoyalty += royalty;
+      earningTitles += 1;
+    }
+  }
+
+  if (totalRoyalty > 0) {
+    studio.money += totalRoyalty;
+    addNotification(
+      gameState,
+      `Earned ₹${(totalRoyalty / 1000000).toFixed(2)}M in streaming royalties this week from ${earningTitles} exclusive title${earningTitles === 1 ? "" : "s"}.`
+    );
+  }
+
+  return totalRoyalty;
+};

--- a/backend/src/services/simulation/engines/tickEngine.js
+++ b/backend/src/services/simulation/engines/tickEngine.js
@@ -9,7 +9,7 @@ import { generateRivalStudios, processRivalStudios } from "./rivalStudioEngine.j
 import { processProductionEvents } from "./eventEngine.js";
 import { processRandomEvents } from "./eventEngine.js";
 import { generateNewsFromTrend, generateNewsFromEvent } from "./newsEngine.js";
-import { processStreamingPlatformGrowth } from "./streamingEngine.js";
+import { processStreamingPlatformGrowth, processStreamingRevenue } from "./streamingEngine.js";
 
 import { addNotification } from "../helpers/notificationHelper.js";
 import { processWriterAging } from "../helpers/agingHelper.js";
@@ -123,6 +123,10 @@ export const processWeeklyTick = async (gameState, studio) => {
   }
 
   await processStreamingPlatformGrowth(gameState);
+
+  // Recurring weekly streaming revenue for accepted deals (issue #41) — runs
+  // after platform growth so royalties reflect this week's platform popularity.
+  await processStreamingRevenue(gameState, studio);
 
   return { gameState, rivalReleases };
 };


### PR DESCRIPTION
## Description

Implements the two genuinely-unbuilt pieces of the V2 media foundation, closing #41.

### Scope — confirmed by the owner in the issue thread

I didn't work from the title. On a fresh read of `elusoc` I found that most of the original acceptance criteria were **already implemented**, and the owner confirmed the narrowed scope directly in the issue:

> "Your analysis is correct—the streaming platform foundation, streaming deal lifecycle, OTT metrics, and simulation integration are already present, so there's no need to duplicate or refactor those systems. For this issue, let's focus on the remaining unimplemented pieces:
> - Implement a **TV Show** model with appropriate studio ownership and supporting backend structure.
> - Add **recurring weekly streaming revenue** for accepted streaming deals, integrated into the existing weekly simulation tick.
> - **Reuse the current streaming platform and embedded `streamingDeal` implementation rather than introducing a standalone `StreamingDeal` model.** The embedded approach already fits the current architecture well, and avoiding a large refactor will reduce regression risk.
> - Ensure the new functionality is fully additive and keeps the existing movie release flow unchanged."

This PR does exactly those four things and nothing else.

### Mapping to the original acceptance criteria

| Criterion | Status |
|---|---|
| TV Show model created | ✅ New `TVShow` model, studio-owned |
| Streaming Deal model created | ✅ Already exists as the embedded `Movie.streamingDeal` subdoc — **reused, not duplicated**, per the owner's explicit instruction |
| Weekly streaming revenue supported | ✅ New `processStreamingRevenue` accrues royalties on the tick |
| Simulation integration implemented | ✅ Wired into the existing `processWeeklyTick` |
| Architecture supports future V2 features | ✅ `TVShow` carries `status`, `popularity`, and a `platformId` hook reserved for future airing/OTT-revenue simulation |

### What was actually missing (verified against live code)

A repo-wide search confirmed the two gaps the owner identified:
1. **No TV-show concept anywhere** in the backend — no model, controller, or route.
2. **`processStreamingPlatformGrowth` grows platform subscribers/popularity weekly but pays the studio nothing.** The *only* studio payout from streaming today is the one-time `studio.money += dealValue` lump sum in `acceptStreamingDeal`. There is no recurring revenue.

## Changes

### Backend — recurring weekly streaming revenue

**`backend/src/services/simulation/engines/streamingEngine.js`** *(modified, +84)*

Adds `processStreamingRevenue(gameState, studio)` alongside the existing growth function:

```js
export const processStreamingRevenue = async (gameState, studio) => { ... }
```

- Loads **only this studio's** accepted-deal movies — `Movie.find({ studioId: studio._id, "streamingDeal.status": "ACCEPTED" })`. The `studioId` scope is essential: an unscoped query would pay a studio for other players' catalogues. This is the same scoping key already used at `movieController.js:422`.
- For each movie, pays a weekly royalty **only inside the exclusivity window**: `weeksElapsed = currentWeek − releaseWeek`, paid when `weeksElapsed ∈ [1, exclusiveWeeks]`. Starting at `1` means the royalty never doubles up with the acceptance-week lump sum; stopping at `exclusiveWeeks` means revenue is **bounded**, not perpetual. This reuses the `releaseWeek` that `acceptStreamingDeal` already records, so **no schema change and no per-movie writes** are needed.
- Royalty = `round(dealValue × 0.5% × popularityFactor)`, where `popularityFactor = 0.5 + platform.popularity/100`. A healthier, more popular platform pays more for the same title; a missing platform falls back to a factor of `1`. Over a full 52-week exclusivity at popularity 80 this totals ≈ 34% of the deal value — a meaningful supplement to the upfront lump sum without dwarfing it.
- Mutates `studio.money` **in place** and emits a single aggregated notification per week (`"Earned ₹X.XXM in streaming royalties this week from N exclusive titles."`). It writes no movie documents and changes no schema — it reuses the embedded `streamingDeal` subdoc exactly as it already exists.

**`backend/src/services/simulation/engines/tickEngine.js`** *(modified, +6/−1)*

`processWeeklyTick(gameState, studio)` already receives the studio. Imports `processStreamingRevenue` and calls it immediately after `processStreamingPlatformGrowth`, so royalties reflect the platform popularity computed for the same week.

#### Why the payout persists correctly (the part I checked most carefully)

`processStreamingRevenue` only mutates `studio.money` in memory — it deliberately does **not** save. That's correct here, and I verified the full persistence chain rather than assuming it:
- `runWeeklySimulation`'s own header documents that *"the caller is responsible for saving both `gameState` and `studio` to the database after this function resolves."*
- The existing payroll and production engines already rely on this exact contract (their deductions to `studio.money` persist), which is proof the contract holds in practice.
- The caller, `simulationController.js`, wraps the week loop in `withTransaction` and calls `await studio.save({ session })` / `await gameState.save({ session })` **after** the loop. So across a multi-week advance, the royalty accrues each week against the correctly-incremented `currentWeek`, and the cumulative balance is persisted atomically.

### Backend — TV Show foundation

**`backend/src/models/TVShow.js`** *(new file)*

A studio-owned production model: `studioId` (ref `Studio`, required), `title`, `genre`, `seasons`, `episodesPerSeason`, `budget`, `quality` (0–100), `popularity`, `platformId` (optional — the string id of an existing `GameState.streamingPlatforms` entry, reusing that convention rather than a parallel system), `status` (`IN_PRODUCTION` / `AIRING` / `ENDED` / `CANCELLED`), `createdWeek`, timestamps. Nothing in the movie flow references it — it is purely additive.

**`backend/src/controllers/tvShowController.js`** *(new file)*

`getTVShows`, `getTVShowById`, `createTVShow`, following the exact studio-ownership pattern of `franchiseController.js` (`Studio.findOne({ owner: req.user._id })`, all queries scoped by `studioId`, `getTVShowById` additionally enforces ownership with a 403 guard).

`createTVShow` adds an **optional** production-budget mechanic — a natural fit the owner invited ("additional ideas that naturally fit this foundation"). If a positive `budget` is supplied, the studio must have sufficient funds and the amount is deducted (`min: 0` on the schema can never be violated because funds are checked first); if `budget` is `0`/omitted, no funds are touched and the show is still created. Initial `quality` is derived from the budget via a logarithmic curve (₹1M ≈ 38, ₹10M ≈ 56, ₹100M ≈ 80, clamping to 100 near ₹1B), so a larger investment yields a better show — consistent with how movie quality scales with budget. A supplied `platformId` is validated against the player's real streaming platforms.

**`backend/src/routes/tvShowRoutes.js`** *(new file)* — `protect`-guarded `GET /`, `POST /`, `GET /:id`, identical in shape to `franchiseRoutes.js`.

**`backend/src/app.js`** *(modified, +2)* — imports `tvShowRoutes` and mounts it at `/api/tv-shows`, alongside the existing route registrations.

## What I deliberately did NOT do

- Did **not** introduce a standalone `StreamingDeal` model — the owner explicitly asked to keep the embedded `Movie.streamingDeal` subdoc to avoid refactor/regression risk.
- Did **not** modify `acceptStreamingDeal`, the movie release flow, or any existing engine's behaviour — the recurring-revenue logic is a new, separate function and the tick simply calls it.
- Did **not** add or change any field on the `Movie` schema — recurring revenue is computed entirely from data that already exists (`streamingDeal.dealValue`, `exclusiveWeeks`, `releaseWeek`, and platform popularity).
- Did **not** touch the streaming platform growth maths.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots

*(attach if useful: the weekly streaming-royalty notification appearing on the tick after a streaming deal has been accepted and at least one week has elapsed; a successful `POST /api/tv-shows` creating a studio-owned show and the corresponding `money` deduction.)*

## Testing Performed

- **Parse verification:** `node --check` passes cleanly on all six files (3 new + 3 modified).
- **Regression proof (pre-existing failures are not mine):** ran the backend engine suites (`engines.test.js`, `eventEngine.test.js`, `boxOfficeEngine.test.js`) — 39/41 pass. The two failures (`Box Office Engine - balanced distribution over 1000 trials`, an unseeded probabilistic test, and `careerImpactEngine: a HIT raises stats, salary, earnings and history`) reproduce **identically on a pristine `elusoc` clone with none of my changes applied**, so they pre-date this PR. No test references the streaming engine, tick engine, or TV-show code, so my changes cannot affect them.
- **Revenue logic verified numerically** against the exact formula:
  - Acceptance week (`weeksElapsed = 0`) → ₹0 (no double-pay with the lump sum).
  - First eligible week (`weeksElapsed = 1`) → ₹0.65M at platform popularity 80.
  - Final week of exclusivity (`weeksElapsed = 52`) → still paid.
  - Past exclusivity (`weeksElapsed = 53`) → ₹0 (bounded).
  - Popularity scaling: pop 40 → ₹0.45M; missing platform → ₹0.50M (factor 1).
  - ~52-week total at popularity 80 ≈ 34% of the deal value — a supplement, not a windfall.
- **Quality curve verified:** ₹0 → 30, ₹1M → 38, ₹10M → 56, ₹50M → 73, ₹100M → 80, ₹500M → 97, ₹1B → 100 (clamped).
- **Persistence chain verified by inspection:** confirmed `processWeeklyTick(gameState, studio)` receives the studio, that `simulationController` saves `studio`/`gameState` with `{ session }` after the week loop inside `withTransaction`, and that the multi-week loop increments `currentWeek` each iteration so royalties accrue correctly week-by-week.
- **Multi-tenant safety verified:** the accepted-deal query is scoped by `studioId` (the same key used elsewhere in `movieController`), so a studio is only ever paid for its own catalogue.
- **Signature checks:** `addNotification(gameState, message)` matches the helper's exported signature; `protect` is imported from the same `authMiddleware.js` path used by every other route file.
- **Diff scope verified:** exactly 6 files (3 new, 3 modified), `+91/−1` across the modified files, with no incidental edits and `package-lock.json` untouched.
- **Not independently re-run here:** the full DB-backed API/integration suites (`auth.api`, `gameplay.api`, `integration.lifecycle`) require an in-memory MongoDB that can't be provisioned in my sandbox; I'd ask CI to confirm the full suite and a frontend build stay green as a final check. These paths are unaffected by this change.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] This PR is targetted to the `elusoc` branch