### PR TITLE
test: improve authentication coverage for gameplay endpoints (#362)

### DIFF
--- a/backend/tests/gameplay.api.test.js
+++ b/backend/tests/gameplay.api.test.js
@@ -102,3 +102,22 @@ test("e2e: gameplay endpoints reject unauthenticated access with 401", async () 
   const res = await fetch(`${baseUrl}/api/actors/`);
   assert.strictEqual(res.status, 401);
 });
+test("e2e: gameplay endpoints reject malformed JWT tokens with 401", async () => {
+  const malformedToken = "malformed.jwt.token";
+
+  const marketRes = await authGet("/api/actors/", malformedToken);
+  assert.strictEqual(marketRes.status, 401);
+
+  const hireRes = await authPost("/api/actors/hire/0", malformedToken);
+  assert.strictEqual(hireRes.status, 401);
+});
+
+test("e2e: gameplay endpoints reject invalid bearer tokens with 401", async () => {
+  const invalidToken = "this-is-not-a-valid-jwt";
+
+  const marketRes = await authGet("/api/actors/", invalidToken);
+  assert.strictEqual(marketRes.status, 401);
+
+  const hireRes = await authPost("/api/actors/hire/0", invalidToken);
+  assert.strictEqual(hireRes.status, 401);
+});


### PR DESCRIPTION
## Description

This PR improves authentication test coverage for protected gameplay endpoints.

### Changes
- Added tests for malformed JWT tokens.
- Added tests for invalid bearer tokens.
- Verified protected gameplay endpoints consistently return `401 Unauthorized`.
- Confirmed protected resources are not accessible without valid authentication.

Closes #362