### PR TITLE
fix: resolve talent history validation crash (#177)

### DIFF
--- a/backend/src/models/TalentHistory.js
+++ b/backend/src/models/TalentHistory.js
@@ -12,7 +12,7 @@ const talentHistorySchema = new mongoose.Schema({
   },
   type: {
     type: String,
-    enum: ["CAREER", "SALARY", "AWARD"],
+    enum: ["CAREER", "SALARY", "AWARD", "PROGRESSION"],
     required: true,
   },
   data: {


### PR DESCRIPTION
## Description

Resolves a crash in the weekly simulation tick where `crewProgressionService` attempts to store a `TalentHistory` document with `type: "PROGRESSION"`, which was rejected by the Mongoose schema enum validator because `"PROGRESSION"` was not in the allowed values list. The fix adds `"PROGRESSION"` to the `type` field's enum array in `TalentHistory.js`.

**Related Issue:** Closes #177

---

## Open Source Program

- [ ] ECSOC 2026
- [x] ELUSOC 2026
- [ ] General Contribution

---

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] UI/UX Improvement
- [ ] Breaking Change

---

## Screenshots (If Applicable)

No UI changes.

---

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No console errors
- [x] Build passes successfully

Additional notes: All 37 existing backend tests pass, including `"should add progression history correctly"` in `engines.test.js`. Run `npm test` from the `backend/` directory.

---

## Target Branch

- [ ] `ecsoc`
- [x] `elusoc`

> **Important:** Pull Requests opened against the `main` branch are automatically closed by repository automation. Please ensure your PR targets either the `ecsoc` or `elusoc` branch.

---

## Labels

### ELUSOC

- [x] `ELUSOC2026`

---

## Checklist

- [x] I have requested assignment before starting work.
- [x] My Pull Request targets the correct branch (`ecsoc` or `elusoc`).
- [x] I have linked the related issue.
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes locally.
- [x] My changes introduce no new warnings or errors.
- [x] I have updated documentation where necessary.
- [ ] I have added screenshots for UI changes (if applicable).
- [ ] If this is an ECSOC contribution, I have requested the `ECSoC26` label before merge.