### PR TITLE
feat: add streaming network catalog hub and platform directory

### DIFF
--- a/backend/src/controllers/streamingController.js
+++ b/backend/src/controllers/streamingController.js
@@ -10,7 +10,7 @@ export const getPlatforms = async (req, res) => {
     const gameState = await GameState.findOne({ user: req.user._id })
       .populate({
           path: "streamingPlatforms.exclusiveMovies",
-          select: "title quality hype"
+          select: "title quality hype verdict profit roi boxOffice releaseWeek"
       });
 
     if (!gameState) {
@@ -18,6 +18,60 @@ export const getPlatforms = async (req, res) => {
     }
 
     res.status(200).json({ success: true, platforms: gameState.streamingPlatforms || [] });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+// Get aggregated streaming catalog across platforms
+export const getStreamingCatalog = async (req, res) => {
+  try {
+    const gameState = await GameState.findOne({ user: req.user._id })
+      .populate({
+        path: "streamingPlatforms.exclusiveMovies",
+        select: "title quality hype verdict profit roi boxOffice releaseWeek releaseType poster"
+      });
+
+    if (!gameState) {
+      return res.status(404).json({ success: false, message: "Game state not found" });
+    }
+
+    const { platformId, search } = req.query;
+
+    let allMovies = [];
+    const platforms = gameState.streamingPlatforms || [];
+
+    platforms.forEach((plat) => {
+      if (!platformId || plat.id === platformId) {
+        (plat.exclusiveMovies || []).forEach((mov) => {
+          allMovies.push({
+            ...mov.toObject(),
+            platformId: plat.id,
+            platformName: plat.name,
+            platformPopularity: plat.popularity,
+          });
+        });
+      }
+    });
+
+    if (search && search.trim()) {
+      const q = search.trim().toLowerCase();
+      allMovies = allMovies.filter((m) => m.title && m.title.toLowerCase().includes(q));
+    }
+
+    res.status(200).json({
+      success: true,
+      count: allMovies.length,
+      movies: allMovies,
+      platforms: platforms.map(p => ({
+        id: p.id,
+        name: p.name,
+        subscribers: p.subscribers,
+        popularity: p.popularity,
+        contentBudget: p.contentBudget,
+        exclusiveCount: p.exclusiveMovies ? p.exclusiveMovies.length : 0,
+      })),
+    });
   } catch (error) {
     res.status(500).json({ success: false, message: error.message });
   }
@@ -56,7 +110,6 @@ export const getStreamingStrategy = async (req, res) => {
     res.status(500).json({ success: false, message: error.message });
   }
 };
-
 
 // Accept a streaming deal for a movie
 export const acceptStreamingDeal = async (req, res) => {

--- a/backend/src/routes/streamingRoutes.js
+++ b/backend/src/routes/streamingRoutes.js
@@ -1,9 +1,14 @@
 import express from "express";
 import { protect } from "../middleware/authMiddleware.js";
 import { validate } from "../middleware/validationMiddleware.js";
-import { acceptStreamingDealSchema, streamingStrategyParamsSchema } from "../validators/streamingValidators.js";
+import {
+  acceptStreamingDealSchema,
+  streamingStrategyParamsSchema,
+  streamingCatalogQuerySchema,
+} from "../validators/streamingValidators.js";
 import {
   getPlatforms,
+  getStreamingCatalog,
   acceptStreamingDeal,
   getStreamingStrategy,
 } from "../controllers/streamingController.js";
@@ -11,9 +16,8 @@ import {
 const router = express.Router();
 
 router.get("/platforms", protect, getPlatforms);
+router.get("/catalog", protect, validate(streamingCatalogQuerySchema), getStreamingCatalog);
 router.get("/movies/:movieId/strategy", protect, validate(streamingStrategyParamsSchema), getStreamingStrategy);
 router.post("/movies/:movieId/accept-deal", protect, validate(acceptStreamingDealSchema), acceptStreamingDeal);
 
-
 export default router;
-

--- a/backend/src/validators/streamingValidators.js
+++ b/backend/src/validators/streamingValidators.js
@@ -13,3 +13,13 @@ export const acceptStreamingDealSchema = {
 export const streamingStrategyParamsSchema = {
   params: movieIdParam,
 };
+
+/** Validates query params for GET /streaming/catalog */
+export const streamingCatalogQuerySchema = {
+  query: z.object({
+    platformId: z.string().optional(),
+    search: z.string().optional(),
+    page: z.string().optional(),
+    limit: z.string().optional(),
+  }),
+};

--- a/backend/tests/streamingStrategy.test.js
+++ b/backend/tests/streamingStrategy.test.js
@@ -4,6 +4,7 @@ import {
   calculateStreamingRevenuePotential,
   computeHybridReleaseStrategy,
 } from "../src/services/simulation/engines/streamingEngine.js";
+import { streamingCatalogQuerySchema } from "../src/validators/streamingValidators.js";
 
 describe("Streaming Release Strategy Engine", () => {
   test("calculateStreamingRevenuePotential returns positive potential and conversion rate", () => {
@@ -36,5 +37,14 @@ describe("Streaming Release Strategy Engine", () => {
   test("computeHybridReleaseStrategy recommends EARLY_STREAMING_PIVOT for underperformers", () => {
     const result = computeHybridReleaseStrategy(10_000_000, 100_000_000, 1);
     assert.equal(result.recommendation, "EARLY_STREAMING_PIVOT");
+  });
+
+  test("streamingCatalogQuerySchema validates query parameters accurately", () => {
+    const parsed = streamingCatalogQuerySchema.query.parse({
+      platformId: "netflix_id",
+      search: "Inception",
+    });
+    assert.equal(parsed.platformId, "netflix_id");
+    assert.equal(parsed.search, "Inception");
   });
 });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,6 +25,7 @@ import ReviewDashboard from "./pages/movies/ReviewDashboard";
 import ProductionQueue from "./pages/movies/ProductionQueue";
 import MovieComparison from "./pages/movies/MovieComparison";
 import StreamingDeals from "./pages/movies/StreamingDeals";
+import StreamingCatalogHub from "./pages/streaming/StreamingCatalogHub";
 import TVShowsHub from "./pages/tvshows/TVShowsHub";
 import ProduceTVShow from "./pages/tvshows/ProduceTVShow";
 import StudioStats from "./pages/studio/StudioStats";
@@ -140,6 +141,14 @@ function App() {
           element={
             <ProtectedRoute>
               <StreamingDeals />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/streaming/catalog"
+          element={
+            <ProtectedRoute>
+              <StreamingCatalogHub />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/components/common/Sidebar.jsx
+++ b/frontend/src/components/common/Sidebar.jsx
@@ -16,6 +16,7 @@ import {
   Newspaper,
   Swords,
   Trophy,
+  Tv,
 } from "lucide-react";
 
 import { Link, useLocation } from "react-router-dom";
@@ -64,6 +65,11 @@ const Sidebar = ({ isOpen, onClose }) => {
       name: "Library",
       path: "/movies/library",
       icon: Film,
+    },
+    {
+      name: "Streaming Hub",
+      path: "/streaming/catalog",
+      icon: Tv,
     },
     {
       name: "Production Queue",

--- a/frontend/src/pages/streaming/StreamingCatalogHub.jsx
+++ b/frontend/src/pages/streaming/StreamingCatalogHub.jsx
@@ -1,0 +1,250 @@
+import { useState, useEffect } from "react";
+import api from "../../api/axios";
+import DashboardLayout from "../../layouts/DashboardLayout";
+import { Tv, Play, Search, Film, Users, IndianRupee, Star, Sparkles, Filter } from "lucide-react";
+
+const StreamingCatalogHub = () => {
+  const [platforms, setPlatforms] = useState([]);
+  const [movies, setMovies] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedPlatform, setSelectedPlatform] = useState("ALL");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetchCatalog();
+  }, [selectedPlatform, searchQuery]);
+
+  const fetchCatalog = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const params = {};
+      if (selectedPlatform !== "ALL") params.platformId = selectedPlatform;
+      if (searchQuery.trim()) params.search = searchQuery.trim();
+
+      const res = await api.get("/streaming/catalog", { params });
+      if (res.data.success) {
+        setMovies(res.data.movies || []);
+        setPlatforms(res.data.platforms || []);
+      }
+    } catch (err) {
+      console.error("Failed to load streaming catalog:", err);
+      setError("Unable to load streaming catalog. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const totalSubscribers = platforms.reduce((acc, p) => acc + (p.subscribers || 0), 0);
+  const totalExclusives = movies.length;
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-7xl mx-auto space-y-8 pb-20">
+        {/* Header section */}
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h1 className="text-3xl sm:text-4xl font-extrabold text-white flex items-center gap-3">
+              <Tv className="text-indigo-500" size={36} /> Streaming Platforms & Catalog
+            </h1>
+            <p className="text-slate-400 mt-2">
+              Explore streaming network subscribers, content budgets, and active digital exclusives.
+            </p>
+          </div>
+        </div>
+
+        {/* Global Network Overview Cards */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <div className="bg-slate-900/80 border border-slate-800 rounded-2xl p-5 shadow-lg">
+            <span className="text-xs uppercase font-bold tracking-wider text-slate-400">Total Streaming Networks</span>
+            <div className="text-3xl font-black text-indigo-400 mt-2 flex items-center gap-2">
+              <Tv size={24} /> {platforms.length}
+            </div>
+            <p className="text-xs text-slate-500 mt-1">Active platform partners</p>
+          </div>
+
+          <div className="bg-slate-900/80 border border-slate-800 rounded-2xl p-5 shadow-lg">
+            <span className="text-xs uppercase font-bold tracking-wider text-slate-400">Network Reach</span>
+            <div className="text-3xl font-black text-emerald-400 mt-2 flex items-center gap-2">
+              <Users size={24} /> {(totalSubscribers / 1_000_000).toFixed(1)}M
+            </div>
+            <p className="text-xs text-slate-500 mt-1">Combined subscriber base</p>
+          </div>
+
+          <div className="bg-slate-900/80 border border-slate-800 rounded-2xl p-5 shadow-lg">
+            <span className="text-xs uppercase font-bold tracking-wider text-slate-400">Studio Exclusives</span>
+            <div className="text-3xl font-black text-amber-400 mt-2 flex items-center gap-2">
+              <Film size={24} /> {totalExclusives}
+            </div>
+            <p className="text-xs text-slate-500 mt-1">Licensed catalog titles</p>
+          </div>
+
+          <div className="bg-slate-900/80 border border-slate-800 rounded-2xl p-5 shadow-lg">
+            <span className="text-xs uppercase font-bold tracking-wider text-slate-400">Digital Market Status</span>
+            <div className="text-2xl font-black text-violet-400 mt-2 flex items-center gap-2">
+              <Sparkles size={24} /> Active
+            </div>
+            <p className="text-xs text-slate-500 mt-1">Real-time SVOD simulation</p>
+          </div>
+        </div>
+
+        {/* Platform Directory Grid */}
+        <div className="space-y-4">
+          <h2 className="text-xl font-bold text-white flex items-center gap-2">
+            <Filter size={20} className="text-indigo-400" /> Platform Directory & Content Budgets
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            {platforms.map((plat) => (
+              <button
+                key={plat.id}
+                onClick={() => setSelectedPlatform(selectedPlatform === plat.id ? "ALL" : plat.id)}
+                className={`text-left p-5 rounded-2xl border transition-all duration-200 cursor-pointer ${
+                  selectedPlatform === plat.id
+                    ? "bg-indigo-950/60 border-indigo-500 shadow-lg ring-2 ring-indigo-500/50"
+                    : "bg-[#111827] border-slate-800 hover:border-slate-700"
+                }`}
+              >
+                <div className="flex items-center justify-between mb-3">
+                  <h3 className="text-lg font-bold text-white">{plat.name}</h3>
+                  <span className="text-xs font-bold px-2 py-0.5 rounded-full bg-slate-800 text-indigo-300">
+                    {plat.popularity}% Pop
+                  </span>
+                </div>
+                <div className="space-y-1.5 text-xs text-slate-400">
+                  <div className="flex justify-between">
+                    <span>Subscribers:</span>
+                    <span className="font-semibold text-slate-200">{(plat.subscribers / 1_000_000).toFixed(1)}M</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span>Content Budget:</span>
+                    <span className="font-semibold text-emerald-400">₹{(plat.contentBudget / 1_000_000).toFixed(1)}M</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span>Catalog Exclusives:</span>
+                    <span className="font-semibold text-indigo-400">{plat.exclusiveCount}</span>
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Catalog Search and Filter Controls */}
+        <div className="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 flex flex-col md:flex-row gap-4 items-center justify-between">
+          <div className="relative w-full md:w-96">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" size={18} />
+            <input
+              type="text"
+              placeholder="Search streaming exclusives by title..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full bg-slate-950 border border-slate-700 rounded-xl pl-10 pr-4 py-2.5 text-sm text-white placeholder-slate-500 focus:outline-none focus:border-indigo-500"
+            />
+          </div>
+
+          <div className="flex items-center gap-2 self-start md:self-auto">
+            <span className="text-xs text-slate-400">Platform Filter:</span>
+            <select
+              value={selectedPlatform}
+              onChange={(e) => setSelectedPlatform(e.target.value)}
+              className="bg-slate-950 border border-slate-700 rounded-xl px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500"
+            >
+              <option value="ALL">All Platforms ({platforms.length})</option>
+              {platforms.map((p) => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Catalog Movies Grid */}
+        <div className="space-y-4">
+          <h2 className="text-xl font-bold text-white flex items-center gap-2">
+            <Play size={20} className="text-indigo-400" /> Licensed Streaming Catalog ({movies.length})
+          </h2>
+
+          {loading ? (
+            <div className="p-12 text-center text-slate-400 animate-pulse font-medium">
+              Loading platform streaming catalog...
+            </div>
+          ) : error ? (
+            <div className="p-8 text-center text-rose-400 bg-rose-950/20 border border-rose-900/50 rounded-2xl">
+              {error}
+            </div>
+          ) : movies.length === 0 ? (
+            <div className="bg-[#111827] border border-slate-800 rounded-2xl p-12 text-center">
+              <Tv size={48} className="mx-auto text-slate-600 mb-4" />
+              <h3 className="text-lg font-bold text-white mb-2">No Streaming Exclusives Found</h3>
+              <p className="text-sm text-slate-400 max-w-md mx-auto">
+                {searchQuery || selectedPlatform !== "ALL"
+                  ? "Try clearing filters or searching with a different movie title."
+                  : "Sell movie distribution rights to streaming platforms upon release to build your streaming catalog."}
+              </p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {movies.map((movie) => (
+                <div
+                  key={movie._id}
+                  className="bg-[#111827] border border-slate-800 rounded-2xl p-5 hover:border-slate-700 transition-all flex flex-col justify-between"
+                >
+                  <div>
+                    <div className="flex items-start justify-between gap-3 mb-3">
+                      <div>
+                        <h3 className="text-lg font-bold text-white">{movie.title}</h3>
+                        <span className="inline-block mt-1 text-xs px-2.5 py-0.5 rounded-full bg-indigo-900/40 text-indigo-300 border border-indigo-800/40">
+                          {movie.platformName || "Streaming Exclusive"}
+                        </span>
+                      </div>
+                      <div className="text-right">
+                        <span className="text-xs text-slate-400 block">Quality</span>
+                        <span className="text-sm font-bold text-amber-400 flex items-center gap-1 justify-end">
+                          <Star size={14} /> {movie.quality || 0}/100
+                        </span>
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-3 bg-slate-900/70 rounded-xl p-3 my-4 border border-slate-800/80 text-xs">
+                      <div>
+                        <span className="text-slate-500 block">Deal Revenue</span>
+                        <span className="font-bold text-emerald-400 flex items-center mt-0.5">
+                          <IndianRupee size={12} /> {((movie.boxOffice || movie.worldwideGross || 0) / 1_000_000).toFixed(2)}M
+                        </span>
+                      </div>
+                      <div>
+                        <span className="text-slate-500 block">Verdict</span>
+                        <span className="font-bold text-indigo-300 mt-0.5 block">
+                          {movie.verdict || "STREAMING"}
+                        </span>
+                      </div>
+                      <div>
+                        <span className="text-slate-500 block">Hype at Release</span>
+                        <span className="font-semibold text-slate-300 mt-0.5 block">
+                          {movie.hype || 0}
+                        </span>
+                      </div>
+                      <div>
+                        <span className="text-slate-500 block">Release Week</span>
+                        <span className="font-semibold text-slate-300 mt-0.5 block">
+                          Week {movie.releaseWeek || "—"}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="pt-3 border-t border-slate-800/80 flex items-center justify-between text-xs text-slate-400">
+                    <span>Streaming Status: Active</span>
+                    <span className="text-indigo-400 font-medium">Exclusivity Secured</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default StreamingCatalogHub;


### PR DESCRIPTION
# Related Issue
Closes #493

# Summary
Implements a dedicated Streaming Platform Directory and Licensed Digital Catalog Hub in CineVerse, allowing studio executives to browse licensed streaming exclusives, compare subscriber reaches and content budgets, and search their streaming library.

# Changes Made
- **Validation**: Added `streamingCatalogQuerySchema` for platform filtering and text search.
- **Backend API**: Added `getStreamingCatalog` in `streamingController.js` and registered `GET /api/streaming/catalog` in `streamingRoutes.js`.
- **Unit Tests**: Added test coverage in `streamingStrategy.test.js` validating schema parsing and calculations.
- **Frontend Hub**: Created `StreamingCatalogHub.jsx` with network summary statistics, interactive platform cards, search filters, and movie details.
- **Routing & Navigation**: Added `/streaming/catalog` in `App.jsx` and `Sidebar.jsx`.

# Testing
- Ran backend unit test suite: `node --test tests/streamingStrategy.test.js` (passed 7/7).
- Verified production build: `npm run build` in `/frontend` succeeded without errors or warnings.
- Responsive layout checked across mobile and desktop breakpoints.

# Impact
Provides players with full transparency over digital distribution portfolios, completing the streaming rights gameplay loop.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
