### PR TITLE
fix(marketplace): sort by string fields (name, rarity) instead of silently no-oping (Closes #152)

### DIFF
--- a/backend/src/utils/marketplaceHelper.js
+++ b/backend/src/utils/marketplaceHelper.js
@@ -107,9 +107,21 @@ export const getMarketplaceTalent = (items, query = {}) => {
   const sortBy = query.sortBy || "popularity";
   const sortOrder = query.sortOrder === "asc" ? 1 : -1;
   filtered.sort((a, b) => {
-    const aVal = Number(a[sortBy] || 0);
-    const bVal = Number(b[sortBy] || 0);
-    return (aVal - bVal) * sortOrder;
+    const aRaw = a[sortBy];
+    const bRaw = b[sortBy];
+
+    // Numeric fields (popularity, salary, age) compare numerically; string
+    // fields (name, rarity) fall back to a locale-aware string compare so they
+    // sort correctly instead of coercing to NaN and silently no-oping.
+    if (typeof aRaw === "number" || typeof bRaw === "number") {
+      const aVal = Number(aRaw) || 0;
+      const bVal = Number(bRaw) || 0;
+      return (aVal - bVal) * sortOrder;
+    }
+
+    const aStr = String(aRaw ?? "");
+    const bStr = String(bRaw ?? "");
+    return aStr.localeCompare(bStr) * sortOrder;
   });
 
   // --- Paginate ---

--- a/backend/tests/marketplaceHelper.test.js
+++ b/backend/tests/marketplaceHelper.test.js
@@ -71,6 +71,34 @@ test('getMarketplaceTalent sorts ascending', () => {
   }
 });
 
+test('getMarketplaceTalent sorts by a string field (name) ascending and descending', () => {
+  const items = [
+    { name: 'Zara', popularity: 10 },
+    { name: 'Alice', popularity: 90 },
+    { name: 'Mike', popularity: 50 },
+  ];
+
+  const asc = getMarketplaceTalent(items, { sortBy: 'name', sortOrder: 'asc', limit: '200' });
+  assert.deepStrictEqual(asc.items.map((t) => t.name), ['Alice', 'Mike', 'Zara']);
+
+  const desc = getMarketplaceTalent(items, { sortBy: 'name', sortOrder: 'desc', limit: '200' });
+  assert.deepStrictEqual(desc.items.map((t) => t.name), ['Zara', 'Mike', 'Alice']);
+});
+
+test('getMarketplaceTalent still sorts numeric fields after the type-aware fix', () => {
+  const items = [
+    { name: 'A', popularity: 10 },
+    { name: 'B', popularity: 90 },
+    { name: 'C', popularity: 50 },
+  ];
+
+  const asc = getMarketplaceTalent(items, { sortBy: 'popularity', sortOrder: 'asc', limit: '200' });
+  assert.deepStrictEqual(asc.items.map((t) => t.popularity), [10, 50, 90]);
+
+  const desc = getMarketplaceTalent(items, { sortBy: 'popularity', sortOrder: 'desc', limit: '200' });
+  assert.deepStrictEqual(desc.items.map((t) => t.popularity), [90, 50, 10]);
+});
+
 test('getMarketplaceTalent caps limit at 100', () => {
   const items = makeTalent(200);
   const result = getMarketplaceTalent(items, { limit: '999' });


### PR DESCRIPTION
## 📄 Description

### Problem

`getMarketplaceTalent` in `backend/src/utils/marketplaceHelper.js` powers the search/filter/sort/paginate endpoint shared by all four talent marketplaces (actors, directors, writers, crew teams — confirmed: `actorController.js`, `directorController.js`, `writerController.js`, `crewController.js` all call it). Its sort coerced both operands to `Number`:

```js
filtered.sort((a, b) => {
  const aVal = Number(a[sortBy] || 0);
  const bVal = Number(b[sortBy] || 0);
  return (aVal - bVal) * sortOrder;
});
```

This works for numeric fields (`popularity`, `salary`, `age`), which is why it went unnoticed. But the function's JSDoc documents `sortBy` as any field name, and for string fields (`name`, `rarity`) `Number("Alice")` is `NaN`. A comparator that returns `NaN` makes `Array.prototype.sort` treat every pair as already-ordered, so the list comes back in its **original order** — no error, no warning, a 200 response with a plausible-but-unsorted list. Sorting the marketplace by name (a very common, expected UI action) silently does nothing, across all four marketplaces.

### Fix

Use a type-aware comparator — numeric compare for numeric fields, locale-aware string compare otherwise:

```js
filtered.sort((a, b) => {
  const aRaw = a[sortBy];
  const bRaw = b[sortBy];
  if (typeof aRaw === "number" || typeof bRaw === "number") {
    const aVal = Number(aRaw) || 0;
    const bVal = Number(bRaw) || 0;
    return (aVal - bVal) * sortOrder;
  }
  const aStr = String(aRaw ?? "");
  const bStr = String(bRaw ?? "");
  return aStr.localeCompare(bStr) * sortOrder;
});
```

All existing numeric-sort behavior is preserved; string fields now sort correctly. No schema or API-contract change — this is a self-contained fix in one shared utility, so the fix lands in all four marketplaces at once.

### Tests

- All existing marketplace tests still pass (numeric `salary` ascending sort, pagination, filters, clamping, etc.).
- Added tests: `sortBy=name` ascending → `["Alice","Mike","Zara"]` and descending → `["Zara","Mike","Alice"]`; plus a numeric-`popularity` asc/desc test to guard against regression. The name-sort test **fails on the old code** (returns original order) and passes on the fix.

**Related Issue:** Closes #152

---

## 🚀 Open Source Program

- [ ] ECSOC 2026
- [x] ELUSOC 2026
- [ ] General Contribution

---

## 🛠 Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] UI/UX Improvement
- [ ] Breaking Change

---

## 📸 Screenshots (If Applicable)

N/A — backend utility logic, no UI.

---

## 🧪 Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No console errors
- [x] Build passes successfully

Additional notes:

ran: node --test "tests/marketplaceHelper.test.js"  →  # pass 16, # fail 0
(14 existing tests + 2 new string/numeric sort tests)
Verified the new name-sort test fails on the pre-fix code (list stays in
original order), confirming it captures the bug.
Note on CI: the "Backend test suite" job is red on the base branch due to a
pre-existing, unrelated issue (mongodb-memory-server can't download the
mongod binary for ubuntu2404) affecting DB-backed API tests. The utility
unit tests this PR touches run without a DB and pass.


---

## 🌿 Target Branch

- [ ] `ecsoc`
- [x] `elusoc`

---

## 🏷 Labels

### ELUSOC

- [x] `ELUSOC2026`

---

## ✅ Checklist

- [x] I have requested assignment before starting work.
- [x] My Pull Request targets the correct branch (`ecsoc` or `elusoc`).
- [x] I have linked the related issue.
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes locally.
- [x] My changes introduce no new warnings or errors.
- [ ] I have updated documentation where necessary.
- [x] I have added screenshots for UI changes (if applicable).