### PR TITLE
fix: stop re-validating marketing budget after deducting it (false 500 + money loss) (#431)

### DIFF
--- a/backend/src/controllers/movieController.js
+++ b/backend/src/controllers/movieController.js
@@ -27,7 +27,6 @@ import {
   validateLeadActor,
   validateSupportingActors,
   validateCrewTeam,
-  validateMarketingBudget,
   findScriptById,
   ValidationError,
 } from "../services/movie/movieValidationService.js";
@@ -93,9 +92,6 @@ export const createMovie = async (req, res) => {
       return res.status(400).json({ success: false, message: "Insufficient funds for marketing" });
     }
     studio.money = updatedStudio.money;
-
-    // Validate Studio Money for Marketing Budget (in-memory guard for downstream logic)
-    validateMarketingBudget(studio, marketingBudget, marketingCampaignIds);
 
     // Soundtrack selection
     const soundtrackTierId = soundtrackTier || "PUBLIC_DOMAIN";


### PR DESCRIPTION
## Description

Fixes #431 — a valid `createMovie` request can falsely fail with a 500 and permanently lose the marketing money.

`backend/src/controllers/movieController.js` deducts the player's marketing share atomically:
```js
const updatedStudio = await Studio.findOneAndUpdate(
  { _id: studio._id, money: { $gte: playerMarketingBudget } },
  { $inc: { money: -playerMarketingBudget } }, { returnDocument: "after" });
studio.money = updatedStudio.money;                 // now decremented
validateMarketingBudget(studio, marketingBudget, marketingCampaignIds);  // re-checks AFTER deduction
```
`validateMarketingBudget` throws when `studio.money < marketingBudget` — but `studio.money` was just reduced by the same budget. With co-producer `share = 0` this trips whenever `money < 2 × marketingBudget` (the common case). The `ValidationError` is returned as a raw **500**, and because the deduction isn't wrapped in a transaction, the money is gone and no movie is created.

## Change
The atomic `{ money: { $gte: playerMarketingBudget } }` guard already enforces funds, so the post-deduction `validateMarketingBudget` call is redundant and wrong. Removed it (and its now-unused import). `validateMarketingBudget` only performed that money check (`movieValidationService.js:69-75`), so nothing else is lost.

## Testing
- `node --check` passes.
- Verified `validateMarketingBudget` does only the money comparison, and is no longer referenced elsewhere in the controller.

## Checklist
- [x] I am an ECSoC'26 contributor
- [x] This is an assigned issue

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._
