### PR TITLE
fix: req.user.studioId is always undefined — territory/crisis crash, syndication bonus lost

### DIFF
--- a/backend/src/controllers/crisisController.js
+++ b/backend/src/controllers/crisisController.js
@@ -4,7 +4,11 @@ import { evaluateCrisisResolution } from "../services/simulation/engines/crisisE
 
 export const getActiveCrises = async (req, res, next) => {
   try {
-    const crises = await PRCrisis.find({ studioId: req.user.studioId, status: "ACTIVE" });
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({ success: false, message: "Studio not found" });
+    }
+    const crises = await PRCrisis.find({ studioId: studio._id, status: "ACTIVE" });
     return res.status(200).json({ success: true, data: crises });
   } catch (error) {
     next(error);
@@ -15,14 +19,18 @@ export const resolveCrisis = async (req, res, next) => {
   try {
     const { crisisId, strategy } = req.body;
 
-    const crisis = await PRCrisis.findOne({ _id: crisisId, studioId: req.user.studioId });
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({ success: false, message: "Studio not found" });
+    }
+
+    const crisis = await PRCrisis.findOne({ _id: crisisId, studioId: studio._id });
     if (!crisis) {
       return res.status(404).json({ success: false, message: "Crisis not found" });
     }
 
     const resolution = evaluateCrisisResolution(crisis, strategy);
 
-    const studio = await Studio.findById(req.user.studioId);
     if (studio.money < resolution.cost) {
       return res.status(400).json({ success: false, message: "Insufficient studio funds for selected PR strategy" });
     }

--- a/backend/src/controllers/syndicationController.js
+++ b/backend/src/controllers/syndicationController.js
@@ -5,7 +5,11 @@ import { calculateSyndicationValuation } from "../services/simulation/engines/sy
 
 export const getStudioSyndicationDeals = async (req, res, next) => {
   try {
-    const deals = await SyndicationDeal.find({ studioId: req.user.studioId }).populate("movieId", "title posterUrl boxOffice");
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({ success: false, message: "Studio not found" });
+    }
+    const deals = await SyndicationDeal.find({ studioId: studio._id }).populate("movieId", "title posterUrl boxOffice");
     return res.status(200).json({ success: true, data: deals });
   } catch (error) {
     next(error);
@@ -36,8 +40,13 @@ export const createSyndicationDeal = async (req, res, next) => {
 
     const valuation = calculateSyndicationValuation(movie);
 
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({ success: false, message: "Studio not found" });
+    }
+
     const deal = await SyndicationDeal.create({
-      studioId: req.user.studioId,
+      studioId: studio._id,
       movieId,
       networkName,
       dealType,
@@ -49,7 +58,7 @@ export const createSyndicationDeal = async (req, res, next) => {
     });
 
     // Credit upfront bonus to studio money
-    await Studio.findByIdAndUpdate(req.user.studioId, {
+    await Studio.findByIdAndUpdate(studio._id, {
       $inc: { money: valuation.upfrontBonus },
     });
 

--- a/backend/src/controllers/territoryController.js
+++ b/backend/src/controllers/territoryController.js
@@ -5,7 +5,11 @@ import { calculateTerritoryDealOffer } from "../services/simulation/engines/terr
 
 export const getStudioTerritoryDeals = async (req, res, next) => {
   try {
-    const deals = await TerritoryLicensing.find({ studioId: req.user.studioId }).populate("movieId", "title posterUrl");
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({ success: false, message: "Studio not found" });
+    }
+    const deals = await TerritoryLicensing.find({ studioId: studio._id }).populate("movieId", "title posterUrl");
     return res.status(200).json({ success: true, data: deals });
   } catch (error) {
     next(error);
@@ -37,7 +41,10 @@ export const signTerritoryDeal = async (req, res, next) => {
 
     const offer = calculateTerritoryDealOffer(movie, region, dealType);
 
-    const studio = await Studio.findById(req.user.studioId);
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({ success: false, message: "Studio not found" });
+    }
     if (studio.money < offer.localizationCost) {
       return res.status(400).json({ success: false, message: "Insufficient funds for territory dubbing & localization" });
     }
@@ -47,7 +54,7 @@ export const signTerritoryDeal = async (req, res, next) => {
     await studio.save();
 
     const deal = await TerritoryLicensing.create({
-      studioId: req.user.studioId,
+      studioId: studio._id,
       movieId,
       region,
       dealType,


### PR DESCRIPTION
Closes #471

### Problem
The `User` model has no `studioId` field — the relation is `studio`, and `protect` sets `req.user` to the `User` document. So every `req.user.studioId` is `undefined`:
- **territory** `signTerritoryDeal` / **crisis** `resolveCrisis`: `Studio.findById(undefined)` → `null` → `studio.money` throws → **500 on every call**.
- **syndication** `createSyndicationDeal`: the deal is created, but `Studio.findByIdAndUpdate(undefined, { $inc: { money } })` matches nothing → **the upfront bonus is never credited**.
- The list endpoints query `{ studioId: undefined }` → always empty.

### Fix
Resolve the studio via `Studio.findOne({ owner: req.user._id })` in each handler (with a not-found guard) and use `studio._id` for the queries, creates, and updates — the pattern the working controllers already use.

Scope note: this PR covers `territoryController`, `crisisController`, and `syndicationController`. The `awards`/`merchandise` controllers share the same `req.user.studioId` issue but are also affected by the separate money-field bug (#473 → PR #491) and touch the same lines, so I kept them out of this PR to avoid conflicting edits — happy to fold the studio-resolution fix into whichever of the two lands first.

### Testing
- `node --check` on all three controllers; no `req.user.studioId` references remain in them.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._