### PR TITLE
test: add E2E test for rehiring owned actor (#360)

### DIFF
--- a/backend/tests/gameplay.api.test.js
+++ b/backend/tests/gameplay.api.test.js
@@ -25,12 +25,14 @@ let baseUrl;
 
 before(async () => {
   mongod = await MongoMemoryReplSet.create({
-    replSet: { count: 1 }
+    replSet: { count: 1 },
   });
-  let uri = mongod.getUri();
+
+  const uri = mongod.getUri();
   await mongoose.connect(uri);
 
   const { default: app } = await import("../src/app.js");
+
   await new Promise((resolve) => {
     server = app.listen(0, () => {
       baseUrl = `http://127.0.0.1:${server.address().port}`;
@@ -60,20 +62,28 @@ const registerStudio = async (id = Math.random().toString(36).substring(7)) => {
       studioName: `P1 Studios_${id}`,
     }),
   });
+
   return res.json(); // { success, token, user, studio }
 };
 
 const authGet = (path, token) =>
-  fetch(`${baseUrl}${path}`, { headers: { Authorization: `Bearer ${token}` } });
+  fetch(`${baseUrl}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
 
 const authPost = (path, token) =>
   fetch(`${baseUrl}${path}`, {
     method: "POST",
-    headers: { Authorization: `Bearer ${token}` },
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
   });
 
 test("e2e: register seeds a studio with 10,000,000 starting funds", async () => {
   const { token, studio } = await registerStudio();
+
   assert.ok(token, "registration returns an access token");
   assert.strictEqual(studio.money, 10000000);
 });
@@ -83,13 +93,21 @@ test("e2e: register -> browse actor market -> hire moves an actor to the owned r
 
   const marketRes = await authGet("/api/actors/", token);
   assert.strictEqual(marketRes.status, 200);
+
   const market = await marketRes.json();
+
   assert.strictEqual(market.success, true);
-  assert.ok(Array.isArray(market.actors) && market.actors.length > 0, "market returns actors");
+  assert.ok(
+    Array.isArray(market.actors) && market.actors.length > 0,
+    "market returns actors",
+  );
 
   const hireRes = await authPost("/api/actors/hire/0", token);
+
   assert.strictEqual(hireRes.status, 200);
+
   const hire = await hireRes.json();
+
   assert.strictEqual(hire.success, true);
   assert.ok(hire.actor, "the hired actor is returned");
   assert.ok(
@@ -98,7 +116,73 @@ test("e2e: register -> browse actor market -> hire moves an actor to the owned r
   );
 });
 
+/**
+ * NEW TEST FOR ISSUE #360
+ */
+test("e2e: rehiring an already owned actor is rejected", async () => {
+  const { token } = await registerStudio();
+
+  // Initial hire should succeed.
+  const firstHireRes = await authPost("/api/actors/hire/0", token);
+  assert.strictEqual(firstHireRes.status, 200);
+
+  const firstHire = await firstHireRes.json();
+  assert.strictEqual(firstHire.success, true);
+
+  const ownedBefore = firstHire.ownedActors.length;
+
+  // Attempt to hire the same actor again.
+  const secondHireRes = await authPost("/api/actors/hire/0", token);
+
+  // Duplicate hire should fail.
+  assert.notStrictEqual(
+    secondHireRes.status,
+    200,
+    "rehiring should not succeed",
+  );
+
+  const secondHire = await secondHireRes.json();
+
+  assert.strictEqual(secondHire.success, false);
+
+  // Verify an error message is returned.
+  assert.ok(
+    secondHire.message || secondHire.error,
+    "duplicate hire returns an error message",
+  );
+
+  // Verify the owned actor list remains unchanged if returned.
+  if (Array.isArray(secondHire.ownedActors)) {
+    assert.strictEqual(
+      secondHire.ownedActors.length,
+      ownedBefore,
+      "owned actor list should remain unchanged",
+    );
+  }
+
+  // Otherwise, fetch the owned roster and verify it still contains one actor.
+  else {
+    const ownedRes = await authGet("/api/actors/owned", token);
+
+    if (ownedRes.status === 200) {
+      const owned = await ownedRes.json();
+
+      const ownedActors =
+        owned.ownedActors ??
+        owned.actors ??
+        [];
+
+      assert.strictEqual(
+        ownedActors.length,
+        ownedBefore,
+        "owned actor list should remain unchanged",
+      );
+    }
+  }
+});
+
 test("e2e: gameplay endpoints reject unauthenticated access with 401", async () => {
   const res = await fetch(`${baseUrl}/api/actors/`);
+
   assert.strictEqual(res.status, 401);
 });


### PR DESCRIPTION
## Description

This PR adds an end-to-end gameplay API test to verify that an already owned actor cannot be hired again.

## Changes

- Added a test for rehiring an already owned actor.
- Verified the API returns the expected error status and message.
- Confirmed the owned actor list remains unchanged after the duplicate hire attempt.

## Testing

- Ran gameplay API tests.
- Confirmed the new test passes alongside the existing test suite.

Closes #360