### PR TITLE
refactor: centralize hardcoded game values into gameConstants.js

### DIFF
--- a/backend/src/constants/gameConstants.js
+++ b/backend/src/constants/gameConstants.js
@@ -1,0 +1,56 @@
+export const SPY_COST = 100000;
+
+export const AWARDS_CAMPAIGN_COST = 1000000;
+export const AWARDS_CAMPAIGN_PRESTIGE_GAIN = 15;
+
+export const MERCH_BOOST_COST = 2500000;
+
+export const BOOTCAMPS = {
+  acting_masterclass: { name: "Acting Masterclass", cost: 500000, stat: "actingSkill", boost: 5, target: "actor" },
+  media_training: { name: "Media Training", cost: 200000, stat: "reputation", boost: 5, target: "any" },
+  directing_workshop: { name: "Directing Workshop", cost: 500000, stat: "creativity", boost: 5, target: "director" },
+  leadership_bootcamp: { name: "Leadership Bootcamp", cost: 300000, stat: "leadership", boost: 5, target: "director" },
+};
+
+export const STUDIO_UPGRADES = {
+  marketing_partnership: { name: "Marketing Partnership", cost: 2000000, description: "Establishes a permanent partnership with a leading agency. Hype and promotional effectiveness boosted permanently.", prestigeGain: 25 },
+  advanced_cameras: { name: "Advanced Camera Gear", cost: 1500000, description: "Equip your director and crew with cutting-edge 8K cameras. Boosts future film quality.", prestigeGain: 25 },
+  talent_access: { name: "Talent Agency Access", cost: 3000000, description: "Unlocks priority access to rare writers, directors, and actors.", prestigeGain: 25 },
+};
+
+export const LOAN_TIERS = {
+  SMALL: { amount: 500000, interestRate: 0.08, weeks: 26 },
+  MEDIUM: { amount: 1000000, interestRate: 0.12, weeks: 52 },
+  LARGE: { amount: 2000000, interestRate: 0.18, weeks: 78 },
+};
+
+export const MAX_ACTIVE_LOANS = 3;
+
+export const PRODUCTION_WEEKS = {
+  PRE_PRODUCTION: 4,
+  PRODUCTION: 10,
+  POST_PRODUCTION: 6,
+  TOTAL: 20,
+};
+
+export const QUALITY_WEIGHTS = {
+  SCRIPT: 0.35,
+  DIRECTOR_CREATIVITY: 0.25,
+  LEAD_ACTOR_SKILL: 0.20,
+  CREW_TECHNICAL: 0.20,
+};
+
+export const HYPE_WEIGHTS = {
+  ACTOR_POPULARITY: 0.4,
+  DIRECTOR_REPUTATION: 0.3,
+  MARKETING: 0.3,
+};
+
+export const VERDICT_THRESHOLDS = {
+  DISASTER: 0,
+  FLOP: 20,
+  AVERAGE: 40,
+  HIT: 60,
+  BLOCKBUSTER: 75,
+  ALL_TIME_BLOCKBUSTER: 90,
+};

--- a/backend/src/controllers/academyController.js
+++ b/backend/src/controllers/academyController.js
@@ -1,12 +1,6 @@
 import GameState from "../models/GameState.js";
 import Studio from "../models/Studio.js";
