### PR TITLE
feat: add Zod request validation to streaming, TV show, loan, academy and merchandise routes

### DIFF
--- a/backend/src/routes/academyRoutes.js
+++ b/backend/src/routes/academyRoutes.js
@@ -1,11 +1,13 @@
 import express from "express";
 import { protect } from "../middleware/authMiddleware.js";
+import { validate } from "../middleware/validationMiddleware.js";
+import { trainTalentSchema } from "../validators/academyValidators.js";
 import { trainTalent } from "../controllers/academyController.js";
 
 const router = express.Router();
 
 router.use(protect);
 
-router.post("/train", trainTalent);
+router.post("/train", validate(trainTalentSchema), trainTalent);
 
 export default router;

--- a/backend/src/routes/loanRoutes.js
+++ b/backend/src/routes/loanRoutes.js
@@ -1,10 +1,12 @@
 import express from "express";
 import { protect } from "../middleware/authMiddleware.js";
+import { validate } from "../middleware/validationMiddleware.js";
+import { takeLoanSchema } from "../validators/loanValidators.js";
 import { takeLoan, getLoans } from "../controllers/loanController.js";
 
 const router = express.Router();
 
 router.get("/", protect, getLoans);
-router.post("/take", protect, takeLoan);
+router.post("/take", protect, validate(takeLoanSchema), takeLoan);
 
 export default router;

--- a/backend/src/routes/merchRoutes.js
+++ b/backend/src/routes/merchRoutes.js
@@ -1,12 +1,20 @@
 import express from "express";
+import { z } from "zod";
 import { getMerchandiseStats, boostMerchandiseLevel } from "../controllers/merchController.js";
 import { protect } from "../middleware/authMiddleware.js";
+import { validate } from "../middleware/validationMiddleware.js";
+
+const boostMerchSchema = {
+  params: z.object({
+    movieId: z.string().regex(/^[0-9a-fA-F]{24}$/, "Invalid Movie ID format"),
+  }),
+};
 
 const router = express.Router();
 
 router.use(protect);
 
 router.get("/", getMerchandiseStats);
-router.post("/boost/:movieId", boostMerchandiseLevel);
+router.post("/boost/:movieId", validate(boostMerchSchema), boostMerchandiseLevel);
 
 export default router;

--- a/backend/src/routes/streamingRoutes.js
+++ b/backend/src/routes/streamingRoutes.js
@@ -1,5 +1,7 @@
 import express from "express";
 import { protect } from "../middleware/authMiddleware.js";
