### PR TITLE
fix: resolve ObjectId CastErrors and CI pipeline test failures

### DIFF
--- a/backend/tests/validationMiddleware.test.js
+++ b/backend/tests/validationMiddleware.test.js
@@ -92,10 +92,11 @@ test("errorHandler formats ZodError correctly", () => {
   };
 
   errorHandler(zodError, {}, res, () => {});
-
-  assert.equal(resStatus, 400);
+assert.equal(resStatus, 400);
   assert.deepEqual(resJson, {
     success: false,
+    code: "VALIDATION_ERROR",
+    message: "Request validation failed",
     errors: [
       {
         field: "age",


### PR DESCRIPTION
Fixes #78 

### 📝 Description
This PR resolves an issue where providing invalid MongoDB ObjectId formats would bypass Zod validation and cause the database to throw a `CastError`. Additionally, it fixes subsequent CI pipeline failures caused by a missing export and an outdated test assertion.

### 🛠️ Changes Made
* **`backend/src/validators/movieValidator.js`:** 
  * Created a reusable `objectIdRegex` (`/^[0-9a-fA-F]{24}$/`) and replaced `.min(1)` with `.regex()` for all relational ID fields to ensure proper formatting.
  * Restored the missing `addMarketingCampaignSchema` ESM export to resolve cascading hook failures in the test suite.
* **`backend/tests/validationMiddleware.test.js`:** 
  * Updated the `errorHandler formats ZodError correctly` test. The expected `resJson` payload now correctly includes the `code: 'VALIDATION_ERROR'` and `message: 'Request validation failed'` fields to match the actual API response.

### ✅ Definition of Done
- [x] Zod schemas properly validate 24-character hex strings for ObjectIds.
- [x] All required schemas are properly exported.
- [x] Test suite assertions match the middleware's updated error payloads.
- [x] CI pipeline tests pass successfully.

ELUSOC 2026