-
-const BOOTCAMPS = {
-  acting_masterclass: { name: "Acting Masterclass", cost: 500000, stat: "actingSkill", boost: 5, target: "actor" },
-  media_training: { name: "Media Training", cost: 200000, stat: "reputation", boost: 5, target: "any" },
-  directing_workshop: { name: "Directing Workshop", cost: 500000, stat: "creativity", boost: 5, target: "director" },
-  leadership_bootcamp: { name: "Leadership Bootcamp", cost: 300000, stat: "leadership", boost: 5, target: "director" }
-};
+import { BOOTCAMPS } from "../constants/gameConstants.js";
 
 export const trainTalent = async (req, res) => {
   try {

--- a/backend/src/controllers/awardsCampaignController.js
+++ b/backend/src/controllers/awardsCampaignController.js
@@ -1,10 +1,10 @@
 import Movie from "../models/Movie.js";
 import Studio from "../models/Studio.js";
+import { AWARDS_CAMPAIGN_COST, AWARDS_CAMPAIGN_PRESTIGE_GAIN } from "../constants/gameConstants.js";
 
 export const startAwardsCampaign = async (req, res) => {
   try {
     const { movieId, categoryId } = req.body;
-    const CAMPAIGN_COST = 1000000; // ₹1,000,000
 
     const movie = await Movie.findById(movieId);
     if (!movie) {
@@ -39,8 +39,8 @@ export const startAwardsCampaign = async (req, res) => {
       year: movie.releaseWeek ? Math.floor(movie.releaseWeek / 52) + 2026 : 2026
     });
 
-    studio.money -= CAMPAIGN_COST;
-    studio.prestige += 15; // Boost prestige by +15 for lobbying active campaign
+    studio.money -= AWARDS_CAMPAIGN_COST;
+    studio.prestige += AWARDS_CAMPAIGN_PRESTIGE_GAIN;
 
     await movie.save();
     await studio.save();

--- a/backend/src/controllers/loanController.js
+++ b/backend/src/controllers/loanController.js
@@ -14,24 +14,7 @@
 
 import Studio from "../models/Studio.js";
 import GameState from "../models/GameState.js";
-
-const LOAN_TIERS = {
-  SMALL: {
-    amount: 500_000,
-    interestRate: 0.08,
-    weeks: 26,
-  },
-  MEDIUM: {
-    amount: 1_000_000,
-    interestRate: 0.12,
-    weeks: 52,
-  },
-  LARGE: {
-    amount: 2_000_000,
-    interestRate: 0.18,
-    weeks: 78,
-  },
-};
+import { LOAN_TIERS, MAX_ACTIVE_LOANS } from "../constants/gameConstants.js";
 
 /**
  * POST /api/studios/loans/take
@@ -56,8 +39,8 @@ export const takeLoan = async (req, res) => {
       return res.status(400).json({ success: false, message: "Bankrupt studios cannot take new loans." });
     }
 
-    // Limit: no more than 3 active loans at once
-    if ((studio.loans || []).length >= 3) {
+    // Limit: no more than MAX_ACTIVE_LOANS active loans at once
+    if ((studio.loans || []).length >= MAX_ACTIVE_LOANS) {
       return res.status(400).json({ success: false, message: "Maximum of 3 active loans allowed at one time." });
     }
 

--- a/backend/src/controllers/merchController.js
+++ b/backend/src/controllers/merchController.js
@@ -1,6 +1,7 @@
 import Movie from "../models/Movie.js";
 import Studio from "../models/Studio.js";
 import GameState from "../models/GameState.js";
+import { MERCH_BOOST_COST } from "../constants/gameConstants.js";
 
 export const getMerchandiseStats = async (req, res) => {
   try {
@@ -74,13 +75,12 @@ export const boostMerchandiseLevel = async (req, res) => {
       return res.status(404).json({ message: "Movie not found or unauthorized" });
     }
 
-    const cost = 2500000; // 2.5 million rupees
-    if (studio.money < cost) {
+    if (studio.money < MERCH_BOOST_COST) {
       return res.status(400).json({ message: "Insufficient funds to upgrade merchandising campaign" });
     }
 
     movie.merchandiseLevel = (movie.merchandiseLevel || 0) + 1;
-    studio.money -= cost;
+    studio.money -= MERCH_BOOST_COST;
 
     await movie.save();
     await studio.save();

--- a/backend/src/controllers/spyController.js
+++ b/backend/src/controllers/spyController.js
@@ -1,10 +1,10 @@
 import GameState from "../models/GameState.js";
 import Studio from "../models/Studio.js";
+import { SPY_COST } from "../constants/gameConstants.js";
 
 export const getSpyReport = async (req, res) => {
   try {
     const { rivalId } = req.params;
-    const SPY_COST = 100000; // ₹100,000
 
     const studio = await Studio.findOne({ owner: req.user._id });
     if (!studio) {

--- a/backend/src/controllers/upgradesController.js
+++ b/backend/src/controllers/upgradesController.js
@@ -1,12 +1,7 @@
 import StudioUpgrade from "../models/StudioUpgrade.js";
 import Studio from "../models/Studio.js";
 import GameState from "../models/GameState.js";
-
-const UPGRADES = {
-  marketing_partnership: { name: "Marketing Partnership", cost: 2000000, description: "Establishes a permanent partnership with a leading agency. Hype and promotional effectiveness boosted permanently." },
-  advanced_cameras: { name: "Advanced Camera Gear", cost: 1500000, description: "Equip your director and crew with cutting-edge 8K cameras. Boosts future film quality." },
-  talent_access: { name: "Talent Agency Access", cost: 3000000, description: "Unlocks priority access to rare writers, directors, and actors." }
-};
+import { STUDIO_UPGRADES as UPGRADES } from "../constants/gameConstants.js";
 
 export const getUpgrades = async (req, res) => {
   try {


### PR DESCRIPTION
# Related Issue
Closes #233

# Summary
Centralizes all game economy values from 6 controllers into a single constants file for maintainable game balancing.

# Changes Made
- Create backend/src/constants/gameConstants.js with all game economy values
- Move SPY_COST, AWARDS_CAMPAIGN_COST, MERCH_BOOST_COST
- Move LOAN_TIERS and MAX_ACTIVE_LOANS
- Move BOOTCAMPS and STUDIO_UPGRADES definitions
- Add PRODUCTION_WEEKS, QUALITY_WEIGHTS, HYPE_WEIGHTS, VERDICT_THRESHOLDS
- Update spyController, awardsCampaignController, merchController, academyController, upgradesController, loanController
- Remove duplicate local constant definitions

# Testing
- All imports verified
- Values match original hardcoded values exactly
- No functional changes to game logic

# Impact
Makes game economy balancing a single-file change instead of hunting across 6 files.

# Checklist
- [x] Code follows project standards
- [x] Backward compatible (identical values)
- [x] Single source of truth established
