### PR TITLE
fix: persist script marketplace rarity filter in URL params (#134)

### DIFF
--- a/frontend/src/pages/scripts/Scripts.jsx
+++ b/frontend/src/pages/scripts/Scripts.jsx
@@ -1,16 +1,28 @@
 import { useCallback, useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 
 import api from "../../api/axios";
 import DashboardLayout from "../../layouts/DashboardLayout";
 import SkeletonGrid from "../../components/common/SkeletonGrid";
+
+const RARITY_OPTIONS = ["All", "Common", "Uncommon", "Rare", "Epic", "Legendary"];
 
 const Scripts = () => {
   const [scripts, setScripts] = useState([]);
   const [ownedScripts, setOwnedScripts] = useState([]);
   const [loading, setLoading] = useState(false);
   const [initialLoading, setInitialLoading] = useState(true);
-  const [activeTab, setActiveTab] = useState("market");
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Derive tab and rarity from URL so back-navigation restores them
+  const activeTab = searchParams.get("tab") || "market";
+  const rarityFilter = searchParams.get("rarity") || "All";
+
+  const setActiveTab = (tab) =>
+    setSearchParams((prev) => { prev.set("tab", tab); return prev; });
+
+  const setRarityFilter = (rarity) =>
+    setSearchParams((prev) => { prev.set("rarity", rarity); return prev; });
 
   const renderWriterName = (script) => {
     const writerName = script.writer || "Unknown Writer";
@@ -110,6 +122,12 @@ const Scripts = () => {
       );
     }
 
+    // Apply rarity filter — persisted in URL so back-navigation restores it
+    const filteredScripts =
+      rarityFilter === "All"
+        ? scripts
+        : scripts.filter((s) => s.rarity === rarityFilter);
+
     const rarityStyles = {
       Common: "bg-slate-500/20 text-slate-300 border border-slate-500/30",
 
@@ -132,8 +150,32 @@ const Scripts = () => {
     };
 
     return (
-      <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-5">
-        {scripts.map((script, index) => (
+      <>
+        {/* Rarity Filter Bar */}
+        <div className="flex flex-wrap gap-2 mb-5">
+          {RARITY_OPTIONS.map((r) => (
+            <button
+              key={r}
+              id={`rarity-filter-${r.toLowerCase()}`}
+              onClick={() => setRarityFilter(r)}
+              className={`px-4 py-2 rounded-xl text-sm font-semibold transition ${
+                rarityFilter === r
+                  ? "bg-violet-600 text-white"
+                  : "bg-slate-800 text-slate-300 hover:bg-slate-700"
+              }`}
+            >
+              {r}
+            </button>
+          ))}
+        </div>
+
+        {filteredScripts.length === 0 ? (
+          <div className="bg-[#111827] border border-slate-800 rounded-2xl p-8 text-center">
+            <p className="text-slate-400">No {rarityFilter} scripts in the market right now.</p>
+          </div>
+        ) : (
+        <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-5">
+          {filteredScripts.map((script, index) => (
           <div
             key={`${script.title}-${index}`}
             className={`group relative overflow-hidden
@@ -211,8 +253,10 @@ const Scripts = () => {
               </button>
             </div>
           </div>
-        ))}
-      </div>
+          ))}
+        </div>
+        )}
+      </>
     );
   };
 


### PR DESCRIPTION
## Description

The Script Marketplace page had no rarity filter UI. The active tab (`market`/`owned`) was stored in `useState`, so navigating away and pressing the browser back button reset both the tab and any applied filters.

This PR replaces `useState` for `activeTab` with `useSearchParams` from `react-router-dom`, so both the active tab and the rarity filter live in the URL (e.g. `?tab=market&rarity=Rare`). A Rarity Filter Bar is added above the script grid with options for All, Common, Uncommon, Rare, Epic, and Legendary. Scripts are filtered client-side before rendering, and an empty-state message is shown when the active filter returns no results.

**Files changed:**
- `frontend/src/pages/scripts/Scripts.jsx` -- replaced useState with useSearchParams, added RARITY_OPTIONS constant, rarity filter bar, and client-side filtering

**Related Issue:** Closes #134

---

## Open Source Program

- [ ] ECSOC 2026
- [x] ELUSOC 2026
- [ ] General Contribution

---

## Type of Change

- [x] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Performance Improvement
- [x] UI/UX Improvement
- [ ] Breaking Change

---

## Screenshots (If Applicable)

Rarity Filter Bar above the script grid showing All / Common / Uncommon / Rare / Epic / Legendary buttons. The active filter is highlighted in violet.

---

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No console errors
- [x] Build passes successfully

Additional notes:

```
Selected the "Rare" rarity filter on the Script Marketplace.
Navigated to Movie Library, then pressed the browser back button.
Confirmed the "Rare" filter is still active (URL retains ?tab=market&rarity=Rare).
Confirmed switching tabs also persists correctly in the URL.
Confirmed the "All" filter shows all available scripts.
Confirmed the empty-state message appears when a filter produces zero results.
```

---

## Target Branch

- [ ] `ecsoc`
- [x] `elusoc`

> **Important:** Pull Requests opened against the `main` branch are automatically closed by repository automation. Please ensure your PR targets either the `ecsoc` or `elusoc` branch.

---

## Labels

### ELUSOC

- [x] `ELUSOC2026`

---

## Checklist

- [x] I have requested assignment before starting work.
- [x] My Pull Request targets the correct branch (`elusoc`).
- [x] I have linked the related issue.
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes locally.
- [x] My changes introduce no new warnings or errors.
- [x] I have updated documentation where necessary.
- [x] I have added screenshots for UI changes (if applicable).
- [ ] If this is an ECSOC contribution, I have requested the `ECSoC26` label before merge.