+import { validate } from "../middleware/validationMiddleware.js";
+import { acceptStreamingDealSchema } from "../validators/streamingValidators.js";
 import {
   getPlatforms,
   acceptStreamingDeal,
@@ -8,6 +10,6 @@ import {
 const router = express.Router();
 
 router.get("/platforms", protect, getPlatforms);
-router.post("/movies/:movieId/accept-deal", protect, acceptStreamingDeal);
+router.post("/movies/:movieId/accept-deal", protect, validate(acceptStreamingDealSchema), acceptStreamingDeal);
 
 export default router;

--- a/backend/src/routes/tvShowRoutes.js
+++ b/backend/src/routes/tvShowRoutes.js
@@ -1,5 +1,7 @@
 import express from "express";
 import { protect } from "../middleware/authMiddleware.js";
+import { validate } from "../middleware/validationMiddleware.js";
+import { createTVShowSchema, getTVShowByIdSchema } from "../validators/tvShowValidators.js";
 import {
   getTVShows,
   getTVShowById,
@@ -9,7 +11,7 @@ import {
 const router = express.Router();
 
 router.get("/", protect, getTVShows);
-router.post("/", protect, createTVShow);
-router.get("/:id", protect, getTVShowById);
+router.post("/", protect, validate(createTVShowSchema), createTVShow);
+router.get("/:id", protect, validate(getTVShowByIdSchema), getTVShowById);
 
 export default router;

--- a/backend/src/validators/academyValidators.js
+++ b/backend/src/validators/academyValidators.js
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+const VALID_TALENT_TYPES = ["actor", "director"];
+
+const VALID_BOOTCAMP_IDS = [
+  "acting_masterclass",
+  "media_training",
+  "directing_workshop",
+  "leadership_bootcamp",
+];
+
+export const trainTalentSchema = {
+  body: z.object({
+    talentId: z.string().min(1, "Talent ID is required"),
+    talentType: z
+      .string()
+      .trim()
+      .toLowerCase()
+      .refine((val) => VALID_TALENT_TYPES.includes(val), {
+        message: `Talent type must be one of: ${VALID_TALENT_TYPES.join(", ")}`,
+      }),
+    bootcampId: z
+      .string()
+      .trim()
+      .refine((val) => VALID_BOOTCAMP_IDS.includes(val), {
+        message: `Bootcamp ID must be one of: ${VALID_BOOTCAMP_IDS.join(", ")}`,
+      }),
+  }),
+};

--- a/backend/src/validators/loanValidators.js
+++ b/backend/src/validators/loanValidators.js
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+const VALID_TIERS = ["SMALL", "MEDIUM", "LARGE"];
+
+export const takeLoanSchema = {
+  body: z.object({
+    tier: z
+      .string()
+      .trim()
+      .toUpperCase()
+      .refine((val) => VALID_TIERS.includes(val), {
+        message: `Loan tier must be one of: ${VALID_TIERS.join(", ")}`,
+      }),
+  }),
+};

--- a/backend/src/validators/streamingValidators.js
+++ b/backend/src/validators/streamingValidators.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const acceptStreamingDealSchema = {
+  params: z.object({
+    movieId: z.string().regex(/^[0-9a-fA-F]{24}$/, "Invalid Movie ID format"),
+  }),
+};

--- a/backend/src/validators/tvShowValidators.js
+++ b/backend/src/validators/tvShowValidators.js
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+export const createTVShowSchema = {
+  body: z.object({
+    title: z.string().trim().min(1, "Title is required").max(200, "Title must not exceed 200 characters"),
+    genre: z.string().trim().max(50, "Genre must not exceed 50 characters").optional(),
+    seasons: z
+      .union([z.string(), z.number()])
+      .transform((val) => Number(val))
+      .pipe(z.number().int().min(1, "Minimum 1 season").max(100, "Maximum 100 seasons"))
+      .optional(),
+    episodesPerSeason: z
+      .union([z.string(), z.number()])
+      .transform((val) => Number(val))
+      .pipe(z.number().int().min(1, "Minimum 1 episode per season").max(100, "Maximum 100 episodes per season"))
+      .optional(),
+    budget: z
+      .union([z.string(), z.number()])
+      .transform((val) => Number(val))
+      .pipe(z.number().min(0, "Budget cannot be negative").max(10000000000, "Budget exceeds maximum allowed"))
+      .optional(),
+    platformId: z.string().optional(),
+  }),
+};
+
+export const getTVShowByIdSchema = {
+  params: z.object({
+    id: z.string().regex(/^[0-9a-fA-F]{24}$/, "Invalid TV Show ID format"),
+  }),
+};


### PR DESCRIPTION
# Related Issue
Closes #265

# Summary
Adds Zod request validation to 5 route groups that were previously unprotected.

# Changes Made
- **streamingValidators.js**: movieId param regex validation
- **tvShowValidators.js**: Title/budget type coercion, genre/platformId validation
- **loanValidators.js**: Tier enum validation (SMALL/MEDIUM/LARGE)
- **academyValidators.js**: Talent type + bootcamp ID enum validation
- **merchRoutes.js**: Inline movieId param validation
- **5 route files**: Added validate() middleware imports and usage

# Testing
- Verified valid requests pass through normally
- Verified invalid requests return structured ValidationError
- Verified Zod schemas match controller expectations