### PR TITLE
perf: add compound index on Movie schema for studioId + status queries

### DIFF
--- a/backend/src/models/Movie.js
+++ b/backend/src/models/Movie.js
@@ -112,6 +112,9 @@ const movieSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
+// Compound index: simulation queries filter by studioId + status (issue #398)
+movieSchema.index({ studioId: 1, status: 1 });
+
 movieSchema.virtual("totalGross").get(function () {
   return this.boxOffice;
 });


### PR DESCRIPTION
## 📄 Description

Add compound index `{ studioId: 1, status: 1 }` on the Movie schema to resolve weekly simulation queries in O(log n) index lookup time instead of full collection scans across all historical movies.

Simulation engines (`merchandiseEngine`, `streamingEngine`) and other endpoints (`movieController`, `merchController`) already filter queries by `studioId` + `status` — the only missing piece was the compound index declaration.

Follows the same index pattern already used by `MarketActor`, `MarketDirector`, and `MarketCrewTeam` in this codebase.

**Related Issue:** Closes #398

---

## 🚀 Open Source Program

- [x] ECSOC 2026
- [ ] ELUSOC 2026
- [ ] General Contribution

---

## 🛠 Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Refactoring
- [x] Performance Improvement
- [ ] UI/UX Improvement
- [ ] Breaking Change

---

## 📸 Screenshots (If Applicable)

N/A (Backend change — no UI impact)

---

## 🧪 Testing

- [x] Tested locally
- [x] Existing functionality verified
- [ ] No console errors (N/A — backend)
- [x] Build passes successfully

Additional notes:

```
All 191 existing tests pass with 0 failures.
The change is a single index declaration — no runtime logic altered.
```

---

## 🌿 Target Branch

- [x] `ecsoc`
- [ ] `elusoc`

> **⚠️ Important:** Pull Requests opened against the `main` branch are automatically closed by repository automation. Please ensure your PR targets either the `ecsoc` or `elusoc` branch.

---

## 🏷 Labels

If applicable, request the appropriate labels.

### ECSOC

- [x] `ECSOC2026`
- [x] `ECSoC26`

### ELUSOC

- [ ] `ELUSOC2026`

---

## ✅ Checklist

- [x] I have requested assignment before starting work.
- [x] My Pull Request targets the correct branch (`ecsoc` or `elusoc`).
- [x] I have linked the related issue.
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes locally.
- [x] My changes introduce no new warnings or errors.
- [x] I have updated documentation where necessary.
- [ ] I have added screenshots for UI changes (if applicable).
- [x] If this is an ECSOC contribution, I have requested the `ECSoC26` label before merge.
