### PR TITLE
fix: validate marketing campaign IDs against known campaigns on backend (#132)

### DIFF
--- a/backend/src/validators/movieValidator.js
+++ b/backend/src/validators/movieValidator.js
@@ -1,6 +1,19 @@
 
 import { z } from "zod";
 
+// Valid campaign IDs must mirror the MARKETING_CAMPAIGNS array in the frontend (CreateMovie.jsx)
+const VALID_CAMPAIGN_IDS = [
+  "trailer",
+  "teaser",
+  "pr",
+  "tv",
+  "newspaper",
+  "digital",
+  "social",
+  "influencer",
+  "billboards",
+];
+
 export const createMovieSchema = {
   body: z.object({
     title: z.string()
@@ -12,7 +25,16 @@ export const createMovieSchema = {
     leadActorId: z.string().min(1, "Lead Actor ID is required"),
     supportingActorIds: z.array(z.string()).optional(),
     crewTeamId: z.string().min(1, "Crew Team ID is required"),
-    marketingCampaignIds: z.array(z.string()).optional(),
+    marketingCampaignIds: z
+      .array(z.string())
+      .optional()
+      .refine(
+        (ids) =>
+          !ids || ids.every((id) => VALID_CAMPAIGN_IDS.includes(id)),
+        {
+          message: `Each marketing campaign ID must be one of: ${VALID_CAMPAIGN_IDS.join(", ")}`,
+        }
+      ),
     franchiseId: z.string().optional(),
     createFranchise: z.boolean().optional(),
     franchiseName: z.string()


### PR DESCRIPTION
## Description

The `createMovieSchema` Zod validator accepted any arbitrary string array for `marketingCampaignIds`, allowing a direct API call to pass unknown campaign IDs and bypass the intended campaign cost system.

This PR adds a `VALID_CAMPAIGN_IDS` allowlist constant that mirrors the nine campaign IDs defined in the frontend `MARKETING_CAMPAIGNS` array. The `marketingCampaignIds` field now uses `.refine()` to reject any ID not in the allowlist, returning a descriptive 400 error.

**Files changed:**
- `backend/src/validators/movieValidator.js` -- added `VALID_CAMPAIGN_IDS` constant and `.refine()` validation

**Related Issue:** Closes #132

---

## Open Source Program

- [ ] ECSOC 2026
- [x] ELUSOC 2026
- [ ] General Contribution

---

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] UI/UX Improvement
- [ ] Breaking Change

---

## Screenshots (If Applicable)

N/A -- backend validation logic.

---

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No console errors
- [x] Build passes successfully

Additional notes:

```
Sent POST /api/movies with a valid payload -- movie creation succeeds normally.
Sent POST /api/movies with marketingCampaignIds: ["invalid-id"] -- API returns 400 Bad Request with a descriptive validation error message.
Confirmed that omitting marketingCampaignIds entirely still works (field is optional).
```

---

## Target Branch

- [ ] `ecsoc`
- [x] `elusoc`

> **Important:** Pull Requests opened against the `main` branch are automatically closed by repository automation. Please ensure your PR targets either the `ecsoc` or `elusoc` branch.

---

## Labels

### ELUSOC

- [x] `ELUSOC2026`

---

## Checklist

- [x] I have requested assignment before starting work.
- [x] My Pull Request targets the correct branch (`elusoc`).
- [x] I have linked the related issue.
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes locally.
- [x] My changes introduce no new warnings or errors.
- [x] I have updated documentation where necessary.
- [ ] I have added screenshots for UI changes (if applicable).
- [ ] If this is an ECSOC contribution, I have requested the `ECSoC26` label before merge.