### PR TITLE
fix: studio money moved via non-existent balance/lifetimeEarnings fields

### DIFF
--- a/backend/src/controllers/awardsController.js
+++ b/backend/src/controllers/awardsController.js
@@ -9,7 +9,7 @@ export const launchAwardsCampaign = async (req, res) => {
     const studioId = req.user.studioId || req.user._id;
 
     const studio = await Studio.findById(studioId);
-    if (!studio || studio.balance < campaignBudget) {
+    if (!studio || studio.money < campaignBudget) {
       return res.status(400).json({ message: "Insufficient studio funds for FYC campaign" });
     }
 
@@ -29,7 +29,7 @@ export const launchAwardsCampaign = async (req, res) => {
       voterSentimentScore: initialSentiment,
     });
 
-    await Studio.findByIdAndUpdate(studioId, { $inc: { balance: -campaignBudget } });
+    await Studio.findByIdAndUpdate(studioId, { $inc: { money: -campaignBudget } });
 
     return res.status(201).json({ success: true, campaign });
   } catch (error) {

--- a/backend/src/controllers/merchandiseController.js
+++ b/backend/src/controllers/merchandiseController.js
@@ -47,7 +47,7 @@ export const createMerchandiseDeal = async (req, res) => {
 
     // Credit advance royalty to studio
     await Studio.findByIdAndUpdate(studioId, {
-      $inc: { balance: valuation.advanceRoyalty, lifetimeEarnings: valuation.advanceRoyalty },
+      $inc: { money: valuation.advanceRoyalty },
     });
 
     return res.status(201).json({ success: true, deal });

--- a/backend/src/services/merchandiseEngine.js
+++ b/backend/src/services/merchandiseEngine.js
@@ -72,9 +72,9 @@ export async function processWeeklyMerchandiseSales() {
 
       await deal.save();
 
-      // Add earnings to studio balance
+      // Add earnings to studio money
       await Studio.findByIdAndUpdate(deal.studioId, {
-        $inc: { balance: studioRoyaltyCut, lifetimeEarnings: studioRoyaltyCut },
+        $inc: { money: studioRoyaltyCut },
       });
 
       totalProcessedRevenue += studioRoyaltyCut;


### PR DESCRIPTION
Closes #473

### Problem
The Studio schema tracks funds in `money`. Top-level `balance` doesn’t exist (it only appears nested inside `financialHistory[]`), and `lifetimeEarnings` doesn’t exist at all. So:
- `awardsController.js:12` — `studio.balance < campaignBudget` reads `undefined` → the funds check is inert (always false).
- `awardsController.js:32`, `merchandiseController.js:50`, `merchandiseEngine.js:77` — `$inc: { balance, lifetimeEarnings }` on unknown paths is silently stripped by Mongoose strict mode, so `money` never changes.

Result: merchandise royalties are never credited, and the FYC campaign cost is never charged. `merchandiseEngine.processWeeklyMerchandiseSales` is reachable directly via `POST /api/merchandise/process-weekly`, so the royalty bug is independently triggerable.

### Fix
Use `money` for the funds check and for all three `$inc` operations (dropping the non-existent `lifetimeEarnings`).

### Testing
- `node --check` on all three files.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._