### PR TITLE
fix: guard weekly tick against double-processing on server restart (#131)

### DIFF
--- a/backend/src/controllers/simulationController.js
+++ b/backend/src/controllers/simulationController.js
@@ -32,8 +32,15 @@ export const simulateWeek = async (req, res) => {
     await withTransaction(async (session) => {
       // Run simulation multiple times
       for (let i = 0; i < numWeeks; i++) {
+        const expectedWeek = startWeek + i;
+        if (gameState.currentWeek > expectedWeek) {
+          // This week was already processed (e.g. due to server restart), skip it
+          continue;
+        }
+
         const prevMoney = studio.money || 0;
         const weekRivalReleases = await runWeeklySimulation(gameState, studio);
+        gameState.lastSimulatedWeek = gameState.currentWeek;
         allRivalReleases.push(...(weekRivalReleases || []));
 
         // Financial History Logging

--- a/backend/src/models/GameState.js
+++ b/backend/src/models/GameState.js
@@ -14,6 +14,11 @@ const gameStateSchema = new mongoose.Schema(
       default: 1,
     },
 
+    lastSimulatedWeek: {
+      type: Number,
+      default: 0,
+    },
+
     // Global Random Event Engine state. Tracks per-event cooldowns and a
     // rolling history of fired events. Mixed because event-id keys are
     // dynamic; the engine reads/writes it as a plain object. Optional with a


### PR DESCRIPTION
## Description

The `simulateWeek` controller runs the weekly tick N times in a loop. If the server restarted mid-tick (e.g. during a multi-week simulation), the same week could be processed twice, resulting in duplicate payroll deductions and duplicate box office revenue.

This PR adds an idempotency guard: before processing each iteration, the controller compares `gameState.currentWeek` against the expected week. If `currentWeek` already exceeds the expected week, that iteration is skipped. A `lastSimulatedWeek` field is added to `GameState` to persistently track the last successfully processed week.

**Files changed:**
- `backend/src/models/GameState.js` -- added `lastSimulatedWeek` field
- `backend/src/controllers/simulationController.js` -- added idempotency guard inside the tick loop

**Related Issue:** Closes #131

---

## Open Source Program

- [ ] ECSOC 2026
- [x] ELUSOC 2026
- [ ] General Contribution

---

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] UI/UX Improvement
- [ ] Breaking Change

---

## Screenshots (If Applicable)

N/A -- backend-only fix.

---

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No console errors
- [x] Build passes successfully

Additional notes:

```
Triggered POST /api/simulation/simulate with { weeks: 3 }.
Verified each week increments currentWeek exactly once and lastSimulatedWeek is persisted in MongoDB.
Simulated a restart scenario by manually setting currentWeek ahead of the loop expectation -- confirmed the duplicate week is safely skipped.
```

---

## Target Branch

- [ ] `ecsoc`
- [x] `elusoc`

> **Important:** Pull Requests opened against the `main` branch are automatically closed by repository automation. Please ensure your PR targets either the `ecsoc` or `elusoc` branch.

---

## Labels

### ELUSOC

- [x] `ELUSOC2026`

---

## Checklist

- [x] I have requested assignment before starting work.
- [x] My Pull Request targets the correct branch (`elusoc`).
- [x] I have linked the related issue.
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes locally.
- [x] My changes introduce no new warnings or errors.
- [x] I have updated documentation where necessary.
- [ ] I have added screenshots for UI changes (if applicable).
- [ ] If this is an ECSOC contribution, I have requested the `ECSoC26` label before merge.