### PR TITLE
fix(auth): add accessible labels to AuthInput fields (Closes #144)

### DIFF
--- a/frontend/src/components/common/AuthInput.jsx
+++ b/frontend/src/components/common/AuthInput.jsx
@@ -1,11 +1,16 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import { Eye, EyeOff } from "lucide-react";
 
 const AuthInput = ({
+  label,
   placeholder,
   type = "text",
+  id,
   ...props
 }) => {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+
   const [showPassword, setShowPassword] =
     useState(false);
 
@@ -14,7 +19,14 @@ const AuthInput = ({
 
   return (
     <div className="relative">
+      {label && (
+        <label htmlFor={inputId} className="sr-only">
+          {label}
+        </label>
+      )}
+
       <input
+        id={inputId}
         type={
           isPassword
             ? showPassword

--- a/frontend/src/pages/auth/Login.jsx
+++ b/frontend/src/pages/auth/Login.jsx
@@ -39,12 +39,14 @@ const Login = () => {
       <AuthCard title="Welcome Back">
         <form onSubmit={handleSubmit} className="space-y-4">
           <AuthInput
+            label="Email"
             placeholder="Email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
           />
 
           <AuthInput
+            label="Password"
             type="password"
             placeholder="Password"
             value={password}

--- a/frontend/src/pages/auth/Register.jsx
+++ b/frontend/src/pages/auth/Register.jsx
@@ -40,6 +40,7 @@ const Register = () => {
       <AuthCard title="Create Studio">
         <form onSubmit={handleSubmit} className="space-y-4">
           <AuthInput
+            label="Username"
             placeholder="Username"
             onChange={(e) =>
               setForm({
@@ -50,6 +51,7 @@ const Register = () => {
           />
 
           <AuthInput
+            label="Email"
             placeholder="Email"
             onChange={(e) =>
               setForm({
@@ -60,6 +62,7 @@ const Register = () => {
           />
 
           <AuthInput
+            label="Password"
             type="password"
             placeholder="Password"
             onChange={(e) =>
@@ -71,6 +74,7 @@ const Register = () => {
           />
 
           <AuthInput
+            label="Studio Name"
             placeholder="Studio Name"
             onChange={(e) =>
               setForm({


### PR DESCRIPTION
## 📄 Description

### Problem

The shared `AuthInput` component (`frontend/src/components/common/AuthInput.jsx`) is the single building block used for every text and password field across the app's auth forms — confirmed via a full search of `frontend/src`, its only two call sites are `pages/auth/Login.jsx` and `pages/auth/Register.jsx`. The component accepts a `placeholder` prop but never rendered or accepted a `<label>`, and had no `id`/`label` prop in its API to support adding one at the call site either.

This means every input built from `AuthInput` — Email and Password on Login; Username, Email, Password, and Studio Name on Register — has no programmatically associated `<label>`. Screen reader users get no reliable accessible name for these fields; placeholder text is not a substitute for a label (it disappears on focus/input, isn't announced consistently across assistive tech, and fails WCAG 1.3.1 / 3.3.2). Because the gap lives in the shared component, it was systemic rather than a per-page oversight — fixing it once at the component level fixes it everywhere.

### Fix

- `AuthInput` now accepts two new optional props: `label` and `id`.
- If no `id` is passed, one is auto-generated internally via React's `useId()` hook, so every rendered input always has a stable, unique id without requiring the caller to invent one.
- When a `label` is supplied, the component renders a real `<label htmlFor={inputId}>` immediately before the `<input>`, and applies that same `inputId` to the input via `id={inputId}`.
- The label is styled with Tailwind's `sr-only` utility class — this makes it fully readable to screen readers and other assistive technology while remaining visually hidden, so the existing placeholder-only visual design of the auth forms is **completely unchanged**. No layout shift, no visual diff.
- `id` is explicitly destructured out of the props object before the `...props` spread onto the `<input>`, so there is no risk of a duplicate/conflicting `id` attribute being spread onto the element.
- Updated both call sites to pass a `label` matching each field's existing placeholder text, so the accessible name and the visible placeholder stay consistent for sighted and non-sighted users alike:
  - `Login.jsx` → `Email`, `Password`
  - `Register.jsx` → `Username`, `Email`, `Password`, `Studio Name`

### Why this approach

This is a one-time structural fix at the shared-component level, exactly as the issue's proposed fix outlines, rather than a per-page patch. Any future form built on top of `AuthInput` automatically gets correct label support for free, as long as it passes a `label` prop.

**Related Issue:** Closes #144

---

## 🚀 Open Source Program

- [ ] ECSOC 2026
- [x] ELUSOC 2026
- [ ] General Contribution

---

## 🛠 Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Performance Improvement
- [x] UI/UX Improvement
- [ ] Breaking Change

---

## 📸 Screenshots (If Applicable)

No visual changes — the label is visually hidden (`sr-only`) by design, to preserve the existing placeholder-only look of the Login and Register forms exactly as-is.

If a maintainer wants proof of the accessibility improvement itself (rather than a visual diff), I'm happy to attach a screen-reader focus-order recording on request showing each field now announcing its label (e.g. "Email, edit text" instead of an unlabeled field).

---

## 🧪 Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No console errors
- [x] Build passes successfully

Additional notes:

ran: npx eslint src/components/common/AuthInput.jsx src/pages/auth/Login.jsx src/pages/auth/Register.jsx
→ clean, zero errors/warnings
ran: npm run build
→ succeeded, no build errors (the "chunk larger than 500kB" note is Vite's
generic bundle-size advisory, pre-existing and unrelated to this change)
Manually verified in the browser that:

Login and Register forms render pixel-identical to before (sr-only label
is not visible)
Placeholders still show as before
Tab order and focus behavior on both forms is unchanged
Password show/hide toggle still functions normally
Form submission (typing into fields, onChange handlers) is unaffected —
only a label + id were added, no input logic was touched


Confirmed via code review that id is destructured out of props before the
{...props} spread, so there's no duplicate-id risk on the <input>.


---

## 🌿 Target Branch

- [ ] `ecsoc`
- [x] `elusoc`

---

## 🏷 Labels

### ELUSOC

- [x] `ELUSOC2026`

---

## ✅ Checklist

- [x] I have requested assignment before starting work.
- [x] My Pull Request targets the correct branch (`ecsoc` or `elusoc`).
- [x] I have linked the related issue.
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes locally.
- [x] My changes introduce no new warnings or errors.
- [ ] I have updated documentation where necessary.
- [x] I have added screenshots for UI changes (if applicable).