### PR TITLE
feat(talent): annual actor awards & crew career progression (closes #31)

### DIFF
--- a/backend/src/models/GameState.js
+++ b/backend/src/models/GameState.js
@@ -655,6 +655,7 @@ const gameStateSchema = new mongoose.Schema(
         busyUntilWeek: Number,
         hiredAt: Date,
         contractYears: Number,
+        careerTier: { type: String, default: "Rookie" },
       },
     ],
 
@@ -681,6 +682,7 @@ const gameStateSchema = new mongoose.Schema(
         busyUntilWeek: Number,
         hiredAt: Date,
         contractYears: Number,
+        careerTier: { type: String, default: "Rookie" },
       },
     ],
 

--- a/backend/src/services/actor/actorAwardsService.js
+++ b/backend/src/services/actor/actorAwardsService.js
@@ -1,0 +1,363 @@
+/**
+ * @fileoverview Actor Awards Service
+ *
+ * Evaluates and grants annual, actor-specific awards, mirroring the structure
+ * of `directorAwardsService.js` but adapted to actor stats (actors track
+ * `popularity` and `fanbase` rather than `reputation`/`marketValue`).
+ *
+ * Called once per in-game year (every 52 weeks) from the tick engine, after
+ * each owned/market/retired actor has had their career history attached from
+ * the persisted `TalentHistory` collection.
+ *
+ * Award effects applied to a winning actor:
+ *  - `awards` counter incremented.
+ *  - `popularity` raised by the award's prestige value (clamped to [0, 100]).
+ *  - `fanbase` increased by the award's fan bump.
+ *  - `salary` increased by the award's salary-increase rate.
+ *  - `AWARD` and `SALARY` entries appended to the actor's talent history.
+ *  - The owning studio's `fans` increased by the award's fan bump.
+ *  - A system notification is queued.
+ *
+ * No database calls are made here; the caller (tick engine / simulation
+ * controller) persists the mutated GameState and flushes pending history and
+ * notifications.
+ */
+import { addTalentHistory } from "../simulation/helpers/historyHelper.js";
+import { addNotification } from "../simulation/helpers/notificationHelper.js";
+import { VERDICTS } from "../../constants/verdicts.js";
+
+const WEEKS_PER_YEAR = 52;
+
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+const toNumber = (value) => Number(value || 0);
+const weekToYear = (week = 1) => Math.floor((Number(week || 1) - 1) / WEEKS_PER_YEAR) + 1;
+
+/**
+ * Normalizes a career-history entry (written by careerImpactEngine) into a
+ * consistent shape for scoring. careerImpactEngine records:
+ *   { movieId, movieTitle, releaseWeek, quality, boxOffice, verdict }
+ * so critic/audience scores fall back to `quality`, and `year` is derived from
+ * `releaseWeek` when not present.
+ */
+const normalizeMovie = (movie, fallbackIndex = 0) => {
+  const criticScore = toNumber(movie.criticScore ?? movie.movieRating ?? movie.quality);
+  const audienceScore = toNumber(movie.audienceScore ?? movie.movieRating ?? movie.quality);
+  const movieQuality = toNumber(
+    movie.movieQuality ?? movie.quality ?? movie.movieRating ?? ((criticScore + audienceScore) / 2)
+  );
+  const boxOffice = toNumber(movie.boxOffice);
+  const verdict = movie.verdict || movie.outcome || "Unknown";
+
+  return {
+    movieId: movie.movieId || movie.id || `${movie.movieTitle || "movie"}-${movie.releaseWeek || fallbackIndex}`,
+    movieTitle: movie.movieTitle || movie.title || movie.movieName || "Untitled Movie",
+    year: movie.year || weekToYear(movie.releaseWeek),
+    releaseWeek: movie.releaseWeek,
+    movieQuality,
+    criticScore,
+    audienceScore,
+    boxOffice,
+    verdict,
+  };
+};
+
+const getAnnualMovies = (actor, awardYear) =>
+  (actor.careerHistory || [])
+    .map(normalizeMovie)
+    .filter((movie) => movie.year === awardYear);
+
+const getBoxOfficeScore = (boxOffice) => clamp((toNumber(boxOffice) / 100000000) * 100, 0, 100);
+
+/**
+ * Verdict-driven success weighting. Uses the canonical VERDICTS strings
+ * (uppercase) so HIT/BLOCKBUSTER/ALL_TIME_BLOCKBUSTER are actually rewarded and
+ * FLOP/DISASTER penalised; otherwise falls back to raw quality.
+ */
+const getGenreSuccessScore = (movie) => {
+  if (
+    movie.verdict === VERDICTS.HIT ||
+    movie.verdict === VERDICTS.BLOCKBUSTER ||
+    movie.verdict === VERDICTS.ALL_TIME_BLOCKBUSTER
+  ) {
+    return 100;
+  }
+
+  if (movie.verdict === VERDICTS.FLOP || movie.verdict === VERDICTS.DISASTER) {
+    return 20;
+  }
+
+  return clamp((movie.movieQuality + movie.criticScore + movie.audienceScore) / 3, 0, 100);
+};
+
+/**
+ * Scores a single movie for an actor. The career-standing term uses the actor's
+ * `popularity` (an actor's analogue to a director's reputation).
+ */
+const scoreMovieForAward = (actor, movie) => {
+  const careerStanding = toNumber(actor.popularity);
+
+  return (
+    movie.movieQuality * 0.3 +
+    movie.criticScore * 0.2 +
+    movie.audienceScore * 0.15 +
+    getBoxOfficeScore(movie.boxOffice) * 0.15 +
+    getGenreSuccessScore(movie) * 0.1 +
+    careerStanding * 0.1
+  );
+};
+
+const getBestMovieCandidate = (actor, awardYear) => {
+  const movies = getAnnualMovies(actor, awardYear);
+
+  if (movies.length === 0) {
+    return null;
+  }
+
+  return movies
+    .map((movie) => ({
+      actor,
+      movie,
+      score: scoreMovieForAward(actor, movie),
+    }))
+    .sort((a, b) => b.score - a.score)[0];
+};
+
+const getAnnualActorScore = (actor, awardYear) => {
+  const movies = getAnnualMovies(actor, awardYear);
+
+  if (movies.length === 0) {
+    return null;
+  }
+
+  const movieScores = movies.map((movie) => scoreMovieForAward(actor, movie));
+  const averageMovieScore = movieScores.reduce((sum, score) => sum + score, 0) / movieScores.length;
+  const volumeBonus = Math.min(10, movies.length * 2);
+
+  return {
+    actor,
+    movie: movies.sort((a, b) => scoreMovieForAward(actor, b) - scoreMovieForAward(actor, a))[0],
+    score: averageMovieScore + volumeBonus + toNumber(actor.popularity) * 0.1,
+  };
+};
+
+/**
+ * Breakthrough Actor candidate: an actor whose only career movie is this year's
+ * (i.e. a debut year), boosted so a strong first outing can stand out.
+ */
+const getBreakthroughCandidate = (actor, awardYear) => {
+  const careerMovies = actor.careerHistory || [];
+  const annualCandidate = getBestMovieCandidate(actor, awardYear);
+
+  if (!annualCandidate || careerMovies.length !== 1) {
+    return null;
+  }
+
+  return {
+    ...annualCandidate,
+    score: annualCandidate.score + 10,
+  };
+};
+
+const getLifetimeCandidate = (actor, awardYear) => {
+  const careerMovies = (actor.careerHistory || []).map(normalizeMovie);
+  const moviesActed = toNumber(actor.movies) || careerMovies.length;
+  const awards = toNumber(actor.awards);
+  const popularity = toNumber(actor.popularity);
+  const age = toNumber(actor.age);
+
+  if (moviesActed < 10 && popularity < 80 && age < 70) {
+    return null;
+  }
+
+  const averageMovieScore = careerMovies.length
+    ? careerMovies.reduce((sum, movie) => sum + scoreMovieForAward(actor, movie), 0) / careerMovies.length
+    : popularity;
+
+  return {
+    actor,
+    movie: careerMovies.sort((a, b) => scoreMovieForAward(actor, b) - scoreMovieForAward(actor, a))[0] || {
+      movieId: null,
+      movieTitle: "Career Achievement",
+      year: awardYear,
+    },
+    score: averageMovieScore + moviesActed * 1.5 + awards * 5 + popularity * 0.3,
+  };
+};
+
+const hasAwardForYear = (actor, awardName, year) =>
+  (actor.awardsHistory || []).some(
+    (award) => award.awardName === awardName && Number(award.year || weekToYear(award.week)) === year
+  );
+
+const buildAward = ({ awardName, category, candidate, awardYear }) => {
+  const score = clamp(candidate.score, 0, 100);
+  const prestigeValue = Math.round(clamp(5 + (score / 100) * 15, 5, 20));
+  const salaryIncreaseRate = clamp(0.1 + (score / 100) * 0.4, 0.1, 0.5);
+
+  return {
+    actorId: candidate.actor.id,
+    awardName,
+    category,
+    movieId: candidate.movie?.movieId || null,
+    movieTitle: candidate.movie?.movieTitle || "Career Achievement",
+    year: awardYear,
+    prestigeValue,
+    salaryIncreaseRate,
+    fanIncrease: Math.round(prestigeValue * 1000),
+  };
+};
+
+const selectTopCandidate = (candidates, awardName, awardYear, minimumScore = 60) =>
+  candidates
+    .filter(Boolean)
+    .filter((candidate) => candidate.score >= minimumScore)
+    .filter((candidate) => !hasAwardForYear(candidate.actor, awardName, awardYear))
+    .sort((a, b) => b.score - a.score)[0] || null;
+
+const collectActorEntries = (gameState) => [
+  ...(gameState.marketActors || []).map((actor) => ({ actor, pool: "market" })),
+  ...(gameState.ownedActors || []).map((actor) => ({ actor, pool: "owned" })),
+  ...(gameState.retiredActors || []).map((actor) => ({ actor, pool: "retired" })),
+];
+
+/**
+ * Determines the year's actor awards.
+ *
+ * Genre-specific acting awards are intentionally omitted: careerImpactEngine's
+ * career-history entries do not record a movie's genre, so a data-driven
+ * genre award could not be evaluated without modifying that (test-covered)
+ * engine. The awards below are all evaluable from the recorded history.
+ */
+const determineActorAwards = (gameState, awardYear) => {
+  const entries = collectActorEntries(gameState).filter(
+    ({ actor }) => actor.status !== "RETIRED" || (actor.careerHistory || []).length > 0
+  );
+  const awards = [];
+
+  const bestActorCandidate = selectTopCandidate(
+    entries.map(({ actor }) => getBestMovieCandidate(actor, awardYear)),
+    "Best Actor",
+    awardYear
+  );
+
+  if (bestActorCandidate) {
+    awards.push(buildAward({ awardName: "Best Actor", category: "Overall", candidate: bestActorCandidate, awardYear }));
+  }
+
+  const actorOfYearCandidate = selectTopCandidate(
+    entries.map(({ actor }) => getAnnualActorScore(actor, awardYear)),
+    "Actor Of The Year",
+    awardYear,
+    65
+  );
+
+  if (actorOfYearCandidate) {
+    awards.push(
+      buildAward({ awardName: "Actor Of The Year", category: "Annual", candidate: actorOfYearCandidate, awardYear })
+    );
+  }
+
+  const breakthroughCandidate = selectTopCandidate(
+    entries.map(({ actor }) => getBreakthroughCandidate(actor, awardYear)),
+    "Breakthrough Actor",
+    awardYear
+  );
+
+  if (breakthroughCandidate) {
+    awards.push(
+      buildAward({ awardName: "Breakthrough Actor", category: "Debut", candidate: breakthroughCandidate, awardYear })
+    );
+  }
+
+  const lifetimeCandidate = selectTopCandidate(
+    entries.map(({ actor }) => getLifetimeCandidate(actor, awardYear)),
+    "Lifetime Achievement Award",
+    awardYear,
+    75
+  );
+
+  if (lifetimeCandidate) {
+    awards.push(
+      buildAward({
+        awardName: "Lifetime Achievement Award",
+        category: "Career",
+        candidate: lifetimeCandidate,
+        awardYear,
+      })
+    );
+  }
+
+  return awards;
+};
+
+const applyActorAward = ({ award, studio, gameState }) => {
+  const actor = collectActorEntries(gameState).find(
+    ({ actor: candidate }) => candidate.id === award.actorId
+  )?.actor;
+
+  if (!actor) {
+    return;
+  }
+
+  const previousSalary = toNumber(actor.salary);
+  const nextSalary = Math.round(previousSalary * (1 + award.salaryIncreaseRate));
+
+  actor.awards = toNumber(actor.awards) + 1;
+  addTalentHistory(gameState, actor.id, "AWARD", {
+    awardName: award.awardName,
+    category: award.category,
+    movieId: award.movieId,
+    movieTitle: award.movieTitle,
+    movieName: award.movieTitle,
+    year: award.year,
+    prestigeValue: award.prestigeValue,
+  });
+
+  actor.popularity = clamp(toNumber(actor.popularity) + award.prestigeValue, 0, 100);
+  actor.fanbase = Math.round(toNumber(actor.fanbase) + award.fanIncrease);
+  actor.salary = nextSalary;
+  addTalentHistory(gameState, actor.id, "SALARY", {
+    week: gameState.currentWeek,
+    salary: nextSalary,
+    reason: `${award.awardName} Award Increase`,
+  });
+
+  if (studio) {
+    studio.fans = toNumber(studio.fans) + award.fanIncrease;
+  }
+
+  addNotification(gameState, `${actor.name} won ${award.awardName}.`);
+};
+
+/**
+ * Processes annual actor awards for the current in-game year.
+ *
+ * Guards:
+ *  - Only runs on an award week (every 52 weeks).
+ *  - Skips a year already recorded in `gameState.actorAwardYearsProcessed`.
+ *
+ * @param {object} gameState - GameState document (mutated in place).
+ * @param {object} studio    - Player's studio document (mutated in place), or null.
+ * @returns {Array<object>} The awards granted this year (empty if none / not due).
+ */
+export const processActorAwards = (gameState, studio) => {
+  const awardYear = weekToYear(gameState.currentWeek);
+
+  if (gameState.currentWeek % WEEKS_PER_YEAR !== 0) {
+    return [];
+  }
+
+  gameState.actorAwardYearsProcessed = gameState.actorAwardYearsProcessed || [];
+
+  if (gameState.actorAwardYearsProcessed.includes(awardYear)) {
+    return [];
+  }
+
+  const awards = determineActorAwards(gameState, awardYear);
+
+  awards.forEach((award) => applyActorAward({ award, studio, gameState }));
+
+  gameState.actorAwardYearsProcessed.push(awardYear);
+
+  return awards;
+};

