### PR TITLE
fix(api): add input validation to movie campaign route (Closes #257)

### DIFF
--- a/backend/src/routes/marketingRoutes.js
+++ b/backend/src/routes/marketingRoutes.js
@@ -1,11 +1,13 @@
 import express from "express";
 import { addMarketingCampaign } from "../controllers/movieController.js";
 import { protect } from "../middleware/authMiddleware.js";
+import { validate } from "../middleware/validationMiddleware.js";
+import { addMarketingCampaignSchema } from "../validators/movieValidator.js";
 
 const router = express.Router();
 
 router.use(protect);
 
-router.post("/:id/campaign", addMarketingCampaign);
+router.post("/:id/campaign", validate(addMarketingCampaignSchema), addMarketingCampaign);
 
 export default router;


### PR DESCRIPTION
## Linked Issue
Fixes #257

## Description
Added missing `validate()` middleware to the `POST /api/movies/:id/campaign` route. Previously, an invalid or missing `campaignId` in the request body would bypass validation and hit the controller, resulting in a misleading 404 error. This change ensures malformed requests are caught early and return a proper 400 Bad Request.

## Type of Change
- [x] Bug fix
- [x] API enhancement

*Contributor for ECSoC & ELUSOC 2026* 