### PR TITLE
feat: [ELUSOC_2026] Feature: AI Rival Studio Release Scheduling Clashes and Screen Share Penalty

### DIFF
--- a/backend/src/controllers/movieController.js
+++ b/backend/src/controllers/movieController.js
@@ -18,6 +18,7 @@ import { generateNewsFromRelease } from "../services/simulation/engines/newsEngi
 import { withTransaction } from "../utils/financeTransactionHelper.js";
 import Notification from "../models/Notification.js";
 import logger from "../utils/logger.js";
+import { performMovieRelease } from "../services/movie/releaseService.js";
 import { addHistoricRecord } from "../services/simulation/helpers/historicRecordHelper.js";
 import { backfillMovieNames } from "../services/movie/talentBackfillService.js";
 import {
@@ -266,150 +267,49 @@ export const releaseMovie = async (req, res) => {
             const gameState = await findGameState(req.user._id);
             const studio = await Studio.findOne({ owner: req.user._id });
 
-        // Get all related talent/data for engines
-        const script = findScriptById(gameState, movie.scriptId);
-
-        // Find in owned talent
-        const director = gameState.ownedDirectors.find(d => d.id === movie.directorId);
-        const leadActor = gameState.ownedActors.find(a => a.id === movie.leadActorId);
-        const crewTeam = gameState.ownedCrewTeams.find(c => c.id === movie.crewTeamId);
-
-        // Find Writer (might be in history or owned writers)
-        const writer = gameState.ownedWriters.find(w => w.id === script?.writerId);
-
-        // 1. Generate Reviews
-        const reviews = generateReviews(movie, script, director, leadActor, crewTeam);
-        movie.criticScore = reviews.criticScore;
-        movie.criticLabel = reviews.criticLabel;
-        movie.audienceScore = reviews.audienceScore;
-        movie.audienceLabel = reviews.audienceLabel;
-
-        // 2. Generate Box Office
-        // Apply the current market climate: if a trend is active for one of
-        // this movie's genres, its multiplier boosts or dampens the gross.
-        const activeTrends = gameState.marketTrends?.activeTrends || [];
-        const marketMultiplier = getGenreMultiplier(activeTrends, script?.genres);
-        const demographicMultiplier = getDemographicMultiplier(script?.genres, movie.marketingCampaigns);
-        const boxOffice = generateBoxOffice(movie, leadActor, director, marketMultiplier, demographicMultiplier);
-        Object.assign(movie, boxOffice);
-
-        // Franchise reputation (read): load the franchise's accumulated shared
-        // fanbase and prestige, earned from prior installments, and feed them into
-        // studio growth so this release benefits from the franchise's track record.
-        // Read within the session for transactional consistency.
-        let franchiseDoc = null;
-        let franchiseModifiers = {};
-        if (movie.franchiseId) {
-            franchiseDoc = await Franchise.findById(movie.franchiseId).session(session);
-            if (franchiseDoc) {
-                franchiseModifiers = {
-                    fanMultiplier: franchiseDoc.fanbaseMultiplier || 1,
-                    prestigeBonus: franchiseDoc.prestigeBonus || 0,
-                };
-            }
-        }
-
-        // 3. Update Studio Growth (Money handled here, Fans/Prestige inside)
-        const growth = processStudioGrowth(gameState, studio, movie, franchiseModifiers);
-
-        // Franchise reputation (write): fold this installment's outcome into the
-        // franchise's lifetime revenue and accumulated fanbase/prestige. Persisted
-        // with the same session below so it rolls back atomically with the release.
-        if (franchiseDoc) {
-            const progress = computeFranchiseProgress(franchiseDoc, movie);
-            franchiseDoc.fanbaseMultiplier = progress.fanbaseMultiplier;
-            franchiseDoc.prestigeBonus = progress.prestigeBonus;
-            franchiseDoc.totalRevenue = progress.totalRevenue;
-        }
-
-        // 4. Update Careers
-        processCareerImpact(gameState, movie, writer, director, leadActor, crewTeam);
-
-        // 5. Release Talent (Set back to AVAILABLE)
-        if (director) {
-            director.status = "AVAILABLE";
-            director.busyUntilWeek = null;
-        }
-        if (leadActor) {
-            leadActor.status = "AVAILABLE";
-            leadActor.busyUntilWeek = null;
-        }
-        if (crewTeam) {
-            crewTeam.status = "AVAILABLE";
-            crewTeam.busyUntilWeek = null;
-        }
-        // Supporting Actors
-        if (movie.supportingActorIds && movie.supportingActorIds.length > 0) {
-            movie.supportingActorIds.forEach(actorId => {
-                const sActor = gameState.ownedActors.find(a => a.id === actorId);
-                if (sActor) {
-                    sActor.status = "AVAILABLE";
-                    sActor.busyUntilWeek = null;
-                }
-            });
-        }
-
-        // 6. Finalize Movie Status
-        movie.status = "RELEASED";
-        movie.releaseWeek = gameState.currentWeek;
-
-        // Move to history in GameState if needed
-        if (!gameState.movieHistory) gameState.movieHistory = [];
-        gameState.movieHistory.push(movie._id);
-
-        // Remove from active movies
-        gameState.activeMovies = gameState.activeMovies.filter(mId => mId.toString() !== movie._id.toString());
-
-        // Notifications
-        addNotification(gameState, `"${movie.title}" released! Critic Score: ${movie.criticScore} (${movie.criticLabel})`);
-        addNotification(gameState, `"${movie.title}" earned ₹${movie.worldwideGross.toLocaleString()} worldwide. Verdict: ${movie.verdict}`);
-
-        // Generate news article for the release
-        await generateNewsFromRelease(movie, studio, gameState.currentWeek);
-
-        // Surface the market climate's effect when it was material.
-        if (marketMultiplier > 1.01) {
-            const matched = activeTrends.find((t) => (script?.genres || []).includes(t.genre));
-            addNotification(
-                gameState,
-                `Market boost: the "${matched ? matched.label : "current trend"}" lifted "${movie.title}" at the box office.`
-            );
-        } else if (marketMultiplier < 0.99) {
-            const matched = activeTrends.find((t) => (script?.genres || []).includes(t.genre));
-            addNotification(
-                gameState,
-                `Market headwind: "${matched ? matched.label : "current trend"}" dampened "${movie.title}" at the box office.`
-            );
-        }
-
-            await movie.save({ session });
-            await studio.save({ session });
-            await gameState.save({ session });
-            if (franchiseDoc) await franchiseDoc.save({ session });
-
-            return { movie, growth };
+            const releaseResult = await performMovieRelease(movie, studio, gameState, session);
+            return releaseResult;
         });
