### PR TITLE
fix: upgrade postcss to 8.5.18 (GHSA-r28c-9q8g-f849)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3001,9 +3001,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,5 +32,8 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.8.0",
     "vite": "^8.0.12"
+  },
+  "overrides": {
+    "postcss": "8.5.18"
   }
 }


### PR DESCRIPTION
## Summary
Upgrade postcss from 8.5.15 to 8.5.18 to fix GHSA-r28c-9q8g-f849.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | GHSA-r28c-9q8g-f849 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `GHSA-r28c-9q8g-f849` |
| **File** | `frontend/package-lock.json` (dependency: `postcss`) |
| **Assessment** | Present in dependency tree, not confirmed reachable |

**Description**: PostCSS: Path Traversal in Previous Source Map Auto-Loading (sourceMappingURL) leads to Arbitrary .map File Disclosure

## Changes
- `frontend/package.json`
- `frontend/package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