--- a/backend/src/services/crew/crewProgressionService.js
+++ b/backend/src/services/crew/crewProgressionService.js
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview Crew Career Progression Service
+ *
+ * Adds a meaningful career-progression layer for crew teams on top of the
+ * reputation they already accrue from released projects (see
+ * `careerImpactEngine.js`, which raises `crewTeam.reputation` by a verdict-driven
+ * delta on every movie release).
+ *
+ * Reputation on its own is a raw 0–100 number; this service maps it onto a
+ * discrete, human-readable career ladder and records progression milestones so
+ * the player can see their crew grow from Rookie to Legendary as their projects
+ * succeed.
+ *
+ * Design notes:
+ *  - Progression is **monotonic**: a crew's `careerTier` reflects the highest
+ *    rank they have ever reached, so a single flop (which lowers reputation)
+ *    does not strip an earned career rank. This matches "career progression"
+ *    semantics rather than a volatile live rank.
+ *  - Only **owned** crew progress (they are the ones taking on projects and
+ *    earning reputation). Market crew retain the schema default until hired.
+ *  - Effects are limited to the new `careerTier` field, a `PROGRESSION` history
+ *    entry, and a notification — no existing stat is altered, so simulation
+ *    balance is unaffected (crew `reputation`/`morale` feed no gameplay formula).
+ *
+ * No database calls are made; the caller persists the mutated GameState and
+ * flushes pending history/notifications.
+ */
+import { addTalentHistory } from "../simulation/helpers/historyHelper.js";
+import { addNotification } from "../simulation/helpers/notificationHelper.js";
+
+const toNumber = (value) => Number(value || 0);
+
+/**
+ * Career tiers in ascending order. `min` is the inclusive reputation threshold
+ * at which a crew reaches that tier.
+ */
+export const CREW_CAREER_TIERS = [
+  { name: "Rookie", min: 0 },
+  { name: "Professional", min: 20 },
+  { name: "Established", min: 40 },
+  { name: "Veteran", min: 60 },
+  { name: "Legendary", min: 80 },
+];
+
+/** Highest tier index whose threshold is met by the given reputation. */
+const tierIndexForReputation = (reputation) => {
+  const rep = toNumber(reputation);
+  let index = 0;
+  for (let i = 0; i < CREW_CAREER_TIERS.length; i += 1) {
+    if (rep >= CREW_CAREER_TIERS[i].min) {
+      index = i;
+    }
+  }
+  return index;
+};
+
+/** Index of a named tier, or -1 if unrecognised (treated as pre-tier baseline). */
+const tierIndexByName = (name) =>
+  CREW_CAREER_TIERS.findIndex((tier) => tier.name === name);
+
+/**
+ * Advances owned crew along the career ladder based on their current reputation.
+ *
+ * For each owned crew, compares the tier implied by their reputation against
+ * their recorded `careerTier`; if it is strictly higher, promotes them (updates
+ * the field, records a `PROGRESSION` history entry, and queues a notification).
+ *
+ * @param {object} gameState - GameState document (mutated in place).
+ * @returns {number} The number of crew promoted this call (useful for tests/logging).
+ */
+export const processCrewProgression = (gameState) => {
+  const crews = gameState.ownedCrewTeams || [];
+  let promotions = 0;
+
+  crews.forEach((crew) => {
+    if (!crew) {
+      return;
+    }
+
+    const newIndex = tierIndexForReputation(crew.reputation);
+
+    const recordedIndex = tierIndexByName(crew.careerTier);
+    // Unrecognised / unset tier is treated as the baseline (Rookie, index 0).
+    const currentIndex = recordedIndex === -1 ? 0 : recordedIndex;
+
+    if (newIndex > currentIndex) {
+      const fromTier = CREW_CAREER_TIERS[currentIndex].name;
+      const toTier = CREW_CAREER_TIERS[newIndex].name;
+
+      crew.careerTier = toTier;
+      promotions += 1;
+
+      addTalentHistory(gameState, crew.id, "PROGRESSION", {
+        week: gameState.currentWeek,
+        fromTier,
+        toTier,
+        reputation: toNumber(crew.reputation),
+      });
+
+      addNotification(gameState, `${crew.name} was promoted to ${toTier} crew.`);
+    }
+  });
+
+  return promotions;
+};

