### PR TITLE
fix(simulation): weekly payroll deducts only what was actually paid, not the full bill (Closes #153)

### DIFF
--- a/backend/src/services/simulation/engines/payrollEngine.js
+++ b/backend/src/services/simulation/engines/payrollEngine.js
@@ -28,7 +28,8 @@ import { addNotification } from "../helpers/notificationHelper.js";
  * 3. If `studio.money < totalPayroll`, push a notification warning.
  * 4. Compute `payrollCoverage = min(1, availableMoney / totalPayroll)`.
  * 5. Each talent's `totalEarnings` is incremented by their pro-rated salary.
- * 6. Deduct `totalPayroll` from studio money (floored at 0).
+ * 6. Deduct the amount actually paid out (sum of pro-rated salaries) from
+ *    studio money (floored at 0).
  *
  * No-ops when there is no talent or total payroll is zero.
  *
@@ -73,12 +74,15 @@ export const processWriterPayroll = (gameState, studio) => {
 
   const payrollCoverage = Math.min(1, availableMoney / totalPayroll);
 
+  let totalActuallyPaid = 0;
+
   allTalent.forEach((talent) => {
     const paidSalary = Math.floor(Number(talent.salary || 0) * payrollCoverage);
+    totalActuallyPaid += paidSalary;
     if (talent.totalEarnings !== undefined) {
         talent.totalEarnings = Number(talent.totalEarnings || 0) + paidSalary;
     }
   });
 
-  studio.money = Math.max(0, availableMoney - totalPayroll);
+  studio.money = Math.max(0, availableMoney - totalActuallyPaid);
 };

--- a/backend/tests/engines.test.js
+++ b/backend/tests/engines.test.js
@@ -207,6 +207,30 @@ test("payrollEngine: underfunded studio pays partial, floors money at 0, warns",
   );
 });
 
+test("payrollEngine: partial payment deducts only what was actually paid, not the full payroll", () => {
+  const gameState = {
+    ownedWriters: [],
+    ownedDirectors: [],
+    ownedActors: [
+      { salary: 50, totalEarnings: 0 },
+      { salary: 50, totalEarnings: 0 },
+      { salary: 50, totalEarnings: 0 },
+    ],
+    ownedCrewTeams: [],
+  };
+  const studio = { money: 100 }; // payroll = 150, coverage = 100 / 150
+
+  processWriterPayroll(gameState, studio);
+
+  // Each talent is paid floor(50 * 0.6667) = 33, so 99 is actually paid out.
+  // The studio should lose only that 99 and keep the 1 it never spent,
+  // instead of being deducted the full 150 and wiped to 0.
+  assert.strictEqual(gameState.ownedActors[0].totalEarnings, 33);
+  assert.strictEqual(gameState.ownedActors[1].totalEarnings, 33);
+  assert.strictEqual(gameState.ownedActors[2].totalEarnings, 33);
+  assert.strictEqual(studio.money, 1);
+});
+
 test("payrollEngine: no talent is a no-op", () => {
   const gameState = {
     ownedWriters: [],


### PR DESCRIPTION
## 📄 Description

### Problem

`processWriterPayroll` in `backend/src/services/simulation/engines/payrollEngine.js` runs once per simulation tick to deduct weekly talent salaries from a studio's cash. When a studio can't fully afford payroll, it computes a `payrollCoverage` ratio and pays each talent member a **floored, pro-rated** salary — and credits each talent's `totalEarnings` with only that pro-rated amount. That part is correct and matches the function's documented intent.

But the studio's cash was then deducted by the **full, un-prorated `totalPayroll`** (floored at 0), not the amount actually paid out:

```js
studio.money = Math.max(0, availableMoney - totalPayroll); // ← full bill, not what was paid
```

Because per-talent payments are individually floored, the sum actually paid is typically **less** than `totalPayroll` under a shortfall. And whenever `availableMoney < totalPayroll`, `max(0, availableMoney - totalPayroll)` is always `0` — so a studio that's even slightly short is **wiped to ₹0 in a single tick**, regardless of how large the shortfall is, and the amount removed from the studio never matches what talent received. This directly contradicts the function's own docstring ("the ledger stays accurate even during financial hardship"), which is a strong signal the behavior is unintended.

Worked example (3 talent × ₹50 salary = ₹150 payroll, studio has ₹100):
- `payrollCoverage = 100/150 ≈ 0.667`
- each paid `floor(50 × 0.667) = 33` → **₹99 actually paid to talent**
- old code deducts the full ₹150 → `max(0, 100 − 150) = 0` → studio loses all ₹100
- **mismatch: studio lost ₹100, talent received ₹99**

### Fix

Accumulate the amount actually paid out (already computed per-talent in the existing loop) and deduct **that** from the studio, instead of the stale `totalPayroll`:

```js
let totalActuallyPaid = 0;
allTalent.forEach((talent) => {
  const paidSalary = Math.floor(Number(talent.salary || 0) * payrollCoverage);
  totalActuallyPaid += paidSalary;
  // ...credit talent.totalEarnings (unchanged)...
});
studio.money = Math.max(0, availableMoney - totalActuallyPaid);
```

Now the studio loses exactly what talent received (₹99 in the example, leaving ₹1 it never spent). The talent-side pro-rating logic and `totalEarnings` are **completely unchanged** — only the studio-side deduction is corrected. The JSDoc step describing the deduction was updated to match.

### Tests

- All existing payroll tests still pass (full-coverage, single-talent underfunded, no-talent no-op).
- Added a test: 3 talent × ₹50 with a ₹100 studio — asserts each talent's `totalEarnings` is `33` and `studio.money` is `1` (not `0`). This test **fails on the old code** (`expected 1, actual 0`) and passes on the fix, so it locks in the corrected behavior.

**Related Issue:** Closes #153

---

## 🚀 Open Source Program

- [ ] ECSOC 2026
- [x] ELUSOC 2026
- [ ] General Contribution

---

## 🛠 Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] UI/UX Improvement
- [ ] Breaking Change

---

## 📸 Screenshots (If Applicable)

N/A — backend simulation logic, no UI.

---

## 🧪 Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No console errors
- [x] Build passes successfully

Additional notes:

ran: node --test "tests/engines.test.js"  →  # pass 16, # fail 0
(15 existing engine tests + 1 new partial-payment test)
Verified the new test fails on the pre-fix code (expected 1, actual 0),
confirming it captures the exact ledger bug.
Note on CI: the "Backend test suite" job is currently red on the base branch
due to a pre-existing, unrelated issue (mongodb-memory-server can't download
the mongod binary for ubuntu2404). That affects the DB-backed API tests, not
this change — the engine unit tests this PR touches run without a DB and pass.


---

## 🌿 Target Branch

- [ ] `ecsoc`
- [x] `elusoc`

---

## 🏷 Labels

### ELUSOC

- [x] `ELUSOC2026`

---

## ✅ Checklist

- [x] I have requested assignment before starting work.
- [x] My Pull Request targets the correct branch (`ecsoc` or `elusoc`).
- [x] I have linked the related issue.
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes locally.
- [x] My changes introduce no new warnings or errors.
- [ ] I have updated documentation where necessary.
- [x] I have added screenshots for UI changes (if applicable).

closes #153 