### PR TITLE
fix(simulation): write awards and merchandise notifications to the Notification collection (Closes #224)

### DIFF
--- a/backend/src/services/simulation/engines/awardsEngine.js
+++ b/backend/src/services/simulation/engines/awardsEngine.js
@@ -1,5 +1,6 @@
 import Movie from "../../../models/Movie.js";
 import Studio from "../../../models/Studio.js";
+import Notification from "../../../models/Notification.js";
 
 // Awards run annually at Week 52.
 export const processAnnualAwards = async (gameState, studio) => {
@@ -55,17 +56,26 @@ export const processAnnualAwards = async (gameState, studio) => {
             studio.prestige += 500;
         }
 
-        if (won) {
-            gameState.notifications.push({
-                message: `🏆 Annual Awards! Your studio won: ${messages.join(", ")}! You gained massive prestige!`,
-                createdAt: new Date()
-            });
-        } else {
-            gameState.notifications.push({
-                message: `🏆 Annual Awards Year ${year}: Best Picture goes to '${bestPicture.title}'.`,
-                createdAt: new Date()
-            });
-        }
+        // Notifications are their own collection, not a field on gameState.
+        //
+        // This pushed to `gameState.notifications`, which the GameState schema
+        // does not declare — so it was always undefined and the push threw
+        // `Cannot read properties of undefined (reading 'push')`, failing the
+        // whole weekly tick with a 500 and rolling back the transaction. Since
+        // awards run on week 52, 104 and so on, the simulation became
+        // impossible to advance past the first year end.
+        //
+        // Every other writer in the codebase uses Notification.create with a
+        // gameStateId, which is what the client reads from; anything pushed
+        // onto gameState would not have been displayed even had it persisted.
+        await Notification.create({
+            gameStateId: gameState._id,
+            type: "AWARDS",
+            message: won
+                ? `🏆 Annual Awards! Your studio won: ${messages.join(", ")}! You gained massive prestige!`
+                : `🏆 Annual Awards Year ${year}: Best Picture goes to '${bestPicture.title}'.`,
+            createdAt: new Date(),
+        });
     }
 };
 

--- a/backend/src/services/simulation/engines/merchandiseEngine.js
+++ b/backend/src/services/simulation/engines/merchandiseEngine.js
@@ -1,6 +1,7 @@
 import Movie from "../../../models/Movie.js";
 import Studio from "../../../models/Studio.js";
 import { SOUNDTRACK_TIERS } from "../../../constants/soundtrackTiers.js";
+import Notification from "../../../models/Notification.js";
 
 // Merchandise sales generated based on movie's hype and existing popularity.
 // Only movies with a threshold of success or hype will start generating sales.
@@ -78,11 +79,16 @@ export const processMerchandiseSales = async (gameState, studio) => {
             reason: "Weekly Merchandise & Licensing Sales"
         });
 
-        // We could also add a notification if revenue is high
+        // Same defect as awardsEngine: gameState.notifications is not a field
+        // on the schema, so this push threw on undefined. It bites harder here
+        // because merchandise runs every week rather than annually — any studio
+        // clearing ₹1M in a week failed its tick entirely.
         if (weeklyMerchRevenue > 1000000) {
-            gameState.notifications.push({
+            await Notification.create({
+                gameStateId: gameState._id,
+                type: "MERCHANDISE",
                 message: `Merchandise & Licensing generated ₹${weeklyMerchRevenue.toLocaleString()} this week!`,
-                createdAt: new Date()
+                createdAt: new Date(),
             });
         }
     }


### PR DESCRIPTION
Closes #224

## The cause isn't an initialisation order problem

The issue suggests the array should be initialised before `.push()` is called. It can't be — **`notifications` is not a field on the GameState schema at all.** `backend/src/models/GameState.js` doesn't declare it, so `gameState.notifications` is `undefined` on every document, permanently.

Initialising it earlier would stop the crash and then silently do nothing useful: notifications live in their own collection (`backend/src/models/Notification.js`), which is what the client reads. Anything pushed onto `gameState` would never have been displayed even if it had persisted.

Reproduced directly:

```
BEFORE  TypeError: Cannot read properties of undefined (reading 'push')
AFTER   created 1 notification -> {"gameStateId":"gs1","type":"AWARDS","message":"🏆 ..."}
```

## What the rest of the codebase does

`Notification.create({ gameStateId, type, message })` — the pattern used by `testScreeningController`, `contractController` and others. These two engines were the only writers doing something different, which is why the schema mismatch went unnoticed.

Also worth noting the surrounding code already knew this was fragile territory: line 43 of `awardsEngine` guards `gameState.pastAwards = gameState.pastAwards || []` — a real schema field — while the line below pushes to `notifications` with no guard and no field behind it.

## A second occurrence, unreported and more damaging

`merchandiseEngine.js:83` has the identical bug:

```js
if (weeklyMerchRevenue > 1000000) {
    gameState.notifications.push({ ... });   // same undefined
}
```

**This one runs every week**, not annually. Any studio clearing ₹1M in merchandise in a single week crashes its tick — so in practice it fires far more often than the awards path, and would have surfaced as apparently random simulation failures rather than a reliable week-52 crash.

Both are fixed here. Fixing only the reported one would have left the weekly failure in place and made #224 look resolved.

## Why this matters beyond one 500

Both engines run inside `withTransaction` from `simulationController`. The throw rolls back the entire weekly tick — box office, contracts, finances, everything — so the game cannot advance past the failure at all, not merely lose its notification. For awards that means the simulation is stuck at week 52 permanently.

## Verification

- `node --check` clean on both files.
- `grep -rn "gameState.notifications.push" backend/src/` returns nothing — both occurrences replaced.
- The `type` field is set (`"AWARDS"` / `"MERCHANDISE"`) rather than relying on the schema's `"SYSTEM"` default, so these are filterable client-side.
- Both enclosing functions were already `async`, so the added `await` needed no signature change.

I could not run the simulation end to end: the backend suite needs `MongoMemoryServer`, which downloads a MongoDB binary my environment can't reach, and it fails identically on unmodified `elusoc`. **Worth triggering `POST /api/simulation/next-week` at week 52 against a real database before merge** — the fix is small and the reasoning is verified, but this restores a broken path and deserves a live confirmation.

## Follow-up worth considering

Nothing prevents the next contributor writing `gameState.someField.push(...)` against a field that doesn't exist — Mongoose won't complain until runtime. If `GameState` were declared with `strict: "throw"`, assignments to undeclared paths would fail loudly at development time rather than in a production transaction. Happy to open that separately if it's of interest.