### PR TITLE
feat: add proper skeleton loading states to detail and profile pages

### DIFF
--- a/frontend/src/components/common/SkeletonGrid.jsx
+++ b/frontend/src/components/common/SkeletonGrid.jsx
@@ -17,6 +17,12 @@ const variantConfig = {
     showTags: false,
     rows: 4,
   },
+  detail: {
+    minHeight: "min-h-[480px]",
+    showAvatar: false,
+    showTags: false,
+    rows: 6,
+  },
 };
 
 const SkeletonLine = ({ className = "" }) => (
@@ -68,6 +74,54 @@ const SkeletonCard = ({ variant = "default" }) => {
     </div>
   );
 };
+
+export const PageSkeleton = ({ title = "Loading..." }) => (
+  <div className="animate-pulse space-y-6 p-6" role="status" aria-label={title}>
+    <div className="flex items-center gap-4">
+      <SkeletonLine className="h-10 w-10 rounded-xl" />
+      <div className="space-y-2">
+        <SkeletonLine className="h-6 w-48 rounded-lg" />
+        <SkeletonLine className="h-4 w-32 rounded-lg" />
+      </div>
+    </div>
+    <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div
+          key={i}
+          className="flex h-40 animate-pulse flex-col rounded-2xl border border-slate-800 bg-[#111827] p-5"
+        >
+          <SkeletonLine className="h-4 w-24 rounded-lg" />
+          <SkeletonLine className="mt-3 h-8 w-20 rounded-lg" />
+          <SkeletonLine className="mt-auto h-4 w-32 rounded-lg" />
+        </div>
+      ))}
+    </div>
+    <SkeletonLine className="h-64 w-full rounded-2xl" />
+  </div>
+);
+
+export const DetailSkeleton = ({ title = "Loading details..." }) => (
+  <div className="animate-pulse space-y-6" role="status" aria-label={title}>
+    <div className="flex flex-col items-center space-y-4 py-8">
+      <SkeletonLine className="h-28 w-28 rounded-full" />
+      <SkeletonLine className="h-8 w-56 rounded-lg" />
+      <SkeletonLine className="h-4 w-32 rounded-lg" />
+    </div>
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div
+          key={i}
+          className="flex flex-col gap-2 rounded-xl border border-slate-800 bg-[#111827] p-4"
+        >
+          <SkeletonLine className="h-3 w-20 rounded-lg" />
+          <SkeletonLine className="h-6 w-16 rounded-lg" />
+        </div>
+      ))}
+    </div>
+    <SkeletonLine className="h-48 w-full rounded-2xl" />
+    <SkeletonLine className="h-48 w-full rounded-2xl" />
+  </div>
+);
 
 export const SkeletonGrid = ({ count = 6, variant = "default" }) => {
   return (

--- a/frontend/src/pages/directors/DirectorProfile.jsx
+++ b/frontend/src/pages/directors/DirectorProfile.jsx
@@ -3,6 +3,7 @@ import { Link, useParams } from "react-router-dom";
 
 import api from "../../api/axios";
 import DashboardLayout from "../../layouts/DashboardLayout";
+import { DetailSkeleton } from "../../components/common/SkeletonGrid";
 
 const tabs = ["Overview", "Career", "Statistics", "Awards", "Filmography"];
 
@@ -50,13 +51,7 @@ const DirectorProfile = () => {
   }, [loadProfile]);
 
   if (loading) {
-    return (
-      <DashboardLayout>
-        <div className="rounded-2xl border border-slate-800 bg-[#111827] p-12 text-center">
-          <h2 className="text-2xl font-bold text-white">Loading director profile...</h2>
-        </div>
-      </DashboardLayout>
-    );
+    return <DashboardLayout><DetailSkeleton title="Loading director profile..." /></DashboardLayout>;
   }
 
   if (error || !profile) {

--- a/frontend/src/pages/movies/MovieDetails.jsx
+++ b/frontend/src/pages/movies/MovieDetails.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import { useParams, Link } from "react-router-dom";
 import api from "../../api/axios";
 import DashboardLayout from "../../layouts/DashboardLayout";
+import { DetailSkeleton } from "../../components/common/SkeletonGrid";
 import { Film, Calendar, Users, Briefcase, IndianRupee, Clock, ArrowLeft, CheckCircle2 } from "lucide-react";
 
 const MovieDetails = () => {
@@ -25,7 +26,7 @@ const MovieDetails = () => {
     fetchMovieDetails();
   }, [fetchMovieDetails]);
 
-  if (loading) return <DashboardLayout><div className="text-white text-center py-20 font-bold">Loading Production Data...</div></DashboardLayout>;
+  if (loading) return <DashboardLayout><DetailSkeleton title="Loading movie details..." /></DashboardLayout>;
   if (!movie) return <DashboardLayout><div className="text-white text-center py-20 font-bold">Movie Not Found</div></DashboardLayout>;
 
   const stages = [

--- a/frontend/src/pages/movies/ReleasedMovieDetail.jsx
+++ b/frontend/src/pages/movies/ReleasedMovieDetail.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import { useParams, Link } from "react-router-dom";
 import api from "../../api/axios";
 import DashboardLayout from "../../layouts/DashboardLayout";
+import { DetailSkeleton } from "../../components/common/SkeletonGrid";
 import { Film, Calendar, Users, Briefcase, IndianRupee, Clock, ArrowLeft, Star, TrendingUp, Award } from "lucide-react";
 
 const ReleasedMovieDetail = () => {
@@ -25,7 +26,7 @@ const ReleasedMovieDetail = () => {
     fetchMovieDetails();
   }, [fetchMovieDetails]);
 
-  if (loading) return <DashboardLayout><div className="text-white text-center py-20 font-bold tracking-widest uppercase">Loading Historical Archive...</div></DashboardLayout>;
+  if (loading) return <DashboardLayout><DetailSkeleton title="Loading movie archive..." /></DashboardLayout>;
   if (!movie) return <DashboardLayout><div className="text-white text-center py-20 font-bold">Movie Record Not Found</div></DashboardLayout>;
 
   const getVerdictColor = (verdict) => {

--- a/frontend/src/pages/talent/TalentProfile.jsx
+++ b/frontend/src/pages/talent/TalentProfile.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import { useParams, Link } from "react-router-dom";
 import api from "../../api/axios";
 import DashboardLayout from "../../layouts/DashboardLayout";
+import { DetailSkeleton } from "../../components/common/SkeletonGrid";
 import { User, Award, TrendingUp, IndianRupee, Star, ArrowLeft, Calendar, Briefcase } from "lucide-react";
 
 const TalentProfile = () => {
@@ -31,7 +32,7 @@ const TalentProfile = () => {
     fetchTalent();
   }, [fetchTalent]);
 
-  if (loading) return <DashboardLayout><div className="text-white text-center py-20">Loading Talent File...</div></DashboardLayout>;
+  if (loading) return <DashboardLayout><DetailSkeleton title="Loading talent profile..." /></DashboardLayout>;
   if (!talent) return <DashboardLayout><div className="text-white text-center py-20">Talent Not Found</div></DashboardLayout>;
 
   return (

--- a/frontend/src/pages/writers/WriterProfile.jsx
+++ b/frontend/src/pages/writers/WriterProfile.jsx
@@ -3,6 +3,7 @@ import { Link, useParams } from "react-router-dom";
 
 import api from "../../api/axios";
 import DashboardLayout from "../../layouts/DashboardLayout";
+import { DetailSkeleton } from "../../components/common/SkeletonGrid";
 
 const formatCurrency = (value) => `₹${Number(value || 0).toLocaleString()}`;
 
@@ -33,13 +34,7 @@ const WriterProfile = () => {
   }, [loadProfile]);
 
   if (loading) {
-    return (
-      <DashboardLayout>
-        <div className="bg-[#111827] border border-slate-800 rounded-2xl p-12 text-center">
-          <h2 className="text-2xl font-bold text-white">Loading profile...</h2>
-        </div>
-      </DashboardLayout>
-    );
+    return <DashboardLayout><DetailSkeleton title="Loading writer profile..." /></DashboardLayout>;
   }
 
   if (error || !profile) {


### PR DESCRIPTION
# Related Issue
Closes #268

# Summary
Replaces basic "Loading..." text with animated skeleton layouts on all detail and profile pages.

# Changes Made
- **SkeletonGrid.jsx**: Added DetailSkeleton, PageSkeleton components, detail variant config
- **MovieDetails.jsx**: Replaced loading text with DetailSkeleton
- **DirectorProfile.jsx**: Replaced loading text with DetailSkeleton
- **WriterProfile.jsx**: Replaced loading text with DetailSkeleton
- **TalentProfile.jsx**: Replaced loading text with DetailSkeleton
- **ReleasedMovieDetail.jsx**: Replaced loading text with DetailSkeleton

# Testing
- Verified skeletons render during loading state
- Verified proper content renders after load completes
- Verified aria-labels for accessibility