### PR TITLE
feat(notifications): wire notification bell and dropdown into layout (Closes #145)

### DIFF
--- a/frontend/src/components/notifications/NotificationBell.jsx
+++ b/frontend/src/components/notifications/NotificationBell.jsx
@@ -2,8 +2,17 @@ import { Bell } from "lucide-react";
 
 const NotificationBell = ({ unreadCount, onClick }) => {
   return (
-    <button onClick={onClick} className="relative">
-      <Bell size={22} className="text-slate-300" />
+    <button
+      type="button"
+      onClick={onClick}
+      className="relative cursor-pointer"
+      aria-label={
+        unreadCount > 0
+          ? `Notifications, ${unreadCount} unread`
+          : "Notifications"
+      }
+    >
+      <Bell size={22} className="text-slate-300" aria-hidden="true" />
 
       {unreadCount > 0 && (
         <span

--- a/frontend/src/components/notifications/NotificationDropdown.jsx
+++ b/frontend/src/components/notifications/NotificationDropdown.jsx
@@ -1,19 +1,36 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
 import api from "../../api/axios";
 
 const NotificationDropdown = () => {
   const [notifications, setNotifications] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/immutability
-    fetchNotifications();
+  const loadNotifications = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+
+    try {
+      const res = await api.get("/notifications");
+      const list = Array.isArray(res.data?.notifications)
+        ? res.data.notifications
+        : [];
+
+      setNotifications(list.slice(0, 6));
+    } catch (err) {
+      console.error(err);
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  const fetchNotifications = async () => {
-    const res = await api.get("/notifications");
-
-    setNotifications(res.data.notifications.slice(0, 6));
-  };
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    loadNotifications();
+  }, [loadNotifications]);
 
   return (
     <div
@@ -36,24 +53,41 @@ const NotificationDropdown = () => {
       </div>
 
       <div className="max-h-112.5 overflow-y-auto">
-        {notifications.map((n) => (
-          <div
-            key={n._id}
-            className="
-            p-4
-            border-b
-            border-slate-800
-            hover:bg-slate-800/50
-          "
-          >
-            <p className="text-sm text-white">{n.message}</p>
+        {loading ? (
+          <p className="p-4 text-sm text-slate-400">Loading...</p>
+        ) : error ? (
+          <p className="p-4 text-sm text-slate-400">
+            Couldn't load notifications. Please try again.
+          </p>
+        ) : notifications.length === 0 ? (
+          <p className="p-4 text-sm text-slate-400">You're all caught up.</p>
+        ) : (
+          notifications.map((n) => (
+            <div
+              key={n._id}
+              className="
+              p-4
+              border-b
+              border-slate-800
+              hover:bg-slate-800/50
+            "
+            >
+              <p className="text-sm text-white">{n.message}</p>
 
-            <p className="text-xs text-slate-500 mt-1">
-              {new Date(n.createdAt).toLocaleString()}
-            </p>
-          </div>
-        ))}
+              <p className="text-xs text-slate-500 mt-1">
+                {new Date(n.createdAt).toLocaleString()}
+              </p>
+            </div>
+          ))
+        )}
       </div>
+
+      <Link
+        to="/notifications"
+        className="block p-3 text-center text-sm text-violet-400 hover:text-violet-300 border-t border-slate-800"
+      >
+        View all notifications
+      </Link>
     </div>
   );
 };

--- a/frontend/src/layouts/DashboardLayout.jsx
+++ b/frontend/src/layouts/DashboardLayout.jsx
@@ -1,30 +1,110 @@
-import { useState } from "react";
-import Sidebar from "../components/common/Sidebar";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Menu } from "lucide-react";
+
+import api from "../api/axios";
+import Sidebar from "../components/common/Sidebar";
+import NotificationBell from "../components/notifications/NotificationBell";
+import NotificationDropdown from "../components/notifications/NotificationDropdown";
 
 const DashboardLayout = ({ children }) => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [isNotificationsOpen, setIsNotificationsOpen] = useState(false);
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  const notificationsRef = useRef(null);
+
+  const loadUnreadCount = useCallback(async () => {
+    try {
+      const res = await api.get("/notifications/unread-count");
+
+      setUnreadCount(res.data?.unreadCount || 0);
+    } catch (error) {
+      console.error(error);
+    }
+  }, []);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    loadUnreadCount();
+  }, [loadUnreadCount]);
+
+  useEffect(() => {
+    if (!isNotificationsOpen) {
+      return;
+    }
+
+    const handleClickOutside = (event) => {
+      if (
+        notificationsRef.current &&
+        !notificationsRef.current.contains(event.target)
+      ) {
+        setIsNotificationsOpen(false);
+      }
+    };
+
+    const handleEscape = (event) => {
+      if (event.key === "Escape") {
+        setIsNotificationsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscape);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [isNotificationsOpen]);
 
   return (
-    <div className="min-h-screen flex flex-col md:flex-row" style={{ backgroundColor: "var(--bg)" }}>
-      {/* Mobile Top Navigation */}
-      <header className="md:hidden flex items-center justify-between p-4 shrink-0" style={{ backgroundColor: "var(--surface)", borderBottom: "1px solid var(--border)" }}>
-        <h1 className="text-2xl font-bold" style={{ color: "var(--primary)" }}>CineVerse</h1>
-        <button
-          onClick={() => setIsSidebarOpen(true)}
-          className="p-2 cursor-pointer"
-          style={{ color: "var(--muted)" }}
-          aria-label="Open sidebar"
-        >
-          <Menu size={24} />
-        </button>
-      </header>
-
+    <div
+      className="min-h-screen flex flex-col md:flex-row"
+      style={{ backgroundColor: "var(--bg)" }}
+    >
       <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
 
-      <main className="flex-1 p-4 sm:p-6 md:p-8 overflow-y-auto w-full max-w-full overflow-x-hidden">
-        {children}
-      </main>
+      <div className="flex-1 flex flex-col min-w-0">
+        {/* Top navigation: notifications on every screen, sidebar toggle on mobile */}
+        <header
+          className="flex items-center justify-between gap-4 p-4 shrink-0"
+          style={{
+            backgroundColor: "var(--surface)",
+            borderBottom: "1px solid var(--border)",
+          }}
+        >
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => setIsSidebarOpen(true)}
+              className="p-2 cursor-pointer md:hidden"
+              style={{ color: "var(--muted)" }}
+              aria-label="Open sidebar"
+            >
+              <Menu size={24} />
+            </button>
+
+            <h1
+              className="text-2xl font-bold md:hidden"
+              style={{ color: "var(--primary)" }}
+            >
+              CineVerse
+            </h1>
+          </div>
+
+          <div className="relative" ref={notificationsRef}>
+            <NotificationBell
+              unreadCount={unreadCount}
+              onClick={() => setIsNotificationsOpen((open) => !open)}
+            />
+
+            {isNotificationsOpen && <NotificationDropdown />}
+          </div>
+        </header>
+
+        <main className="flex-1 p-4 sm:p-6 md:p-8 overflow-y-auto w-full max-w-full overflow-x-hidden">
+          {children}
+        </main>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 📄 Description

### Background

Per the issue and @SRV30's direction on it ("keep and complete this feature rather than remove it — wire the notification bell and dropdown into the existing layout, improve error handling, and ensure the feature integrates cleanly with the current notification system"), this completes the in-header notification feature rather than deleting the components.

Two fully-implemented components existed but were imported nowhere (confirmed via a full `frontend/src` search — zero importers outside their own files):
- `frontend/src/components/notifications/NotificationBell.jsx` — a bell icon with an unread-count badge, designed for a header/nav bar.
- `frontend/src/components/notifications/NotificationDropdown.jsx` — a panel that fetches `/notifications` and lists the most recent, designed to open from the bell.

As a result the app had no in-header quick-access notification affordance — notifications were only reachable via the full `/notifications` page. Additionally, `NotificationDropdown`'s fetch had no error handling and assumed `res.data.notifications` was always a present array, so any API error or unexpected response shape would throw inside an unguarded async function.

### What this PR does

**1. Wires the bell + dropdown into `DashboardLayout` (`frontend/src/layouts/DashboardLayout.jsx`)**

- `DashboardLayout` now renders a single top header that is visible on every screen size. On mobile it still contains the existing sidebar-toggle (hamburger) and the "CineVerse" title; the notification bell is right-aligned on all sizes. Previously the header was mobile-only (`md:hidden`), so desktop had no place for the bell — this gives the feature a consistent home everywhere. The header is styled with the app's existing CSS variables (`--surface`, `--border`, `--primary`, `--muted`), so it stays on-theme with no new design tokens.
- The layout is restructured to: `Sidebar` first, then a `flex-1` content column holding the header + `main`. This is layout-safe because `Sidebar` is `fixed`/off-canvas on mobile and `md:static` (in-flow left column) on desktop — so it renders identically to before in both cases.
- The unread count is tracked from the existing `GET /notifications/unread-count` endpoint (the same one the `/notifications` page already uses) and passed to the bell.
- Clicking the bell toggles the dropdown. The dropdown closes on outside click and on `Escape`; both listeners are attached only while open and are cleaned up on unmount / close.

**2. Hardens `NotificationDropdown` (`frontend/src/components/notifications/NotificationDropdown.jsx`)**

- The fetch is now wrapped in `try / catch / finally` with an `Array.isArray(res.data?.notifications)` guard before `.slice(0, 6)`, so an API error or unexpected shape can never throw an unhandled rejection.
- Added explicit **loading**, **error**, and **empty** states, so the panel always shows something sensible instead of a blank/broken list.
- Added a "View all notifications" link to the existing `/notifications` page, so the quick-view integrates cleanly with the full notification system rather than duplicating it.
- The data-loading pattern (`useCallback` loader + a `react-hooks/set-state-in-effect` disable on the effect call) matches the established, lint-passing pattern already used in `pages/notifications/Notifications.jsx`, for consistency.

**3. Makes `NotificationBell` accessible (`frontend/src/components/notifications/NotificationBell.jsx`)**

- The icon-only button gets a count-aware `aria-label` ("Notifications" / "Notifications, N unread"), an explicit `type="button"`, and `cursor-pointer` to match the existing header button styling. The decorative `Bell` icon is marked `aria-hidden="true"`.

### Integration notes

- No new files were added — the wiring lives entirely in existing files, so it applies cleanly and doesn't disturb the module graph.
- Reuses the existing `api` client (`src/api/axios.js`) and the existing notification endpoints; no backend changes.
- The full-page `/notifications` experience (`Notifications.jsx` + `NotificationCard.jsx`) is untouched and continues to work as the source of truth for read/delete actions; the dropdown is a lightweight quick-view that links into it.

**Related Issue:** Closes #145

---

## 🚀 Open Source Program

- [ ] ECSOC 2026
- [x] ELUSOC 2026
- [ ] General Contribution

---

## 🛠 Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Performance Improvement
- [x] UI/UX Improvement
- [ ] Breaking Change

---

## 🧪 Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No console errors
- [x] Build passes successfully

Additional notes:

ran: npx eslint on all 3 changed files → clean, zero errors/warnings
ran: npm install (elusoc added new deps, e.g. recharts, since prior install)
ran: npm run build → succeeded (2423 modules transformed)
(the "chunk larger than 500kB" note is Vite's generic bundle-size advisory,
pre-existing and unrelated to this change)
Manually verified:

Bell renders in the header on both mobile and desktop; badge shows the
unread count from /notifications/unread-count
Clicking the bell opens/closes the dropdown
Dropdown shows a loading state, then the 6 most recent notifications
Clicking outside the dropdown closes it; pressing Escape closes it
Simulated an API failure → dropdown shows the error state instead of
throwing; empty response → shows the "all caught up" empty state
"View all notifications" navigates to the existing /notifications page
Existing sidebar toggle + full /notifications page are unaffected
Layout renders identically to before on desktop (sidebar left, content
right) and mobile (drawer sidebar), with the header now hosting the bell




---

## 🌿 Target Branch

- [ ] `ecsoc`
- [x] `elusoc`

---

## 🏷 Labels

### ELUSOC

- [x] `ELUSOC2026`

---

## ✅ Checklist

- [x] I have requested assignment before starting work.
- [x] My Pull Request targets the correct branch (`ecsoc` or `elusoc`).
- [x] I have linked the related issue.
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes locally.
- [x] My changes introduce no new warnings or errors.
- [ ] I have updated documentation where necessary.