### PR TITLE
fix: regional box-office summary queries by studioId (was always 0) (#433)

### DIFF
--- a/backend/src/controllers/boxOfficeController.js
+++ b/backend/src/controllers/boxOfficeController.js
@@ -6,6 +6,7 @@
  */
 
 import Movie from "../models/Movie.js";
+import Studio from "../models/Studio.js";
 import { generateBoxOfficeTelemetry, calculateRegionalBreakdown, computeClashImpactSummary } from "../utils/boxOfficeAnalytics.js";
 
 /**
@@ -69,8 +70,14 @@ export const getBoxOfficeClashAnalytics = async (req, res, next) => {
  */
 export const getRegionalSummary = async (req, res, next) => {
   try {
-    const movies = await Movie.find({ userId: req.user._id, status: "RELEASED" });
-    
+    // Movies key off studioId, not userId — resolve the caller's studio first.
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({ success: false, message: "Studio not found" });
+    }
+
+    const movies = await Movie.find({ studioId: studio._id, status: "RELEASED" });
+
     let globalNorthAmerica = 0;
     let globalEurope = 0;
     let globalAsiaPacific = 0;


### PR DESCRIPTION
## Description

Fixes #433 — the regional box-office summary always returned zeros.

`getRegionalSummary` (`backend/src/controllers/boxOfficeController.js`) filtered:
```js
const movies = await Movie.find({ userId: req.user._id, status: "RELEASED" });
```
`Movie` has no `userId` field — it keys off `studioId` (`models/Movie.js`, and `getReleasedMovies` queries by `studioId`). So this matched nothing and every total, including `totalReleasedMovies`, was `0`.

## Change
Resolve the caller's studio (`Studio.findOne({ owner: req.user._id })`, 404 if none) and query `{ studioId: studio._id, status: "RELEASED" }`.

## Testing
- `node --check` passes.
- Matches how `getReleasedMovies` resolves and queries movies.

## Checklist
- [x] I am an ECSoC'26 contributor
- [x] This is an assigned issue

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._
