### PR TITLE
feat: introduce audience demographics and target marketing modifiers (#193)

### DIFF
--- a/backend/src/controllers/movieController.js
+++ b/backend/src/controllers/movieController.js
@@ -5,6 +5,7 @@ import Franchise from "../models/Franchise.js";
 import { generateReviews } from "../services/simulation/engines/reviewEngine.js";
 import { generateBoxOffice } from "../services/simulation/engines/boxOfficeEngine.js";
 import { getGenreMultiplier } from "../services/simulation/engines/trendEngine.js";
+import { getDemographicMultiplier } from "../services/simulation/engines/demographicsEngine.js";
 import { processCareerImpact } from "../services/simulation/engines/careerImpactEngine.js";
 import { processStudioGrowth } from "../services/simulation/engines/studioGrowthEngine.js";
 import { computeFranchiseProgress } from "../services/simulation/engines/franchiseEngine.js";
@@ -333,7 +334,8 @@ export const releaseMovie = async (req, res) => {
         // this movie's genres, its multiplier boosts or dampens the gross.
         const activeTrends = gameState.marketTrends?.activeTrends || [];
         const marketMultiplier = getGenreMultiplier(activeTrends, script?.genres);
-        const boxOffice = generateBoxOffice(movie, leadActor, director, marketMultiplier);
+        const demographicMultiplier = getDemographicMultiplier(script?.genres, movie.marketingCampaigns);
+        const boxOffice = generateBoxOffice(movie, leadActor, director, marketMultiplier, demographicMultiplier);
         Object.assign(movie, boxOffice);
 
         // Franchise reputation (read): load the franchise's accumulated shared

--- a/backend/src/services/simulation/engines/boxOfficeEngine.js
+++ b/backend/src/services/simulation/engines/boxOfficeEngine.js
@@ -86,7 +86,7 @@ const getVerdict = (roi) => {
  *   verdict: string
  * }} Full box-office breakdown.
  */
-export const generateBoxOffice = (movie, leadActor, director, marketMultiplier = 1) => {
+export const generateBoxOffice = (movie, leadActor, director, marketMultiplier = 1, demographicMultiplier = 1) => {
   const qualityFactor = movie.quality / 100;
   const criticFactor = movie.criticScore / 100;
   const audienceFactor = movie.audienceScore / 100;
@@ -112,7 +112,7 @@ export const generateBoxOffice = (movie, leadActor, director, marketMultiplier =
   // movie's genre). Applied at the opening weekend so it propagates through
   // worldwide gross, profit, ROI, and verdict.
   const openingWeekend = Math.round(
-    (openingBase + starPower + marketingBoost) * (hypeFactor + 0.4) * (0.7 + Math.random() * 0.6) * marketMultiplier * franchiseMultiplier
+    (openingBase + starPower + marketingBoost) * (hypeFactor + 0.4) * (0.7 + Math.random() * 0.6) * marketMultiplier * franchiseMultiplier * demographicMultiplier
   );
 
   // Worldwide Gross influenced by Audience Score (legs) and Critic Score (prestige)

--- a/backend/src/services/simulation/engines/demographicsEngine.js
+++ b/backend/src/services/simulation/engines/demographicsEngine.js
@@ -1,0 +1,108 @@
+/**
+ * @fileoverview Audience Demographics Engine (issue #193)
+ *
+ * Assigns a primary target demographic to each movie based on its genre(s),
+ * and applies a box office modifier when the movie's marketing campaign
+ * aligns with or mismatches that demographic.
+ *
+ * ## Genre -> Demographic mapping
+ * | Genre       | Primary demographic |
+ * |-------------|---------------------|
+ * | Animation   | FAMILIES            |
+ * | Horror      | TEENS               |
+ * | Romance     | TEENS               |
+ * | Action      | ADULTS              |
+ * | Thriller    | ADULTS              |
+ * | Sci-Fi      | ADULTS              |
+ * | Drama       | SENIORS             |
+ * | Documentary | SENIORS             |
+ * | default     | ADULTS              |
+ *
+ * ## Campaign -> Demographic alignment
+ * | Campaign    | Best demographic |
+ * |-------------|------------------|
+ * | social      | TEENS            |
+ * | influencer  | TEENS            |
+ * | tv          | FAMILIES/SENIORS |
+ * | newspaper   | SENIORS          |
+ * | pr          | SENIORS          |
+ * | trailer     | ADULTS           |
+ * | digital     | ADULTS/TEENS     |
+ * | billboards  | FAMILIES         |
+ *
+ * ## Modifiers
+ * - Perfect alignment (campaign → demographic matches genre demographic): +15% box office
+ * - Mismatch (campaign demographic is opposite): -10% box office
+ * - Neutral: ±0%
+ */
+
+const GENRE_DEMOGRAPHICS = {
+  Animation:   "FAMILIES",
+  Horror:      "TEENS",
+  Romance:     "TEENS",
+  Action:      "ADULTS",
+  Thriller:    "ADULTS",
+  "Sci-Fi":    "ADULTS",
+  Adventure:   "ADULTS",
+  Fantasy:     "ADULTS",
+  Comedy:      "FAMILIES",
+  Drama:       "SENIORS",
+  Documentary: "SENIORS",
+};
+
+const CAMPAIGN_DEMOGRAPHICS = {
+  social:      ["TEENS"],
+  influencer:  ["TEENS"],
+  tv:          ["FAMILIES", "SENIORS"],
+  newspaper:   ["SENIORS"],
+  pr:          ["SENIORS"],
+  trailer:     ["ADULTS"],
+  teaser:      ["ADULTS"],
+  digital:     ["ADULTS", "TEENS"],
+  billboards:  ["FAMILIES"],
+};
+
+/**
+ * Determines the primary audience demographic for a movie.
+ *
+ * @param {string[]} genres - Array of genre strings.
+ * @returns {"TEENS"|"FAMILIES"|"ADULTS"|"SENIORS"}
+ */
+export const getMovieDemographic = (genres = []) => {
+  for (const genre of genres) {
+    if (GENRE_DEMOGRAPHICS[genre]) return GENRE_DEMOGRAPHICS[genre];
+  }
+  return "ADULTS";
+};
+
+/**
+ * Computes a box office multiplier based on how well the selected marketing
+ * campaigns target the movie's primary demographic.
+ *
+ * @param {string[]} genres            - Movie genre list.
+ * @param {string[]} marketingCampaigns - Campaign IDs selected during creation.
+ * @returns {number} Multiplier (0.90 – 1.15)
+ */
+export const getDemographicMultiplier = (genres, marketingCampaigns = []) => {
+  if (!marketingCampaigns || marketingCampaigns.length === 0) return 1;
+
+  const targetDemo = getMovieDemographic(genres);
+  let matchCount = 0;
+  let mismatchCount = 0;
+
+  for (const campaignId of marketingCampaigns) {
+    const campaignDemos = CAMPAIGN_DEMOGRAPHICS[campaignId];
+    if (!campaignDemos) continue;
+
+    if (campaignDemos.includes(targetDemo)) {
+      matchCount++;
+    } else {
+      // Opposite demographics penalise (e.g. newspaper ads for a teen horror)
+      mismatchCount++;
+    }
+  }
+
+  if (matchCount > mismatchCount) return 1.15;   // Targeted audience well
+  if (mismatchCount > matchCount) return 0.90;   // Missed the audience
+  return 1.0;                                     // Neutral
+};


### PR DESCRIPTION
## Description

Introduces an audience demographics system that assigns a primary target demographic to each movie based on its genres (TEENS, FAMILIES, ADULTS, or SENIORS). The marketing campaigns selected for the movie are then evaluated against that demographic. A majority-matching campaign set applies a +15% box office multiplier at release; a mismatched set applies a -10% penalty; neutral alignment leaves the multiplier at 1.0. New file: `demographicsEngine.js`. Modified: `boxOfficeEngine.js` (added `demographicMultiplier` parameter to `generateBoxOffice()`), `movieController.js` (computes and passes the multiplier during release). Genre mapping examples: Animation and Comedy map to FAMILIES, Horror and Romance to TEENS, Action, Thriller, and Sci-Fi to ADULTS, Drama and Documentary to SENIORS. Campaign alignment: social and influencer target TEENS, tv and newspaper target SENIORS and FAMILIES, trailer and digital target ADULTS, billboards target FAMILIES.

**Related Issue:** Closes #193

---

## Open Source Program

- [ ] ECSOC 2026
- [x] ELUSOC 2026
- [ ] General Contribution

---

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] UI/UX Improvement
- [ ] Breaking Change

---

## Screenshots (If Applicable)

No UI changes. Feature is backend-only.

---

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No console errors
- [x] Build passes successfully

Additional notes: Verified a Horror movie with social and influencer campaigns receives the +15% multiplier. Verified a Drama movie with social campaigns receives the -10% penalty. Verified a balanced campaign set returns a 1.0 multiplier. Verified the multiplier correctly propagates through to `worldwideGross`.

---

## Target Branch

- [ ] `ecsoc`
- [x] `elusoc`

> **Important:** Pull Requests opened against the `main` branch are automatically closed by repository automation. Please ensure your PR targets either the `ecsoc` or `elusoc` branch.

---

## Labels

### ELUSOC

- [x] `ELUSOC2026`

---

## Checklist

- [x] I have requested assignment before starting work.
- [x] My Pull Request targets the correct branch (`ecsoc` or `elusoc`).
- [x] I have linked the related issue.
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes locally.
- [x] My changes introduce no new warnings or errors.
- [x] I have updated documentation where necessary.
- [ ] I have added screenshots for UI changes (if applicable).
- [ ] If this is an ECSOC contribution, I have requested the `ECSoC26` label before merge.