### PR TITLE
fix: read Studio/GameState inside the transaction session in simulateWeek

### DIFF
--- a/backend/src/controllers/simulationController.js
+++ b/backend/src/controllers/simulationController.js
@@ -11,17 +11,6 @@ export const simulateWeek = async (req, res) => {
     const { weeks = 1 } = req.body;
     const numWeeks = Math.min(52, Math.max(1, Number(weeks)));
 
-    const gameState = await GameState.findOne({ user: req.user._id });
-    const studio = await Studio.findOne({ owner: req.user._id });
-
-    if (!gameState || !studio) {
-      return res.status(404).json({ message: "Game state or studio not found" });
-    }
-
-    const startWeek = gameState.currentWeek;
-    const startFans = studio.fans || 0;
-    const startPrestige = studio.prestige || 0;
-
     // Accumulate notifications generated during the simulation ticks
     let newNotifications = [];
     let newHistories = [];
@@ -29,7 +18,32 @@ export const simulateWeek = async (req, res) => {
     // Accumulate rival releases across all simulated weeks
     const allRivalReleases = [];
 
+    let gameState;
+    let studio;
+    let startWeek;
+    let startFans;
+    let startPrestige;
+
     await withTransaction(async (session) => {
+      // Load the documents *inside* the transaction and bind them to the
+      // session so the version this transaction commits is the version it
+      // read. Loading them outside the session (as before) left a window
+      // where another request could save the same Studio/GameState doc
+      // in between, causing the transactional save at the end to fail
+      // with a Mongoose VersionError against a now-stale in-memory copy.
+      gameState = await GameState.findOne({ user: req.user._id }).session(session);
+      studio = await Studio.findOne({ owner: req.user._id }).session(session);
+
+      if (!gameState || !studio) {
+        const notFoundError = new Error("Game state or studio not found");
+        notFoundError.statusCode = 404;
+        throw notFoundError;
+      }
+
+      startWeek = gameState.currentWeek;
+      startFans = studio.fans || 0;
+      startPrestige = studio.prestige || 0;
+
       // Run simulation multiple times
       for (let i = 0; i < numWeeks; i++) {
         const prevMoney = studio.money || 0;
@@ -99,6 +113,9 @@ export const simulateWeek = async (req, res) => {
       summary
     });
   } catch (error) {
+    if (error.statusCode === 404) {
+      return res.status(404).json({ message: error.message });
+    }
     console.error("Simulation Transaction Error:", error);
     res.status(500).json({ success: false, message: `Operation rolled back due to: ${error.message}` });
   }


### PR DESCRIPTION
**ECSOC 2026 contribution.**

Closes #147.

## Bug
In `backend/src/controllers/simulationController.js`, `simulateWeek` loaded `GameState`/`Studio` via `findOne()` **before** opening the Mongo transaction, then mutated those same in-memory documents across the (potentially multi-week, several-`await`) simulation loop and only attached the transaction `session` when saving them at the very end. Any other request that saved the same `Studio`/`GameState` document while that window was open (e.g. hiring an actor, buying a script) would bump its `__v` out-of-band. When the transaction then tried `studio.save({ session })` / `gameState.save({ session })`, Mongoose's optimistic-concurrency check failed against the now-stale in-memory copy, throwing `VersionError` and rolling back the whole weekly simulation (500 on `POST /api/simulation/next-week`), exactly as described in #147.

## Fix
Move the `GameState.findOne` / `Studio.findOne` reads inside the `withTransaction` callback and bind them to the session via `.session(session)`, so the read and the eventual write are part of the same unit of work instead of a read-outside/write-inside split. The "not found" 404 response is preserved via a tagged error thrown inside the transaction and special-cased in the outer catch.

## Testing
- `node --check` on the modified file.
- Ran the existing backend suite (`npm test` in `backend/`) before and after the change: same 3 pre-existing failures (`boxOfficeEngine` distribution flake, `careerImpactEngine` history assertion, `gameplay.api` auth e2e) on both `main` and this branch — none are related to this change, and no new failures were introduced.

Minimal, single-file change — no unrelated refactoring.