### PR TITLE
fix: remove undefined campaign reference so reReleaseMovie stops 500ing (#430)

### DIFF
--- a/backend/src/controllers/movieController.js
+++ b/backend/src/controllers/movieController.js
@@ -529,11 +529,6 @@ export const reReleaseMovie = async (req, res) => {
       });
     }
   
-    const script = findScriptById(gameState, movie.scriptId);
-    
-    const genres = script?.genres || [];
-    const effectiveHype = getEffectiveHypeBoost(campaign, genres);
-
     // Calculate re-release box office (decaying factor of original)
     const decayFactor = isDirectorsCut ? 0.35 : 0.2;
     const qualityBoost = isDirectorsCut ? 10 : 0;


### PR DESCRIPTION
## Description

Fixes #430 — `reReleaseMovie` (`backend/src/controllers/movieController.js`) always threw and returned 500.

It computed:
```js
const genres = script?.genres || [];
const effectiveHype = getEffectiveHypeBoost(campaign, genres);
```
but `campaign` is never defined in `reReleaseMovie` (it only exists as a local in `addMarketingCampaign`), so every call threw `ReferenceError: campaign is not defined`, which the catch turned into `500 "Failed to re-release movie."` The whole re-release feature was broken.

## Change
`effectiveHype` (and the `script`/`genres` locals feeding it) were never used later in the function — they were stray copy-paste. Removed the dead block, so re-release proceeds to its actual box-office calculation.

## Testing
- `node --check` passes.
- Confirmed `effectiveHype`/`genres`/`script` are not referenced anywhere else in `reReleaseMovie`.

## Checklist
- [x] I am an ECSoC'26 contributor
- [x] This is an assigned issue

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._