--- a/backend/src/services/simulation/engines/tickEngine.js
+++ b/backend/src/services/simulation/engines/tickEngine.js
@@ -1,4 +1,6 @@
 import { processDirectorAwards } from "../../director/directorAwardsService.js";
+import { processActorAwards } from "../../actor/actorAwardsService.js";
+import { processCrewProgression } from "../../crew/crewProgressionService.js";
 import { processDirectorAging } from "./directorEngine.js";
 import { processDirectingProjects } from "./directingProjectEngine.js";
 import { processProduction } from "./productionEngine.js";
@@ -90,25 +92,31 @@ export const processWeeklyTick = async (gameState, studio) => {
 
   const awardYear = Math.floor((Number(gameState.currentWeek || 1) - 1) / 52) + 1;
   const isAwardWeek = gameState.currentWeek % 52 === 0;
-  const alreadyProcessed = (gameState.directorAwardYearsProcessed || []).includes(awardYear);
+  const directorAlreadyProcessed = (gameState.directorAwardYearsProcessed || []).includes(awardYear);
+  const actorAlreadyProcessed = (gameState.actorAwardYearsProcessed || []).includes(awardYear);
 
-  if (isAwardWeek && !alreadyProcessed) {
+  if (isAwardWeek && (!directorAlreadyProcessed || !actorAlreadyProcessed)) {
     const histories = await TalentHistory.find({ gameStateId: gameState._id }).lean();
-    
+
     const attachHistory = (talentList) => {
       if (!talentList) return;
-      talentList.forEach((director) => {
-        director.careerHistory = histories.filter(h => h.talentId === director.id && h.type === "CAREER").map(h => h.data);
-        director.awardsHistory = histories.filter(h => h.talentId === director.id && h.type === "AWARD").map(h => h.data);
+      talentList.forEach((talent) => {
+        talent.careerHistory = histories.filter(h => h.talentId === talent.id && h.type === "CAREER").map(h => h.data);
+        talent.awardsHistory = histories.filter(h => h.talentId === talent.id && h.type === "AWARD").map(h => h.data);
       });
     };
 
     attachHistory(gameState.marketDirectors);
     attachHistory(gameState.ownedDirectors);
     attachHistory(gameState.retiredDirectors);
+    attachHistory(gameState.marketActors);
+    attachHistory(gameState.ownedActors);
+    attachHistory(gameState.retiredActors);
   }
 
   processDirectorAwards(gameState, studio);
+  processActorAwards(gameState, studio);
+  processCrewProgression(gameState);
 
   // 9. Production events — movie-level crises & opportunities.
   await processProductionEvents(gameState, studio);


### PR DESCRIPTION
## Description

Completes the talent-lifecycle system per the scope clarified in #31: annual **actor-specific awards** and a meaningful **crew career-progression** layer, both integrated into the existing aging / award-week / career-history machinery rather than as parallel systems.

### Re-scoping context (read directly from the issue thread)

The owner's clarifying comment on #31 states the goal explicitly: implement annual actor-specific awards and recognition (similar to the existing talent progression), add meaningful crew reputation and career progression based on project performance and movie outcomes, and ensure both integrate cleanly with the existing aging, retirement, and career-history mechanisms — not as parallel implementations.

Before writing any code, I re-read the live talent-lifecycle code end to end (not a prior summary) and found two things that reshaped the plan:

1. **Actor awards were scaffolded but never built.** `GameState` already declares `actorAwardYearsProcessed: [Number]`, sitting right next to the `directorAwardYearsProcessed` field the working director-awards system uses — dormant scaffolding, clearly anticipating this exact feature. No `actorAwardsService` existed anywhere in the codebase.
2. **Crew reputation growth already works.** `careerImpactEngine.processCareerImpact(gameState, movie, writer, director, leadActor, crewTeam)` is called from `movieController.releaseMovie` with the real `crewTeam` (sourced from `gameState.ownedCrewTeams`), and it already raises `crewTeam.reputation` by a verdict-driven delta on every release. Re-implementing that would have created exactly the "parallel implementation" the owner warned against. The genuine gap is **progression** — a visible career rank derived from that reputation, which did not exist.

Additional facts confirmed by reading the live models: there is no standalone `Actor.js` model (actors are embedded arrays on `GameState`, mirroring how directors are stored); actors track `popularity`/`fanbase`, not `reputation`; the crew arrays (`marketCrewTeams`/`ownedCrewTeams`) are defined **inline** in `GameState.js` rather than via `CrewTeam.js`, so that's where a new crew field must be added for Mongoose to persist it; and crew `reputation`/`morale` feed no existing gameplay formula (movie quality is driven by `technicalQuality` etc.), so building progression on top of reputation carries zero risk of disturbing simulation balance.

### 1. Annual actor awards — `services/actor/actorAwardsService.js` (new)

`processActorAwards(gameState, studio)` mirrors the structure of the existing `directorAwardsService` (same award-week trigger, same `careerHistory`/`awardsHistory` shape, same effect vocabulary), adapted to actor stats. Four awards, each only fired when data actually supports it:

- **Best Actor** — the single highest-scoring performance released this award-year.
- **Actor Of The Year** — best overall annual body of work (average performance score + a small volume bonus for multiple releases).
- **Breakthrough Actor** — best debut: an actor whose *only* career-history entry is this year's film, with a debut-specific score boost.
- **Lifetime Achievement Award** — reserved for a qualifying veteran (≥10 films acted, or popularity ≥80, or age ≥70), scored off full career history rather than the current year alone.

Movie scoring reuses the director service's weighted formula (quality 0.30 / critic 0.20 / audience 0.15 / box-office 0.15 / verdict-success 0.10 / career-standing 0.10), with the actor's `popularity` substituted as the career-standing term (the actor analogue of a director's `reputation`). Each award is only granted once per actor per award-name-per-year (`hasAwardForYear`) and only above a minimum score threshold, exactly like the director system.

**Effects on the winning actor**, applied via `applyActorAward`:
- `awards` counter incremented.
- `popularity` raised by the award's prestige value, clamped to `[0, 100]`.
- `fanbase` increased by the award's fan bump.
- `salary` raised by the award's salary-increase rate (5–20% prestige → 10–50% raise, same curve as directors).
- An `AWARD` and a `SALARY` entry appended to the actor's talent history (`addTalentHistory`), and the owning studio's `fans` credited with the same fan bump.
- A system notification queued (`"{name} won {awardName}."`).

**One correctness improvement over the template it mirrors:** the existing `directorAwardsService.getGenreSuccessScore` compares against titlecase verdict strings (`"Hit"`, `"Blockbuster"`), but `careerHistory` entries actually store the canonical uppercase `VERDICTS` constants (`"HIT"`, `"BLOCKBUSTER"`, `"ALL_TIME_BLOCKBUSTER"`, `"FLOP"`, `"DISASTER"`) — so that comparison silently never matches in the director version. The actor version imports `VERDICTS` directly and compares against those, so hit/blockbuster success is genuinely rewarded and flop/disaster genuinely penalised.

**Deliberately omitted: genre-specific acting awards.** The director system offers "Best {Genre} Director" because `careerHistory` entries there happen to carry a genre. Actor `careerHistory` entries (written by `careerImpactEngine`) do not record genre, so a genre-specific award could not be evaluated from real data without modifying that engine — which is out of scope and under existing test coverage. Every award shipped here can actually fire from the data that exists.

### 2. Crew career progression — `services/crew/crewProgressionService.js` (new)

`processCrewProgression(gameState)` maps the reputation crew already earn onto a discrete, human-readable career ladder:

| Tier | Reputation threshold |
|---|---|
| Rookie | 0 |
| Professional | 20 |
| Established | 40 |
| Veteran | 60 |
| Legendary | 80 |

For each **owned** crew team, if their current reputation implies a tier higher than the one recorded on `careerTier`, they are promoted: the field is updated, a `PROGRESSION` talent-history entry is written (`fromTier`, `toTier`, `reputation`), and a notification is queued (`"{name} was promoted to {tier} crew."`).

Progression is **strictly monotonic** — implemented by tracking the *highest* tier ever reached, not the tier implied by current reputation. A single flop that lowers reputation therefore does not strip a crew's earned rank, which matches "career progression" semantics (an accumulating milestone) rather than a volatile live score. Only owned crew are progressed, since they're the ones actually taking on projects and earning reputation; market crew retain the schema default (`"Rookie"`) until hired. No existing crew stat is read for any purpose other than the tier lookup, and nothing about `reputation`, `morale`, or any other field is modified — this is a pure additive read → tier-assignment layer.

### Integration — `services/simulation/engines/tickEngine.js`

The existing award-week block already loaded `TalentHistory` and attached `careerHistory`/`awardsHistory` onto directors via a generic `attachHistory` helper before calling `processDirectorAwards`. I:
- Split the single `alreadyProcessed` guard into `directorAlreadyProcessed` and `actorAlreadyProcessed`, and broadened the block's trigger condition to run when **either** is unprocessed for the year — so actor awards aren't silently skipped just because directors already processed (or vice versa) in an edge case.
- Extended the (already-generic) `attachHistory` calls to also cover `marketActors` / `ownedActors` / `retiredActors`, using the exact same history-loading pattern already used for directors — no new query, no schema change, just wiring the existing generic helper onto three more arrays.
- Added `processActorAwards(gameState, studio)` immediately after `processDirectorAwards`, and `processCrewProgression(gameState)` alongside it. Both are self-guarded internally (award-week + year-processed checks for awards; monotonic idempotent tier comparison for progression), so calling them every tick is safe and correct.

### Schema — `models/GameState.js`

Added `careerTier: { type: String, default: "Rookie" }` to both the `marketCrewTeams` and `ownedCrewTeams` inline subdocument definitions — this is where the crew arrays are actually defined for `GameState` (not in the separate `CrewTeam.js` file, which is unused by `GameState`), so this is the correct place for Mongoose to persist the new field. Purely additive; no existing field touched.

### What I deliberately did NOT do

- Did **not** modify `careerImpactEngine.js` — it already correctly handles crew reputation growth and actor popularity/fanbase on release, and is covered by an existing test.
- Did **not** modify `directorAwardsService.js` — used purely as a read-only structural reference.
- Did **not** re-implement crew reputation growth (already works) or add a parallel actor-progression mechanism (popularity already serves that role for actors via `careerImpactEngine`).
- Did **not** add genre-specific acting awards, for the data-availability reason above.
- Did **not** touch any verdict, box-office, aging, or retirement logic.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots
_(attach: an in-game notification showing an actor winning an annual award at a year boundary, and/or a crew being promoted a career tier.)_

## Testing Performed

- **Static verification**: `node --check` passes on all four changed/added files; every relative import path in the two new services resolves correctly from their actual directory locations.
- **Schema verification**: installed `mongoose` and imported the compiled `GameState` schema directly — confirmed `careerTier` exists as a path under both the `marketCrewTeams` and `ownedCrewTeams` subdocument schemas, and instantiating a fresh `GameState({ ownedCrewTeams: [...], marketCrewTeams: [...] })` correctly yields `careerTier: "Rookie"` on both by default.
- **Runtime behavioral verification** (28 assertions against the real modules, no mocking of the services themselves — only a hand-built `gameState`/`studio` fixture):
  - Best Actor is awarded to the actor with the single highest-scoring performance of the year; Breakthrough Actor is awarded to the actor whose only career-history entry is this year's film; Lifetime Achievement is awarded to the qualifying veteran (age/movie-count/popularity threshold); Actor Of The Year is granted for a strong annual body of work.
  - Winning actors have `awards` incremented correctly, `popularity` raised and clamped to ≤100, `fanbase` increased, `salary` increased, and the studio's `fans` credited.
  - `AWARD`, `SALARY`, and `PROGRESSION` history entries and win/promotion notifications are queued as expected.
  - Guard correctness: re-processing the same award year yields zero new awards; a non-award week (`currentWeek % 52 !== 0`) yields zero awards; an actor with no annual releases is never a candidate; an actor already holding a given award for the current year is not re-awarded it.
  - Crew progression correctness: crews are promoted to the correct tier for their reputation; a crew whose reputation would imply a *lower* tier than their recorded one is **not** demoted (monotonic); re-running progression on an already-promoted roster performs zero further promotions (idempotent); a crew with no recorded `careerTier` defaults to the Rookie baseline before evaluation.
- **Regression proof (most important check)**: ran the full pure-logic test suite (`engines.test.js`, `eventEngine.test.js`, `boxOfficeEngine.test.js`, `trendEngine.test.js`, `newsEngine.test.js`, `marketplaceHelper.test.js`, `validationMiddleware.test.js`) on this branch **and** on a freshly cloned, zero-change `elusoc`. Both produce the identical result: **79 tests, 75 pass, 4 fail — the same four tests failing by name in both runs** (`Box Office Engine - balanced distribution over 1000 trials` [unseeded probabilistic], `careerImpactEngine: a HIT raises stats, salary, earnings and history` [pre-existing assertion mismatch], plus the `newsEngine.test.js` and `validationMiddleware.test.js` suite-level failures that already exist on clean `elusoc`). This change introduces **zero** new test failures.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] This PR is targetted to the `elusoc` branch