### PR TITLE
docs: fix placeholder repo URL in CONTRIBUTING.md clone command (#138)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,8 +70,8 @@ Contributions made without assignment may not be accepted.
 ## 3. Fork & Clone the Repository
 
 ```bash
-git clone https://github.com/<owner>/<repository>.git
-cd <repository>
+git clone https://github.com/SRV30/Box_Office_Inc-Movie_Sim.git
+cd Box_Office_Inc-Movie_Sim
 ```
 
 ---


### PR DESCRIPTION
## Description

The "Fork & Clone the Repository" section of `CONTRIBUTING.md` contained a placeholder clone URL (`https://github.com/<owner>/<repository>.git`) which would cause new contributors following the guide literally to receive a 404 or clone the wrong repository.

This PR replaces the placeholder with the actual repository URL.

Before:
```
git clone https://github.com/<owner>/<repository>.git
cd <repository>
```

After:
```
git clone https://github.com/SRV30/Box_Office_Inc-Movie_Sim.git
cd Box_Office_Inc-Movie_Sim
```

**Files changed:**
- `CONTRIBUTING.md` -- replaced placeholder clone URL with the actual repository URL

**Related Issue:** Closes #138

---

## Open Source Program

- [ ] ECSOC 2026
- [x] ELUSOC 2026
- [ ] General Contribution

---

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [x] Documentation
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] UI/UX Improvement
- [ ] Breaking Change

---

## Screenshots (If Applicable)

N/A

---

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No console errors
- [x] Build passes successfully

Additional notes:

```
Verified the corrected clone URL points to the live repository at https://github.com/SRV30/Box_Office_Inc-Movie_Sim.
No code changes -- documentation fix only.
```

---

## Target Branch

- [ ] `ecsoc`
- [x] `elusoc`

> **Important:** Pull Requests opened against the `main` branch are automatically closed by repository automation. Please ensure your PR targets either the `ecsoc` or `elusoc` branch.

---

## Labels

### ELUSOC

- [x] `ELUSOC2026`

---

## Checklist

- [x] I have requested assignment before starting work.
- [x] My Pull Request targets the correct branch (`elusoc`).
- [x] I have linked the related issue.
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes locally.
- [x] My changes introduce no new warnings or errors.
- [x] I have updated documentation where necessary.
- [ ] I have added screenshots for UI changes (if applicable).
- [ ] If this is an ECSOC contribution, I have requested the `ECSoC26` label before merge.