-
-        // Add to historic records
-        try {
-            await addHistoricRecord({
-                title: result.movie.title,
-                studioId: result.movie.studioId.toString(),
-                studioName: studio.name,
-                worldwideGross: result.movie.worldwideGross,
-                openingWeekend: result.movie.openingWeekend,
-                roi: result.movie.roi,
-                releaseWeek: result.movie.releaseWeek,
-                isRival: false
-            });
-        } catch (recordErr) {
-            logger.error("Failed to save historic record for player", { error: recordErr.message });
-        }
 
         res.status(200).json({ success: true, movie: result.movie, growth: result.growth });
     } catch (error) {
         logger.error("Release Movie Error", { error: error.message, movieId: id });
         res.status(500).json({ success: false, message: `Operation rolled back due to: ${error.message}` });
+    }
+};
+
+export const scheduleRelease = async (req, res) => {
+    try {
+        const { id } = req.params;
+        const { releaseWeek } = req.body;
+
+        if (!releaseWeek || typeof releaseWeek !== "number") {
+            return res.status(400).json({ success: false, message: "releaseWeek (number) is required." });
+        }
+
+        const gameState = await GameState.findOne({ user: req.user._id });
+        if (!gameState) return res.status(404).json({ success: false, message: "Game state not found" });
+
+        if (releaseWeek <= gameState.currentWeek) {
+            return res.status(400).json({ success: false, message: "scheduledReleaseWeek must be in the future." });
+        }
+
+        const movie = await Movie.findById(id);
+        if (!movie) return res.status(404).json({ success: false, message: "Movie not found" });
+        if (movie.status !== "READY_FOR_RELEASE" && movie.status !== "POST_PRODUCTION") {
+            return res.status(400).json({ success: false, message: "Only post-production or ready-for-release movies can be scheduled." });
+        }
+
+        movie.scheduledReleaseWeek = releaseWeek;
+        await movie.save();
+
+        res.status(200).json({
+            success: true,
+            message: `"${movie.title}" scheduled for release in week ${releaseWeek}.`,
+            scheduledReleaseWeek: releaseWeek,
+        });
+    } catch (error) {
+        res.status(500).json({ success: false, message: error.message });
     }
 };
 

--- a/backend/src/models/Movie.js
+++ b/backend/src/models/Movie.js
@@ -53,6 +53,8 @@ const movieSchema = new mongoose.Schema(
 
     createdWeek: { type: Number, required: true },
     releaseWeek: { type: Number, default: null },
+    scheduledReleaseWeek: { type: Number, default: null },
+    clashPenaltyApplied: { type: Boolean, default: false },
     productionProgress: { type: Number, default: 0 },
     remainingWeeks: { type: Number, default: 0 },
 

--- a/backend/src/routes/movieRoutes.js
+++ b/backend/src/routes/movieRoutes.js
@@ -12,6 +12,7 @@ import {
   generateTitle,
   getMovieTracking,
   reReleaseMovie,
+  scheduleRelease,
 } from "../controllers/movieController.js";
 
 const router = express.Router();
@@ -24,6 +25,7 @@ router.get("/released", protect, getReleasedMovies);
 
 // FIXED: Wrapped schemas in an object containing a 'body' property
 router.post("/:id/release", protect, validate({ params: releaseMovieParamsSchema }), releaseMovie);
+router.post("/:id/schedule", protect, scheduleRelease);
 router.get("/:id/tracking", protect, getMovieTracking);
 router.post("/:id/rerelease", protect, reReleaseMovie);
 router.get("/:id", protect, getMovieDetails);

--- a/backend/src/services/movie/releaseService.js
+++ b/backend/src/services/movie/releaseService.js
@@ -1,0 +1,152 @@
+import Movie from "../../models/Movie.js";
+import Studio from "../../models/Studio.js";
+import Franchise from "../../models/Franchise.js";
+import { generateReviews } from "../simulation/engines/reviewEngine.js";
+import { generateBoxOffice } from "../simulation/engines/boxOfficeEngine.js";
+import { getGenreMultiplier } from "../simulation/engines/trendEngine.js";
+import { getDemographicMultiplier } from "../simulation/engines/demographicsEngine.js";
+import { processCareerImpact } from "../simulation/engines/careerImpactEngine.js";
+import { processStudioGrowth } from "../simulation/engines/studioGrowthEngine.js";
+import { computeFranchiseProgress } from "../simulation/engines/franchiseEngine.js";
+import { addNotification } from "../simulation/helpers/notificationHelper.js";
+import { generateNewsFromRelease } from "../simulation/engines/newsEngine.js";
+import { findScriptById } from "./movieValidationService.js";
+import { computeClashPenalty } from "../simulation/engines/clashEngine.js";
+import { addHistoricRecord } from "../simulation/helpers/historicRecordHelper.js";
+
+/**
+ * Handles the complete release process of a movie (manual or scheduled).
+ *
+ * @param {object} movie
+ * @param {object} studio
+ * @param {object} gameState
+ * @param {object} [session=null]
+ * @returns {Promise<object>} { movie, growth }
+ */
+export const performMovieRelease = async (movie, studio, gameState, session = null) => {
+  const script = findScriptById(gameState, movie.scriptId);
+
+  // Find in owned talent
+  const director = gameState.ownedDirectors.find(d => d.id === movie.directorId);
+  const leadActor = gameState.ownedActors.find(a => a.id === movie.leadActorId);
+  const crewTeam = gameState.ownedCrewTeams.find(c => c.id === movie.crewTeamId);
+
+  // Find Writer
+  const writer = gameState.ownedWriters.find(w => w.id === script?.writerId);
+
+  // 1. Generate Reviews
+  const reviews = generateReviews(movie, script, director, leadActor, crewTeam);
+  movie.criticScore = reviews.criticScore;
+  movie.criticLabel = reviews.criticLabel;
+  movie.audienceScore = reviews.audienceScore;
+  movie.audienceLabel = reviews.audienceLabel;
+
+  // 2. Generate Box Office
+  const activeTrends = gameState.marketTrends?.activeTrends || [];
+  const marketMultiplier = getGenreMultiplier(activeTrends, script?.genres);
+  const demographicMultiplier = getDemographicMultiplier(script?.genres, movie.marketingCampaigns);
+  const boxOffice = generateBoxOffice(movie, leadActor, director, marketMultiplier, demographicMultiplier);
+  Object.assign(movie, boxOffice);
+
+  // Apply clash penalty
+  const clash = computeClashPenalty(gameState, movie);
+  if (clash.boxOfficeMultiplier < 1.0) {
+    movie.openingWeekend = Math.round(movie.openingWeekend * clash.boxOfficeMultiplier);
+    movie.worldwideGross = Math.round(movie.worldwideGross * clash.boxOfficeMultiplier);
+    movie.domesticGross = Math.round(movie.domesticGross * clash.boxOfficeMultiplier);
+    movie.internationalGross = Math.round(movie.internationalGross * clash.boxOfficeMultiplier);
+    movie.boxOffice = movie.worldwideGross;
+    movie.clashPenaltyApplied = true;
+    addNotification(gameState, `⚠️ Box Office Clash! "${movie.title}" faced screen-share penalty due to competition from: ${clash.clashedWith.join(", ")}.`);
+  }
+
+  // Franchise modifiers
+  let franchiseDoc = null;
+  let franchiseModifiers = {};
+  if (movie.franchiseId) {
+    franchiseDoc = session
+      ? await Franchise.findById(movie.franchiseId).session(session)
+      : await Franchise.findById(movie.franchiseId);
+    if (franchiseDoc) {
+      franchiseModifiers = {
+        fanMultiplier: franchiseDoc.fanbaseMultiplier || 1,
+        prestigeBonus: franchiseDoc.prestigeBonus || 0,
+      };
+    }
+  }
+
+  // 3. Update Studio Growth
+  const growth = processStudioGrowth(gameState, studio, movie, franchiseModifiers);
+
+  // Franchise progress
+  if (franchiseDoc) {
+    const progress = computeFranchiseProgress(franchiseDoc, movie);
+    franchiseDoc.fanbaseMultiplier = progress.fanbaseMultiplier;
+    franchiseDoc.prestigeBonus = progress.prestigeBonus;
+    franchiseDoc.totalRevenue = progress.totalRevenue;
+  }
+
+  // 4. Update Careers
+  processCareerImpact(gameState, movie, writer, director, leadActor, crewTeam);
+
+  // 5. Release Talent (Set back to AVAILABLE)
+  if (director) {
+    director.status = "AVAILABLE";
+    director.busyUntilWeek = null;
+  }
+  if (leadActor) {
+    leadActor.status = "AVAILABLE";
+    leadActor.busyUntilWeek = null;
+  }
+  if (crewTeam) {
+    crewTeam.status = "AVAILABLE";
+    crewTeam.busyUntilWeek = null;
+  }
+  if (movie.supportingActorIds && movie.supportingActorIds.length > 0) {
+    movie.supportingActorIds.forEach(actorId => {
+      const sActor = gameState.ownedActors.find(a => a.id === actorId);
+      if (sActor) {
+        sActor.status = "AVAILABLE";
+        sActor.busyUntilWeek = null;
+      }
+    });
+  }
+
+  // 6. Finalize Movie Status
+  movie.status = "RELEASED";
+  movie.releaseWeek = gameState.currentWeek;
+
+  if (!gameState.movieHistory) gameState.movieHistory = [];
+  gameState.movieHistory.push(movie._id);
+
+  gameState.activeMovies = gameState.activeMovies.filter(mId => mId.toString() !== movie._id.toString());
+
+  // Notifications
+  addNotification(gameState, `"${movie.title}" released! Critic Score: ${movie.criticScore} (${movie.criticLabel})`);
+  addNotification(gameState, `"${movie.title}" earned ₹${movie.worldwideGross.toLocaleString()} worldwide. Verdict: ${movie.verdict}`);
+
+  // Generate news article for the release
+  await generateNewsFromRelease(movie, studio, gameState.currentWeek);
+
+  // Add to historic records
+  try {
+    await addHistoricRecord({
+      title: movie.title,
+      studioId: movie.studioId.toString(),
+      studioName: studio.name,
+      worldwideGross: movie.worldwideGross,
+      openingWeekend: movie.openingWeekend,
+      roi: movie.roi,
+      releaseWeek: movie.releaseWeek,
+      isRival: false
+    });
+  } catch (recordErr) {
+    console.error("Failed to save historic record for player", recordErr.message);
+  }
+
+  // Save documents
+  await movie.save(session ? { session } : undefined);
+  if (franchiseDoc) await franchiseDoc.save(session ? { session } : undefined);
+
+  return { movie, growth };
+};

--- a/backend/src/services/simulation/engines/clashEngine.js
+++ b/backend/src/services/simulation/engines/clashEngine.js
@@ -1,0 +1,99 @@
+import Movie from "../../../models/Movie.js";
+import { findScriptById } from "../../movie/movieValidationService.js";
+import { performMovieRelease } from "../../movie/releaseService.js";
+
+/**
+ * Pure helper — calculates clash penalty based on pre-fetched data.
+ * Separated from DB calls so it can be unit-tested without a Mongoose connection.
+ *
+ * @param {object} gameState
+ * @param {object} movie - Movie being released (must have scriptId)
+ * @param {Array}  playerMovies - Other READY_FOR_RELEASE player movies with same scheduledReleaseWeek
+ * @returns {{ boxOfficeMultiplier: number, marketingMultiplier: number, clashedWith: string[] }}
+ */
+export const computeClashPenalty = (gameState, movie, playerMovies = []) => {
+  let sameGenreCompetitors = 0;
+  const clashedWith = [];
+
+  const currentScript = findScriptById(gameState, movie.scriptId);
+  const currentGenres = currentScript?.genres || [];
+
+  // 1. Check rival movies whose weeksRemaining === 0 (releasing this tick)
+  if (gameState.rivalStudios) {
+    for (const rival of gameState.rivalStudios) {
+      for (const rMovie of rival.activeMovies || []) {
+        if (rMovie.weeksRemaining === 0 && currentGenres.includes(rMovie.genre)) {
+          sameGenreCompetitors++;
+          clashedWith.push(`${rival.name}'s "${rMovie.title}"`);
+        }
+      }
+    }
+  }
+
+  // 2. Check other player movies releasing the same week
+  for (const pMovie of playerMovies) {
+    const pScript = findScriptById(gameState, pMovie.scriptId);
+    const pGenres = pScript?.genres || [];
+    if (pGenres.some(g => currentGenres.includes(g))) {
+      sameGenreCompetitors++;
+      clashedWith.push(`your own movie "${pMovie.title}"`);
+    }
+  }
+
+  let boxOfficeMultiplier = 1.0;
+  let marketingMultiplier = 1.0;
+
+  if (sameGenreCompetitors === 1) {
+    boxOfficeMultiplier = 0.85;
+    marketingMultiplier = 0.80;
+  } else if (sameGenreCompetitors >= 2) {
+    boxOfficeMultiplier = 0.70;
+    marketingMultiplier = 0.65;
+  }
+
+  return { boxOfficeMultiplier, marketingMultiplier, clashedWith };
+};
+
+/**
+ * Async wrapper used by the release service — fetches player clash candidates
+ * from the DB then delegates to the pure computeClashPenalty helper.
+ *
+ * @param {object} gameState
+ * @param {object} movie - Movie being released
+ * @returns {Promise<{ boxOfficeMultiplier: number, marketingMultiplier: number, clashedWith: string[] }>}
+ */
+export const calculateClashPenalty = async (gameState, movie) => {
+  const currentWeek = gameState.currentWeek;
+
+  // Fetch other player movies scheduled for the same week
+  const playerMovies = await Movie.find({
+    scheduledReleaseWeek: currentWeek,
+    status: "READY_FOR_RELEASE",
+    _id: { $ne: movie._id }
+  }).lean();
+
+  return computeClashPenalty(gameState, movie, playerMovies);
+};
+
+/**
+ * Auto-releases player movies whose scheduled release week has arrived.
+ *
+ * @param {number} currentWeek
+ * @param {object} gameState
+ * @param {object} studio
+ * @returns {Promise<void>}
+ */
+export const processScheduledReleases = async (currentWeek, gameState, studio) => {
+  const moviesReadyThisWeek = await Movie.find({
+    scheduledReleaseWeek: currentWeek,
+    status: "READY_FOR_RELEASE"
+  });
+
+  for (const movie of moviesReadyThisWeek) {
+    try {
+      await performMovieRelease(movie, studio, gameState);
+    } catch (err) {
+      console.error(`Failed to auto-release movie "${movie.title}":`, err.message);
+    }
+  }
+};

--- a/backend/src/services/simulation/engines/rivalStudioEngine.js
+++ b/backend/src/services/simulation/engines/rivalStudioEngine.js
@@ -209,7 +209,7 @@ export const processRivalStudios = (gameState) => {
     if (rival.activeMovies.length < MAX_ACTIVE_MOVIES) {
       const startChance = MOVIE_START_CHANCE[rival.personality] || 0.15;
       if (Math.random() < startChance) {
-        const newMovie = _startRivalMovie(rival);
+        const newMovie = _startRivalMovie(rival, gameState.currentWeek);
         rival.activeMovies.push(newMovie);
       }
     }
@@ -310,7 +310,7 @@ const _releaseRivalMovie = (rival, movie, currentWeek) => {
 // Internal: start a new rival movie in production
 // ---------------------------------------------------------------------------
 
-const _startRivalMovie = (rival) => {
+const _startRivalMovie = (rival, currentWeek = 1) => {
   const personality = rival.personality || "COMMERCIAL";
   const genres = GENRES_BY_PERSONALITY[personality];
   const genre = pick(genres);
@@ -334,6 +334,7 @@ const _startRivalMovie = (rival) => {
     quality,
     totalWeeks,
     weeksRemaining: totalWeeks,
+    scheduledReleaseWeek: currentWeek + totalWeeks,
   };
 };
 

--- a/backend/src/services/simulation/engines/tickEngine.js
+++ b/backend/src/services/simulation/engines/tickEngine.js
@@ -19,6 +19,7 @@ import { processLoanRepayments } from "./loanRepaymentEngine.js";
 import { processFanClubTick } from "./fanClubEngine.js";
 import { processUnionSatisfaction } from "./unionEngine.js";
 import { processScandals } from "./prEngine.js";
+import { processScheduledReleases } from "./clashEngine.js";
 
 import { addNotification } from "../helpers/notificationHelper.js";
 import { processWriterAging } from "../helpers/agingHelper.js";
@@ -102,6 +103,9 @@ export const processWeeklyTick = async (gameState, studio) => {
   processDirectingProjects(gameState, studio);
 
   await processProduction(gameState, studio);
+
+  // Auto-release movies whose scheduled release week has arrived (issue #348)
+  await processScheduledReleases(gameState.currentWeek, gameState, studio);
 
   // Process crew union satisfaction and strike states (issue #285)
   processUnionSatisfaction(gameState, studio);

--- a/backend/tests/clashEngine.test.js
+++ b/backend/tests/clashEngine.test.js
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert";
+import { computeClashPenalty } from "../src/services/simulation/engines/clashEngine.js";
+
+// Helper to build mock gameState
+const makeGameState = (rivalStudios = []) => ({
+  currentWeek: 5,
+  marketScripts: [{ id: "script1", genres: ["Action"] }],
+  ownedScripts: [],
+  rivalStudios
+});
+
+test("clashEngine: computeClashPenalty returns 1.0 when no competitors", () => {
+  const gameState = makeGameState([]);
+  const movie = { scriptId: "script1" };
+
+  const result = computeClashPenalty(gameState, movie, []);
+  assert.strictEqual(result.boxOfficeMultiplier, 1.0);
+  assert.strictEqual(result.marketingMultiplier, 1.0);
+  assert.strictEqual(result.clashedWith.length, 0);
+});
+
+test("clashEngine: computeClashPenalty returns 0.85 when 1 same-genre rival competitor", () => {
+  const gameState = makeGameState([
+    {
+      name: "Rival A",
+      activeMovies: [{ title: "Rival Film", genre: "Action", weeksRemaining: 0 }]
+    }
+  ]);
+  const movie = { scriptId: "script1" };
+
+  const result = computeClashPenalty(gameState, movie, []);
+  assert.strictEqual(result.boxOfficeMultiplier, 0.85);
+  assert.strictEqual(result.marketingMultiplier, 0.80);
+  assert.deepStrictEqual(result.clashedWith, ["Rival A's \"Rival Film\""]);
+});
+
+test("clashEngine: computeClashPenalty returns 0.70 when 2 same-genre rival competitors", () => {
+  const gameState = makeGameState([
+    {
+      name: "Rival A",
+      activeMovies: [{ title: "Rival Film 1", genre: "Action", weeksRemaining: 0 }]
+    },
+    {
+      name: "Rival B",
+      activeMovies: [{ title: "Rival Film 2", genre: "Action", weeksRemaining: 0 }]
+    }
+  ]);
+  const movie = { scriptId: "script1" };
+
+  const result = computeClashPenalty(gameState, movie, []);
+  assert.strictEqual(result.boxOfficeMultiplier, 0.70);
+  assert.strictEqual(result.marketingMultiplier, 0.65);
+  assert.ok(result.clashedWith.includes("Rival A's \"Rival Film 1\""));
+  assert.ok(result.clashedWith.includes("Rival B's \"Rival Film 2\""));
+});
+
+test("clashEngine: computeClashPenalty ignores rivals with non-matching genre", () => {
+  const gameState = makeGameState([
+    {
+      name: "Rival A",
+      activeMovies: [{ title: "Comedy Film", genre: "Comedy", weeksRemaining: 0 }]
+    }
+  ]);
+  const movie = { scriptId: "script1" }; // genres: ["Action"]
+
+  const result = computeClashPenalty(gameState, movie, []);
+  assert.strictEqual(result.boxOfficeMultiplier, 1.0);
+  assert.strictEqual(result.marketingMultiplier, 1.0);
+  assert.strictEqual(result.clashedWith.length, 0);
+});
+
+test("clashEngine: computeClashPenalty ignores rivals still in production", () => {
+  const gameState = makeGameState([
+    {
+      name: "Rival A",
+      activeMovies: [{ title: "Action Film", genre: "Action", weeksRemaining: 5 }]
+    }
+  ]);
+  const movie = { scriptId: "script1" };
+
+  const result = computeClashPenalty(gameState, movie, []);
+  assert.strictEqual(result.boxOfficeMultiplier, 1.0);
+  assert.strictEqual(result.clashedWith.length, 0);
+});


### PR DESCRIPTION
Detect genre scheduling clashes between player and rival studio movie releases. Apply box office and marketing multiplier penalties (0.85x / 0.70x) when multiple same-genre movies compete for screen share in the same week. Adds scheduled release capability and a pure clash engine with 5 unit tests.

Closes #348