### PR TITLE
fix(auth): declare the missing Google sign-in state in Login and Register (Closes #327)

### DIFF
--- a/frontend/src/pages/auth/Login.jsx
+++ b/frontend/src/pages/auth/Login.jsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { useDispatch } from "react-redux";
 import api, { persistAuthSession } from "../../api/axios";
@@ -14,6 +15,28 @@ import { useGoogleLoginMutation } from "../../features/auth/authApi";
 const Login = () => {
   const navigate = useNavigate();
   const { loading, error, execute } = useAsyncAction();
+
+
+  // Local state for the two-step Google sign-in.
+  //
+  // A first-time Google user has no studio yet, so the backend answers
+  // { requiresStudio: true } rather than a session (authController.js:476). The
+  // component holds the credential and swaps the Google button for a studio-name
+  // form, then sends both back together.
+  //
+  // These declarations were missing entirely — the handlers and JSX referenced
+  // them without any being declared, and `requiresStudio is not defined` was
+  // just the first one the browser reached.
+  const dispatch = useDispatch();
+  const [googleLoginMutation, { isLoading }] = useGoogleLoginMutation();
+
+  const [requiresStudio, setRequiresStudio] = useState(false);
+  const [pendingToken, setPendingToken] = useState(null);
+  const [studioName, setStudioName] = useState("");
+
+  // useAsyncAction owns `error` for the email/password form; this is the
+  // separate message for the Google path, which doesn't run through it.
+  const [googleError, setError] = useState("");
 
   const { values, errors, touched, setValue, validate } = useFormValidation(
     { email: "", password: "" },

--- a/frontend/src/pages/auth/Register.jsx
+++ b/frontend/src/pages/auth/Register.jsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
 
 import api, { persistAuthSession } from "../../api/axios";
 import { useAsyncAction } from "../../hooks/useAsyncAction";
@@ -13,6 +15,28 @@ import { GoogleLogin } from '@react-oauth/google';
 const Register = () => {
   const navigate = useNavigate();
   const { loading, error, execute } = useAsyncAction();
+
+
+  // Local state for the two-step Google sign-in.
+  //
+  // A first-time Google user has no studio yet, so the backend answers
+  // { requiresStudio: true } rather than a session (authController.js:476). The
+  // component holds the credential and swaps the Google button for a studio-name
+  // form, then sends both back together.
+  //
+  // These declarations were missing entirely — the handlers and JSX referenced
+  // them without any being declared, and `requiresStudio is not defined` was
+  // just the first one the browser reached.
+  const dispatch = useDispatch();
+  const [googleLoginMutation, { isLoading }] = useGoogleLoginMutation();
+
+  const [requiresStudio, setRequiresStudio] = useState(false);
+  const [pendingToken, setPendingToken] = useState(null);
+  const [googleStudioName, setGoogleStudioName] = useState("");
+
+  // useAsyncAction owns `error` for the email/password form; this is the
+  // separate message for the Google path, which doesn't run through it.
+  const [googleError, setError] = useState("");
 
   const { values, errors, touched, setValue, validate } = useFormValidation(
     { username: "", email: "", password: "", studioName: "" },


### PR DESCRIPTION
Closes #327

## It wasn't one variable

`requiresStudio` is the first undefined identifier the browser reaches, not the only one. Neither `Login.jsx` nor `Register.jsx` had **a single `useState` declaration**, while both referenced:

```
requiresStudio    setRequiresStudio
pendingToken      setPendingToken
studioName        setStudioName        (googleStudioName in Register)
setError          dispatch
googleLoginMutation                    isLoading
```

Running ESLint's `no-undef` against the two files on `elusoc` @ cdfa23d:

```
53:25   'googleLoginMutation' is not defined
56:9    'setPendingToken' is not defined
57:9    'setRequiresStudio' is not defined
68:7    'setError' is not defined
75:25   'googleLoginMutation' is not defined
76:16   'pendingToken' is not defined
77:9    'studioName' is not defined
80:7    'dispatch' is not defined
91:13   'requiresStudio' is not defined
94:30   'setError' is not defined
102:24  'studioName' is not defined
103:34  'setStudioName' is not defined
105:27  'isLoading' is not defined
110:27  'isLoading' is not defined
```

`Register.jsx` was additionally missing its `useDispatch` import from `react-redux`.

## What the flow is meant to do

The intent is legible from the surrounding code and the backend. A first-time Google user has no studio yet, so `authController.js:476` answers `{ requiresStudio: true }` instead of a session. The component holds the credential, swaps the Google button for a studio-name form, and sends both back together.

Every declaration here is inferred from that usage: the two-step flow, the form binding, and the RTK Query hook shape — `useGoogleLoginMutation()` returns `[trigger, { isLoading }]`, which supplies both `googleLoginMutation` and `isLoading`.

The two files needed slightly different sets. `Register.jsx` already binds `studioName` through `useFormValidation` for its own registration form and uses a separate `googleStudioName` for the Google path, so its state block isn't a copy of `Login.jsx`'s.

## Verification, with one caveat worth stating plainly

`no-undef` reports **zero errors** on both files after the change, against the fourteen above before it.

**`npm run build` is not meaningful evidence here.** It passes both before and after — Vite doesn't resolve undefined identifiers at build time, which is exactly why this reached `elusoc` and only surfaces at runtime. I've confirmed the build still completes cleanly (2,462 modules transformed) so nothing regressed, but the lint result is what demonstrates the fix.

I could not exercise the live Google sign-in — it needs OAuth credentials and a running backend. The identifiers are now defined and the flow reads correctly against the backend contract, but since this restores a path that's currently broken for everyone, **a manual sign-in test before merge is worth the few minutes** rather than taking my inference for it.

## Note for anyone reproducing locally

`npm run build` failed for me initially with `Rolldown failed to resolve import "@react-oauth/google"` from `main.jsx`. That's a stale `node_modules`, not a missing declaration — the package is in `package.json` and a fresh `npm install` resolves it. Mentioning it because the error points at `main.jsx` and could easily be mistaken for a second bug.