### PR TITLE
fix: undefined CAMPAIGN_COST throws 500 on /api/awards-campaign/lobby

### DIFF
--- a/backend/src/controllers/awardsCampaignController.js
+++ b/backend/src/controllers/awardsCampaignController.js
@@ -20,7 +20,7 @@ export const startAwardsCampaign = async (req, res) => {
       return res.status(404).json({ success: false, message: "Studio not found" });
     }
 
-    if (studio.money < CAMPAIGN_COST) {
+    if (studio.money < AWARDS_CAMPAIGN_COST) {
       return res.status(400).json({ success: false, message: "Insufficient funds for an awards campaign" });
     }
 


### PR DESCRIPTION
Closes #472

### Problem
`awardsCampaignController.js` checked `if (studio.money < CAMPAIGN_COST)`, but `CAMPAIGN_COST` is never defined or imported — the imported constant is `AWARDS_CAMPAIGN_COST`. So `POST /api/awards-campaign/lobby` threw `ReferenceError: CAMPAIGN_COST is not defined` → caught → **500** on every call, and the feature could never succeed.

### Fix
Use `AWARDS_CAMPAIGN_COST` (already imported and used for the deduction a few lines below).

### Testing
- `node --check` on the controller.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._