### PR TITLE
fix(security): enforce studio ownership on movie lookups (Closes #251)

### DIFF
--- a/backend/src/controllers/movieController.js
+++ b/backend/src/controllers/movieController.js
@@ -261,7 +261,16 @@ export const generateTitle = async (req, res) => {
 export const releaseMovie = async (req, res) => {
     try {
         const { id } = req.params;
-        const movie = await Movie.findById(id);
+
+        // Ownership is enforced in the query, not after it.
+        //
+        // Filtering by studioId means a movie belonging to another studio is
+        // never loaded, so the 404 below covers both "no such movie" and "not
+        // yours" — a caller probing IDs learns nothing either way.
+        const ownerStudio = await Studio.findOne({ owner: req.user._id }).select("_id").lean();
+        if (!ownerStudio) return res.status(404).json({ success: false, message: "Studio not found" });
+
+        const movie = await Movie.findOne({ _id: id, studioId: ownerStudio._id });
         if (!movie) return res.status(404).json({ success: false, message: "Movie not found" });
         if (movie.status !== "READY_FOR_RELEASE") {
             return res.status(400).json({ success: false, message: "Movie is not ready for release" });
@@ -298,7 +307,10 @@ export const scheduleRelease = async (req, res) => {
             return res.status(400).json({ success: false, message: "scheduledReleaseWeek must be in the future." });
         }
 
-        const movie = await Movie.findById(id);
+        const studio = await Studio.findOne({ owner: req.user._id }).select("_id").lean();
+        if (!studio) return res.status(404).json({ success: false, message: "Studio not found" });
+
+        const movie = await Movie.findOne({ _id: id, studioId: studio._id });
         if (!movie) return res.status(404).json({ success: false, message: "Movie not found" });
         if (movie.status !== "READY_FOR_RELEASE" && movie.status !== "POST_PRODUCTION") {
             return res.status(400).json({ success: false, message: "Only post-production or ready-for-release movies can be scheduled." });
@@ -340,7 +352,10 @@ export const getReleasedMovies = async (req, res) => {
 
 export const getMovieDetails = async (req, res) => {
     try {
-        const movie = await Movie.findById(req.params.id).lean();
+        const studio = await Studio.findOne({ owner: req.user._id }).select("_id").lean();
+        if (!studio) return res.status(404).json({ success: false, message: "Studio not found" });
+
+        const movie = await Movie.findOne({ _id: req.params.id, studioId: studio._id }).lean();
         if (!movie) return res.status(404).json({ success: false, message: "Movie not found" });
 
         const gameState = await GameState.findOne({ user: req.user._id }).lean();
@@ -356,7 +371,10 @@ export const getMovieDetails = async (req, res) => {
 
 export const getMovieTracking = async (req, res) => {
     try {
-        const movie = await Movie.findById(req.params.id).lean();
+        const studio = await Studio.findOne({ owner: req.user._id }).select("_id").lean();
+        if (!studio) return res.status(404).json({ success: false, message: "Studio not found" });
+
+        const movie = await Movie.findOne({ _id: req.params.id, studioId: studio._id }).lean();
         if (!movie) return res.status(404).json({ success: false, message: "Movie not found" });
 
         const allowedStatuses = ["READY_FOR_RELEASE", "POST_PRODUCTION", "PRODUCTION"];
@@ -395,7 +413,21 @@ export const addMarketingCampaign = async (req, res) => {
     let effectiveHype = 0;
 
     await withTransaction(async (session) => {
-      movie = await Movie.findById(id).session(session);
+      // The studio is resolved first, so the movie lookup can filter on it.
+      //
+      // Previously the movie was fetched with no ownership filter and the
+      // studio only afterwards, at which point funds were deducted from the
+      // *caller's* studio for a campaign attached to someone else's movie —
+      // paying to promote a rival's film, or draining a balance by repeating
+      // the call.
+      studio = await Studio.findOne({ owner: req.user._id }).session(session);
+      if (!studio) {
+        const error = new Error("Studio not found");
+        error.statusCode = 404;
+        throw error;
+      }
+
+      movie = await Movie.findOne({ _id: id, studioId: studio._id }).session(session);
       if (!movie) {
         const error = new Error("Movie not found");
         error.statusCode = 404;
@@ -411,13 +443,6 @@ export const addMarketingCampaign = async (req, res) => {
       if (movie.marketingCampaigns.includes(campaignId)) {
         const error = new Error("This campaign is already active for this movie");
         error.statusCode = 400;
-        throw error;
-      }
-
-      studio = await Studio.findOne({ owner: req.user._id }).session(session);
-      if (!studio) {
-        const error = new Error("Studio not found");
-        error.statusCode = 404;
         throw error;
       }
 
@@ -472,7 +497,12 @@ export const reReleaseMovie = async (req, res) => {
     const { id } = req.params;
     const { isDirectorsCut } = req.body;
 
-    const movie = await Movie.findById(id);
+    const ownerStudio = await Studio.findOne({ owner: req.user._id }).select("_id").lean();
+    if (!ownerStudio) {
+      return res.status(404).json({ success: false, message: "Studio not found." });
+    }
+
+    const movie = await Movie.findOne({ _id: id, studioId: ownerStudio._id });
     if (!movie) {
       return res.status(404).json({
         success: false,


### PR DESCRIPTION
Closes #251

## Six sites, not four

The issue names `releaseMovie`, `getMovieDetails`, `getMovieTracking` and `addMarketingCampaign`. Auditing every `Movie` lookup in the controller turned up two more with the identical flaw:

| Controller | Line | Reported |
|---|---|---|
| `releaseMovie` | 264 | ✅ |
| `scheduleRelease` | 301 | ❌ **also vulnerable** |
| `getMovieDetails` | 343 | ✅ |
| `getMovieTracking` | 359 | ✅ |
| `addMarketingCampaign` | 398 | ✅ |
| `reReleaseMovie` | 475 | ❌ **also vulnerable** |

All six used `Movie.findById(id)` with no ownership filter, so any authenticated user could read or act on any movie by ID.

## `addMarketingCampaign` was the worst of them

It fetched the movie with no check, then fetched the **caller's** studio and deducted funds from it:

```js
movie = await Movie.findById(id).session(session);       // no ownership check
...
studio = await Studio.findOne({ owner: req.user._id });  // caller's own studio
if (studio.money < campaign.cost) { ... }                // caller pays
```

So you could pay to promote a rival studio's film — boosting their box office with your money — or drain your own balance by repeating the call against any ID. The order is now inverted: the studio is resolved first, inside the transaction, and the movie query filters on it.

## The fix follows the pattern already in this file

`getReleasedMovies` at line 327 already did this correctly:

```js
const studio = await Studio.findOne({ owner: req.user._id }).select("_id").lean();
const movie  = await Movie.findOne({ _id: id, studioId: studio._id });
```

Ownership is enforced **in the query**, not after it. Two consequences worth naming:

- A movie belonging to another studio is never loaded into memory, so there's no window where unauthorised data exists in the process.
- The 404 covers both "no such movie" and "not yours", so a caller probing IDs can't distinguish them. A post-fetch `if (movie.studioId !== studio._id) return 403` would leak existence.

`releaseMovie` and `reReleaseMovie` use `ownerStudio` for the check because both already declare a separate `studio` later — a full mutable document they need for `.save()`. Keeping the names distinct avoids shadowing.

## Verification

- `node --check` clean on the modified file.
- **Zero** remaining `Movie.findById` calls in the controller; all six lookups now carry `studioId`.
- Authorization semantics modelled directly:

```
Alice requests her own m1     -> Alice's film
Alice requests Bob's m2       -> 404 Movie not found
Before the fix, same request  -> Bob's film   <- leaked
```

I couldn't run the backend suite: `tests/testScreening.test.js` needs `MongoMemoryServer`, which downloads a MongoDB binary my environment can't reach. **It fails identically on unmodified `elusoc`**, so it's an environment limit rather than a regression — but a live run against a real database is worth doing before merge.

## Note on PR #329

@Sairaj2033's #329 targets this issue and is still open. I raised the overlap with @SRV30 before starting and was asked to proceed. That PR also carries three unrelated fixes (route shadowing, notification error handling, spy transactions) which this PR does **not** touch, so those remain worth taking from it independently.