### PR TITLE
bug: write conflicts under concurrent updates

### DIFF
--- a/backend/src/utils/financeTransactionHelper.js
+++ b/backend/src/utils/financeTransactionHelper.js
@@ -7,22 +7,46 @@ import mongoose from "mongoose";
  * @param {Function} fn - Async function to execute. Receives the `session` object as an argument.
  * @returns {Promise<any>} - The result of the provided function.
  */
-export const withTransaction = async (fn) => {
-  const session = await mongoose.startSession();
-  let result;
-  
-  try {
-    session.startTransaction();
-    result = await fn(session);
-    await session.commitTransaction();
-  } catch (error) {
-    await session.abortTransaction();
-    throw error;
-  } finally {
-    session.endSession();
+export const withTransaction = async (fn, maxRetries = 5, baseDelay = 50) => {
+  let attempts = 0;
+
+  while (true) {
+    const session = await mongoose.startSession();
+    
+    try {
+      session.startTransaction();
+      
+      // Execute the passed operations using this session
+      const result = await fn(session);
+      
+      // If operations succeed, attempt to commit
+      await session.commitTransaction();
+      return result;
+      
+    } catch (error) {
+      // Always abort the current transaction on error before assessing retries
+      await session.abortTransaction();
+
+      const isTransient = error.errorLabels && error.errorLabels.includes('TransientTransactionError');
+      attempts++;
+
+      if (isTransient && attempts < maxRetries) {
+        // Calculate exponential backoff with a bit of jitter (randomness) to avoid thundering herd problem
+        const delay = Math.pow(2, attempts) * baseDelay + Math.random() * 20;
+        console.warn(`[Transaction] WriteConflict or Transient error encountered. Retry attempt ${attempts}/${maxRetries} after ${Math.round(delay)}ms...`);
+        
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        continue; // Re-run the while loop with a fresh session
+      }
+
+      // If it's not a transient error, or we exhausted our retries, throw it up the chain
+      throw error;
+      
+    } finally {
+      // Ensure the session is always closed to prevent connection/memory leaks
+      session.endSession();
+    }
   }
-  
-  return result;
 };
 
 /**


### PR DESCRIPTION
## Description

This Pull Request resolves the intermittent `TransientTransactionError` (WriteConflict / Error 112) occurring during the weekly simulation when concurrent requests modify the same game state or studio records.

### Key Changes:
**Robust Transaction Utility (`withTransaction`):** Enhanced the transaction wrapper to catch `TransientTransactionError` and automatically retry operations using exponential backoff with random jitter. This aligns with MongoDB best practices for multi-document transaction error handling.

**Related Issue:** Closes #204

---

##  Open Source Program

- [x] ECSOC 2026
- [ ] ELUSOC 2026
- [ ] General Contribution

---

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Refactoring
- [x] Performance Improvement
- [ ] UI/UX Improvement
- [ ] Breaking Change

---


## Testing

Describe how you tested your changes.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No console errors
- [x] Build passes successfully

Additional notes: