### PR TITLE
fix: eliminate race condition in studio balance deductions via atomic MongoDB updates (#395)

### DIFF
--- a/backend/src/controllers/movieController.js
+++ b/backend/src/controllers/movieController.js
@@ -82,11 +82,19 @@ export const createMovie = async (req, res) => {
 
     const playerMarketingBudget = (marketingBudget || 0) * (1 - share / 100);
 
-    // Validate Studio Money for Marketing Budget (player's share)
-    if (studio.money < playerMarketingBudget) {
-        return res.status(400).json({ success: false, message: "Insufficient funds for marketing" });
+    // Atomically deduct marketing budget (player's share) to prevent race conditions
+    // from concurrent requests overwriting each other's balance updates.
+    const updatedStudio = await Studio.findOneAndUpdate(
+      { _id: studio._id, money: { $gte: playerMarketingBudget } },
+      { $inc: { money: -playerMarketingBudget } },
+      { returnDocument: "after" }
+    );
+    if (!updatedStudio) {
+      return res.status(400).json({ success: false, message: "Insufficient funds for marketing" });
     }
-    // Validate Studio Money for Marketing Budget
+    studio.money = updatedStudio.money;
+
+    // Validate Studio Money for Marketing Budget (in-memory guard for downstream logic)
     validateMarketingBudget(studio, marketingBudget, marketingCampaignIds);
 
     // Soundtrack selection
@@ -210,9 +218,6 @@ export const createMovie = async (req, res) => {
     crewTeam.status = "BUSY";
     crewTeam.busyUntilWeek = gameState.currentWeek + 20;
 
-    // Deduct marketing budget (player's share)
-    studio.money -= playerMarketingBudget;
-
     gameState.activeMovies.push(movie._id);
 
     await Notification.create({
@@ -221,7 +226,6 @@ export const createMovie = async (req, res) => {
         createdAt: new Date()
     });
 
-    await studio.save();
     await gameState.save();
 
     res.status(201).json({ success: true, movie });

--- a/backend/src/controllers/upgradesController.js
+++ b/backend/src/controllers/upgradesController.js
@@ -36,10 +36,6 @@ export const buyUpgrade = async (req, res) => {
       return res.status(404).json({ success: false, message: "Studio not found" });
     }
 
-    if (studio.money < upgrade.cost) {
-      return res.status(400).json({ success: false, message: "Insufficient funds for this studio upgrade" });
-    }
-
     const alreadyPurchased = await StudioUpgrade.findOne({ studioId: studio._id, upgradeId });
     if (alreadyPurchased) {
       return res.status(400).json({ success: false, message: "This upgrade is already active for your studio" });
@@ -48,8 +44,16 @@ export const buyUpgrade = async (req, res) => {
     const gameState = await GameState.findOne({ user: req.user._id });
     const currentWeek = gameState?.currentWeek || 1;
 
-    studio.money -= upgrade.cost;
-    studio.prestige += 25; // Permanent prestige increase for studio development
+    // Atomically deduct cost and award prestige to prevent race conditions
+    // from concurrent requests overwriting each other's balance updates.
+    const updatedStudio = await Studio.findOneAndUpdate(
+      { _id: studio._id, money: { $gte: upgrade.cost } },
+      { $inc: { money: -upgrade.cost, prestige: 25 } },
+      { returnDocument: "after" }
+    );
+    if (!updatedStudio) {
+      return res.status(400).json({ success: false, message: "Insufficient funds for this studio upgrade" });
+    }
 
     const purchasedUpgrade = await StudioUpgrade.create({
       studioId: studio._id,
@@ -57,13 +61,11 @@ export const buyUpgrade = async (req, res) => {
       purchasedWeek: currentWeek
     });
 
-    await studio.save();
-
     res.status(200).json({
       success: true,
       message: `Successfully purchased "${upgrade.name}"! Prestige increased by +25.`,
       purchasedUpgrade,
-      studioMoney: studio.money
+      studioMoney: updatedStudio.money
     });
   } catch (error) {
     res.status(500).json({ success: false, message: error.message });

--- a/backend/tests/upgrades.api.test.js
+++ b/backend/tests/upgrades.api.test.js
@@ -1,0 +1,193 @@
+import "./helpers/testEnv.js";
+
+import test, { before, after } from "node:test";
+import assert from "node:assert";
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import Studio from "../src/models/Studio.js";
+
+// ---------------------------------------------------------------------------
+// Integration tests for the studio upgrades endpoint, verifying that the
+// balance deduction uses an atomic MongoDB update (`findOneAndUpdate` with
+// `$inc` + `$gte` guard) instead of a read-modify-write pattern. This
+// prevents race conditions where concurrent requests could both see a
+// sufficient balance and double-spend.
+// ---------------------------------------------------------------------------
+
+const TEST_PASSWORD = ["test", "Pw", "8842"].join("-");
+
+let mongod;
+let server;
+let baseUrl;
+
+const registerStudio = async (id = Math.random().toString(36).substring(7)) => {
+  const res = await fetch(`${baseUrl}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      username: `player_${id}`,
+      email: `p1_${id}@example.com`,
+      password: TEST_PASSWORD,
+      studioName: `P1 Studios_${id}`,
+    }),
+  });
+  return res.json();
+};
+
+before(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+
+  const { default: app } = await import("../src/app.js");
+  await new Promise((resolve) => {
+    server = app.listen(0, () => {
+      baseUrl = `http://127.0.0.1:${server.address().port}`;
+      resolve();
+    });
+  });
+});
+
+after(async () => {
+  if (server) await new Promise((resolve) => server.close(resolve));
+  await mongoose.disconnect();
+  if (mongod) await mongod.stop();
+});
+
+test("POST /api/upgrades/buy — deducts funds atomically and awards prestige", async () => {
+  const { token, studio } = await registerStudio("deduct-test");
+  assert.ok(token);
+  assert.strictEqual(studio.money, 10000000);
+
+  // Buy the cheapest upgrade ($1,500,000 for advanced_cameras)
+  const res = await fetch(`${baseUrl}/api/upgrades/buy`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ upgradeId: "advanced_cameras" }),
+  });
+  assert.strictEqual(res.status, 200);
+  const body = await res.json();
+  assert.strictEqual(body.success, true);
+  assert.strictEqual(body.studioMoney, 10000000 - 1500000);
+
+  // Verify the persisted balance and prestige
+  const fresh = await Studio.findById(studio._id).lean();
+  assert.strictEqual(fresh.money, 10000000 - 1500000);
+  assert.strictEqual(fresh.prestige, 25, "prestige should be incremented by 25");
+});
+
+test("POST /api/upgrades/buy — rejects duplicate upgrade purchase", async () => {
+  const { token } = await registerStudio("dup-test");
+
+  const buy = async (upgradeId) =>
+    fetch(`${baseUrl}/api/upgrades/buy`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ upgradeId }),
+    });
+
+  // First purchase succeeds
+  const res1 = await buy("marketing_partnership");
+  assert.strictEqual(res1.status, 200);
+
+  // Duplicate purchase fails with 400
+  const res2 = await buy("marketing_partnership");
+  assert.strictEqual(res2.status, 400);
+  const body = await res2.json();
+  assert.strictEqual(body.success, false);
+  assert.ok(
+    body.message.toLowerCase().includes("already active") ||
+    body.message.toLowerCase().includes("already purchased"),
+    `expected duplicate message, got: ${body.message}`,
+  );
+});
+
+test("POST /api/upgrades/buy — rejects purchase when funds are insufficient", async () => {
+  const { token } = await registerStudio("poor-test");
+
+  // Artificially lower the studio balance to below any upgrade cost
+  const meRes = await fetch(`${baseUrl}/api/auth/me`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const me = await meRes.json();
+  await Studio.updateOne(
+    { owner: me.user._id },
+    { $set: { money: 100000 } },
+  );
+
+  // Even the cheapest upgrade ($1,500,000) should now fail
+  const res = await fetch(`${baseUrl}/api/upgrades/buy`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ upgradeId: "advanced_cameras" }),
+  });
+  assert.strictEqual(res.status, 400);
+  const body = await res.json();
+  assert.strictEqual(body.success, false);
+  assert.ok(
+    body.message.toLowerCase().includes("insufficient") ||
+    body.message.toLowerCase().includes("fund"),
+    `expected insufficient-funds message, got: ${body.message}`,
+  );
+});
+
+test("POST /api/upgrades/buy — concurrent purchases do not produce negative balance", async () => {
+  const { token } = await registerStudio("concur-test");
+
+  // Set balance to exactly enough for ONE upgrade ($1,500,000)
+  const meRes = await fetch(`${baseUrl}/api/auth/me`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const me = await meRes.json();
+  await Studio.updateOne(
+    { owner: me.user._id },
+    { $set: { money: 1500000, prestige: 0 } },
+  );
+
+  // Fire two concurrent purchase requests for the same upgrade
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
+  const [res1, res2] = await Promise.all([
+    fetch(`${baseUrl}/api/upgrades/buy`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ upgradeId: "advanced_cameras" }),
+    }),
+    fetch(`${baseUrl}/api/upgrades/buy`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ upgradeId: "advanced_cameras" }),
+    }),
+  ]);
+
+  const body1 = await res1.json();
+  const body2 = await res2.json();
+
+  // Exactly one must succeed, the other must fail (or both fail)
+  const succeeded = [body1, body2].filter((b) => b.success === true).length;
+  const failed = [body1, body2].filter((b) => b.success === false).length;
+  assert.strictEqual(succeeded, 1, "exactly one concurrent purchase should succeed");
+  assert.strictEqual(failed, 1, "the other concurrent purchase should fail");
+
+  // The studio balance must not be negative
+  const fresh = await Studio.findOne({ owner: me.user._id }).lean();
+  assert.ok(
+    fresh.money >= 0,
+    `studio balance must not be negative, got ${fresh.money}`,
+  );
+  assert.strictEqual(
+    fresh.money,
+    0,
+    `studio balance should be exactly 0 after spending all on one upgrade, got ${fresh.money}`,
+  );
+});


### PR DESCRIPTION
## 📄 Description

**Race condition:** In `backend/src/controllers/movieController.js` (`createMovie`) and `backend/src/controllers/upgradesController.js` (`buyUpgrade`), studio financial transactions used a **read-modify-write** pattern:

1. Read `studio.money` into memory
2. Check if `studio.money >= cost` against the stale in-memory value
3. Subtract cost in memory: `studio.money -= cost`
4. Write the entire document back via `studio.save()`

When two requests execute concurrently, both see the same `studio.money`, both pass the check, and the second `.save()` overwrites the first — allowing funds to drop below zero or incorrect balances.

**Fix:** Replaced read-modify-write with **atomic MongoDB `findOneAndUpdate`** using `{ $inc: { money: -cost } }` filtered by `{ money: { $gte: cost } }`. Concurrent requests now correctly check and deduct funds in a single database operation, preventing double-spend and negative balance scenarios.

**Changes:**
- `movieController.js` — `createMovie`: atomic deduction of player's marketing budget share; removed in-memory subtraction + `studio.save()`
- `upgradesController.js` — `buyUpgrade`: atomic deduction + prestige increment in one `$inc` operation; removed redundant in-memory mutations
- New `backend/tests/upgrades.api.test.js` with integration tests covering atomic deduction, duplicate rejection, insufficient funds, and concurrent purchases

**Related Issue:** Closes #395

---

## 🚀 Open Source Program

- [x] ECSOC 2026
- [ ] ELUSOC 2026
- [ ] General Contribution

---

## 🛠 Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] UI/UX Improvement
- [ ] Breaking Change

---

## 📸 Screenshots (If Applicable)

N/A — backend-only fix.

---

## 🧪 Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No console errors
- [x] Build passes successfully

Additional notes:

```
# Full test suite: 195 pass, 0 fail
npm test

# New upgrade-specific integration tests:
# 1. Atomic deduction + balance + prestige verification
# 2. Duplicate upgrade rejection
# 3. Insufficient funds returns 400
# 4. Concurrent purchases — exactly 1 succeeds, balance never negative

# Test procedure: each test registers a studio via POST /api/auth/register,
# manipulates balance via direct DB where needed, then issues upgrade
# purchase requests through the authenticated HTTP API.
```

---

## 🌿 Target Branch

- [x] `ecsoc`
- [ ] `elusoc`

> **⚠️ Important:** Pull Requests opened against the `main` branch are automatically closed by repository automation. Please ensure your PR targets either the `ecsoc` or `elusoc` branch.

---

## 🏷 Labels

### ECSOC

- [x] `ECSOC2026`
- [x] `ECSoC26`

### ELUSOC

- [ ] `ELUSOC2026`

---

## ✅ Checklist

- [x] I have requested assignment before starting work.
- [x] My Pull Request targets the correct branch (`ecsoc` or `elusoc`).
- [x] I have linked the related issue.
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes locally.
- [x] My changes introduce no new warnings or errors.
- [x] I have updated documentation where necessary.
- [x] I have added screenshots for UI changes (if applicable).
- [x] If this is an ECSOC contribution, I have requested the `ECSoC26` label before merge.
