### PR TITLE
 perf: fix memory leak in custom marketplace TTL cache (#86)

### DIFF
--- a/backend/src/utils/marketplaceHelper.js
+++ b/backend/src/utils/marketplaceHelper.js
@@ -53,6 +53,15 @@ const cacheSet = (key, value) => {
     _cache.set(userId, new Map());
   }
   _cache.get(userId).set(subKey, { value, ts: Date.now() });
+
+  // Active cleanup to prevent memory leak
+  setTimeout(() => {
+    const userCache = _cache.get(userId);
+    if (userCache && userCache.has(subKey)) {
+      userCache.delete(subKey);
+      if (userCache.size === 0) _cache.delete(userId);
+    }
+  }, CACHE_TTL_MS);
 };
 
 /**


### PR DESCRIPTION
Fixes #86

### What changed:

The `_cache` implementation in `marketplaceHelper.js` was operating as a purely passive TTL cache. Cache expiration was only checked and cleared on subsequent `cacheGet()` calls for the same key.

If a user queried the marketplace and then navigated away or disconnected, that `userCache` entry was never accessed again. As a result, the entry remained in the Node.js `Map()`, causing stale data to accumulate over time and leading to memory growth proportional to the number of unique user sessions.

**The Fix:**

Added a native `setTimeout`-based active cleanup inside `cacheSet` to automatically remove expired cache entries when `CACHE_TTL_MS` elapses. The implementation also removes the parent user container when it becomes empty, preventing stale entries from accumulating and avoiding unbounded memory growth.
