### PR TITLE
fix: charge Studio.money for contract buyouts (they were free) (#432)

### DIFF
--- a/backend/src/controllers/contractController.js
+++ b/backend/src/controllers/contractController.js
@@ -1,5 +1,6 @@
 import GameState from "../models/GameState.js";
 import Notification from "../models/Notification.js";
+import Studio from "../models/Studio.js";
 
 const findGameState = async (userId) => GameState.findOne({ user: userId });
 
@@ -270,18 +271,26 @@ export const buyoutContract = async (req, res) => {
     const contract = gameState.pendingContracts[contractIndex];
     const penalty = Math.round((contract.offer?.baseSalary || 100000) * 1.5);
 
-    if (gameState.money < penalty) {
+    // Studio money lives on the Studio document, not on GameState. Charge it
+    // atomically so the penalty is actually deducted (and can't go negative
+    // under concurrent requests). Previously this read/wrote gameState.money,
+    // which is undefined, so the funds check never fired and buyouts were free.
+    const updatedStudio = await Studio.findOneAndUpdate(
+      { owner: req.user._id, money: { $gte: penalty } },
+      { $inc: { money: -penalty } },
+      { returnDocument: "after" }
+    );
+    if (!updatedStudio) {
       return res.status(400).json({ success: false, message: "Insufficient funds for buyout penalty" });
     }
 
-    gameState.money -= penalty;
     gameState.pendingContracts[contractIndex].status = "TERMINATED";
     await gameState.save();
 
     return res.status(200).json({
       success: true,
       message: "Contract terminated successfully",
-      data: { penaltyPaid: penalty },
+      data: { penaltyPaid: penalty, money: updatedStudio.money },
     });
   } catch (error) {
     console.error("Error buying out contract:", error);


### PR DESCRIPTION
## Description

Fixes #432 — contract buyouts were free.

`buyoutContract` (`backend/src/controllers/contractController.js`) read and wrote `gameState.money`:
```js
if (gameState.money < penalty) { ... }   // gameState has no top-level `money`
gameState.money -= penalty;              // undefined - penalty = NaN, non-schema field
```
Studio balance lives on `Studio.money` (`models/Studio.js`); `GameState` has no top-level `money`. So `gameState.money` is `undefined`: the insufficient-funds check never fired (`undefined < penalty` is `false`), and the deduction wrote `NaN` to a field that isn't persisted. The penalty was never actually charged.

## Change
Charge `Studio.money` **atomically** with `findOneAndUpdate({ owner, money: { $gte: penalty } }, { $inc: { money: -penalty } })` — the same race-safe pattern `createMovie` uses — returning 400 when funds are insufficient and reporting the updated balance.

(`renegotiateContract` doesn't touch money, so it's unaffected.)

## Testing
- `node --check` passes.
- Confirmed `Studio.money` is the balance field and `GameState` has no top-level `money`.

## Checklist
- [x] I am an ECSoC'26 contributor
- [x] This is an assigned issue

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._
