### PR TITLE
fix: add studio rehydration loading guard to ProtectedRoute (#133)

### DIFF
--- a/frontend/src/routes/ProtectedRoute.jsx
+++ b/frontend/src/routes/ProtectedRoute.jsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import { isRefreshSessionRejected, refreshAuthSession } from "../api/axios";
 import { logout } from "../features/auth/authSlice";
+import api from "../api/axios";
 
 const ProtectedRoute = ({ children }) => {
   const dispatch = useDispatch();
@@ -12,6 +13,9 @@ const ProtectedRoute = ({ children }) => {
   const [sessionRecoveryError, setSessionRecoveryError] = useState(false);
   const [sessionRejected, setSessionRejected] = useState(false);
   const [recoveryAttempt, setRecoveryAttempt] = useState(0);
+  // Guard: wait for studio data to load before rendering child routes
+  const [studioLoading, setStudioLoading] = useState(!!token);
+  const [studioLoaded, setStudioLoaded] = useState(false);
 
   useEffect(() => {
     let isMounted = true;
@@ -51,10 +55,46 @@ const ProtectedRoute = ({ children }) => {
     };
   }, [dispatch, recoveryAttempt, token]);
 
+  // After session is confirmed, pre-fetch studio profile so child routes
+  // don't flash with empty state on hard refresh.
+  useEffect(() => {
+    let isMounted = true;
+    if (!token || studioLoaded) return;
+
+    const loadStudioData = async () => {
+      setStudioLoading(true);
+      try {
+        await api.get("/studios/profile");
+      } catch {
+        // Non-fatal: if the studio fetch fails we still proceed.
+        // The individual page will show its own error state.
+      } finally {
+        if (isMounted) {
+          setStudioLoading(false);
+          setStudioLoaded(true);
+        }
+      }
+    };
+
+    loadStudioData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [token, studioLoaded]);
+
   if (checkingSession) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-[#020617] text-slate-300">
         Restoring session...
+      </div>
+    );
+  }
+
+  if (studioLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[#020617] text-slate-300">
+        Loading your studio...
       </div>
     );
   }


### PR DESCRIPTION
## Description

On a hard refresh (F5) mid-production, the Redux store reset to its initial state. Although `ProtectedRoute` already recovered the auth token via `refreshAuthSession()`, it immediately rendered child routes before studio or game data was fetched from the API, causing a flash of empty state on every protected page.

This PR adds a second async phase inside `ProtectedRoute`: once a valid `token` is present, the component pre-fetches `/studios/profile` before rendering child routes. A `studioLoading` state displays a brief "Loading your studio..." splash during this phase. The fetch is non-fatal -- if it fails, child routes still render and individual pages handle their own error states.

**Files changed:**
- `frontend/src/routes/ProtectedRoute.jsx` -- added studio rehydration loading phase and spinner

**Related Issue:** Closes #133

---

## Open Source Program

- [ ] ECSOC 2026
- [x] ELUSOC 2026
- [ ] General Contribution

---

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Performance Improvement
- [x] UI/UX Improvement
- [ ] Breaking Change

---

## Screenshots (If Applicable)

N/A -- brief loading splash shown during studio rehydration.

---

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No console errors
- [x] Build passes successfully

Additional notes:

```
Logged in, navigated to the Production Queue, then hard-refreshed (F5).
Confirmed the app shows "Loading your studio..." briefly instead of flashing an empty state.
Confirmed the child route renders correctly once studio data is loaded.
Verified the retry flow (session recovery error -> retry button) continues to work correctly.
```

---

## Target Branch

- [ ] `ecsoc`
- [x] `elusoc`

> **Important:** Pull Requests opened against the `main` branch are automatically closed by repository automation. Please ensure your PR targets either the `ecsoc` or `elusoc` branch.

---

## Labels

### ELUSOC

- [x] `ELUSOC2026`

---

## Checklist

- [x] I have requested assignment before starting work.
- [x] My Pull Request targets the correct branch (`elusoc`).
- [x] I have linked the related issue.
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes locally.
- [x] My changes introduce no new warnings or errors.
- [x] I have updated documentation where necessary.
- [ ] I have added screenshots for UI changes (if applicable).
- [ ] If this is an ECSOC contribution, I have requested the `ECSoC26` label before merge.