### PR TITLE
fix(auth): add accessible name to AuthInput password toggle (Closes #143)

### DIFF
--- a/frontend/src/components/common/AuthInput.jsx
+++ b/frontend/src/components/common/AuthInput.jsx
@@ -44,6 +44,11 @@ const AuthInput = ({
       {isPassword && (
         <button
           type="button"
+          aria-label={
+            showPassword
+              ? "Hide password"
+              : "Show password"
+          }
           onClick={() =>
             setShowPassword(
               !showPassword
@@ -59,9 +64,9 @@ const AuthInput = ({
           "
         >
           {showPassword ? (
-            <EyeOff size={20} />
+            <EyeOff size={20} aria-hidden="true" />
           ) : (
-            <Eye size={20} />
+            <Eye size={20} aria-hidden="true" />
           )}
         </button>
       )}


### PR DESCRIPTION
## 📄 Description

### Problem

The show/hide password toggle in the shared `AuthInput` component (`frontend/src/components/common/AuthInput.jsx`, the toggle button rendered when `type === "password"`) is an icon-only `<button>`. It correctly uses a real `<button>` element — so it is keyboard focusable and operable by default — but its only content is a lucide-react `Eye` / `EyeOff` icon with no text and no accessible name. Assistive technology announces it as a bare, unlabeled "button" with no indication of what it does or what state it's in. That is a WCAG 2.1 **4.1.2 (Name, Role, Value)** failure.

Because `AuthInput` is the single shared component behind every password field in the app (Login and Register today, and anything built on it later), this one gap propagates to every password input in the application.

### Fix

- Added a **state-aware** `aria-label` to the toggle button: `"Show password"` when the password is currently hidden, and `"Hide password"` when it is currently visible. The accessible name now tells the user exactly what activating the control will do, and it updates as the state flips.
- Marked the decorative `Eye` / `EyeOff` icons with `aria-hidden="true"`. Since the button's meaning is now fully conveyed by its `aria-label`, the icons are purely presentational and should not be separately exposed to assistive tech — this keeps the button's accessible name clean and unambiguous.

### Why this approach

The changing-`aria-label` pattern is exactly what the issue's proposed fix specifies, and it's a well-established accessible pattern for password reveal toggles: the control's name communicates the action it performs. Because the label is derived directly from the existing `showPassword` state, it stays correct automatically with no extra state or effects. This is a minimal, purely additive accessibility fix at the shared-component level — it changes no behavior, no markup structure, and no styling, so it resolves the gap for every auth form at once.

### Note on overlap with #144

This change and the label PR for #144 both live in `AuthInput.jsx` but touch entirely disjoint regions — #144 modifies the component signature and the input/label area near the top of the component, while this PR only modifies the password toggle `<button>` and its icons further down. They are independent and can be reviewed/merged in either order without conflict.

**Related Issue:** Closes #143

---

## 🚀 Open Source Program

- [ ] ECSOC 2026
- [x] ELUSOC 2026
- [ ] General Contribution

---

## 🛠 Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Performance Improvement
- [x] UI/UX Improvement
- [ ] Breaking Change

---

## 📸 Screenshots (If Applicable)

No visual change — this is an accessibility-only fix (`aria-label` on the button and `aria-hidden` on the icons). The toggle looks and behaves exactly as before.

Happy to attach a short screen-reader recording on request, demonstrating the toggle announcing "Show password" / "Hide password" and updating as it's activated.

---

## 🧪 Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No console errors
- [x] Build passes successfully

Additional notes:

ran: npx eslint src/components/common/AuthInput.jsx
→ clean, zero errors/warnings
ran: npm run build
→ succeeded, no build errors (the "chunk larger than 500kB" note is Vite's
generic bundle-size advisory, pre-existing and unrelated to this change)
Manually verified in the browser that:

The password field's show/hide toggle still works exactly as before
(clicking flips the input between password/text)
The icon still swaps between Eye and EyeOff
The button is unchanged visually and in layout
Keyboard focus/activation of the toggle is unaffected


Diff is limited to the toggle <button> and its icons: +7 / -2 in a single
file, no other regions touched.


---

## 🌿 Target Branch

- [ ] `ecsoc`
- [x] `elusoc`

---

## 🏷 Labels

### ELUSOC

- [x] `ELUSOC2026`

---

## ✅ Checklist

- [x] I have requested assignment before starting work.
- [x] My Pull Request targets the correct branch (`ecsoc` or `elusoc`).
- [x] I have linked the related issue.
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes locally.
- [x] My changes introduce no new warnings or errors.
- [ ] I have updated documentation where necessary.
- [x] I have added screenshots for UI changes (if applicable).