### PR TITLE
fix: mount boxOfficeRoutes so Box Office Analytics resolves (#429)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -43,6 +43,7 @@ import testScreeningRoutes from "./routes/testScreeningRoutes.js";
 import recordsRoutes from "./routes/recordsRoutes.js";
 import insuranceRoutes from "./routes/insuranceRoutes.js";
 import territoryRoutes from "./routes/territoryRoutes.js";
+import boxOfficeRoutes from "./routes/boxOfficeRoutes.js";
 
 
 const app = express();
@@ -137,6 +138,7 @@ app.use("/api/movies", apiRateLimiter, testScreeningRoutes);
 app.use("/api/records", apiRateLimiter, recordsRoutes);
 app.use("/api/insurance", apiRateLimiter, insuranceRoutes);
 app.use("/api/territories", apiRateLimiter, territoryRoutes);
+app.use("/api/box-office", apiRateLimiter, boxOfficeRoutes);
 
 
 app.use((req, res) => {


### PR DESCRIPTION
## Description

Fixes #429 — the Box Office Analytics feature was fully unreachable because its routes were never registered.

`backend/src/app.js` imported and mounted ~46 route modules but never imported/mounted `boxOfficeRoutes`, so every `/api/box-office/*` request fell through to the catch-all (`app.js:142`) and returned `404 ROUTE_NOT_FOUND`. The frontend page (`frontend/src/pages/movies/BoxOfficeAnalytics.jsx`) calls `/api/box-office/analytics/:movieId` and `/api/box-office/clash-analytics/:movieId`, so the whole page always errored.

## Change
- Import `boxOfficeRoutes` and mount it at `/api/box-office` with `apiRateLimiter`, matching every sibling route.
- The route file already defines `/analytics/:movieId`, `/clash-analytics/:movieId`, and `/regional-summary`, so those now resolve.

## Testing
- `node --check backend/src/app.js` passes.
- The `/api/box-office/*` paths now route to `boxOfficeController` instead of the 404 catch-all.

## Checklist
- [x] I am an ECSoC'26 contributor
- [x] This is an assigned issue

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._
