### PR TITLE
feat: add streaming rights bidding hall and platform auction integration

### DIFF
--- a/backend/src/controllers/streamingAuctionController.js
+++ b/backend/src/controllers/streamingAuctionController.js
@@ -1,20 +1,27 @@
 import StreamingAuction from "../models/StreamingAuction.js";
 import Movie from "../models/Movie.js";
+import Studio from "../models/Studio.js";
 import { runStreamingAuction } from "../services/streamingAuctionEngine.js";
 
 export const createStreamingAuction = async (req, res) => {
   try {
     const { movieId, windowType, askingPrice } = req.body;
-    const studioId = req.user.studioId || req.user._id;
+    
+    // Resolve Studio accurately via owner
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({ success: false, message: "Studio not found" });
+    }
+    const studioId = studio._id;
 
     const movie = await Movie.findOne({ _id: movieId, studioId });
     if (!movie) {
-      return res.status(404).json({ message: "Movie not found or unauthorized" });
+      return res.status(404).json({ success: false, message: "Movie not found or unauthorized" });
     }
 
     const existingAuction = await StreamingAuction.findOne({ movieId, status: "OPEN" });
     if (existingAuction) {
-      return res.status(400).json({ message: "An active streaming auction is already open for this movie" });
+      return res.status(400).json({ success: false, message: "An active streaming auction is already open for this movie" });
     }
 
     const auction = await StreamingAuction.create({
@@ -26,7 +33,7 @@ export const createStreamingAuction = async (req, res) => {
 
     return res.status(201).json({ success: true, auction });
   } catch (error) {
-    return res.status(500).json({ message: error.message });
+    return res.status(500).json({ success: false, message: error.message });
   }
 };
 
@@ -36,16 +43,24 @@ export const executeAuctionBidding = async (req, res) => {
     const auction = await runStreamingAuction(auctionId);
     return res.status(200).json({ success: true, auction });
   } catch (error) {
-    return res.status(400).json({ message: error.message });
+    return res.status(400).json({ success: false, message: error.message });
   }
 };
 
 export const getStudioAuctions = async (req, res) => {
   try {
-    const studioId = req.user.studioId || req.user._id;
-    const auctions = await StreamingAuction.find({ studioId }).populate("movieId", "title rating poster");
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({ success: false, message: "Studio not found" });
+    }
+    const studioId = studio._id;
+
+    const auctions = await StreamingAuction.find({ studioId })
+      .populate("movieId", "title quality criticScore worldwideGross budget boxOffice")
+      .sort({ createdAt: -1 });
+
     return res.status(200).json({ success: true, auctions });
   } catch (error) {
-    return res.status(500).json({ message: error.message });
+    return res.status(500).json({ success: false, message: error.message });
   }
 };

--- a/backend/src/services/streamingAuctionEngine.js
+++ b/backend/src/services/streamingAuctionEngine.js
@@ -6,8 +6,8 @@ import Studio from "../models/Studio.js";
  * Calculates platform valuation & bids for a film based on quality, genre, and box office
  */
 export function calculatePlatformBids(movie, windowType, askingPrice) {
-  const baseValuation = (movie.boxOfficeTotal || movie.budget || 2000000) * 0.4;
-  const ratingMult = Math.max(0.6, (movie.rating || 50) / 50);
+  const baseValuation = (movie.worldwideGross || movie.boxOffice || movie.budget || 2000000) * 0.4;
+  const ratingMult = Math.max(0.6, ((movie.criticScore || movie.quality || 50) / 50));
 
   const platforms = [
     { name: "NetCinema", budgetMultiplier: 1.25 },
@@ -48,9 +48,9 @@ export async function runStreamingAuction(auctionId) {
   auction.status = "COMPLETED";
   await auction.save();
 
-  // Credit winning bid payout to studio
+  // Credit winning bid payout to studio money
   await Studio.findByIdAndUpdate(auction.studioId, {
-    $inc: { balance: highestBid.amount, lifetimeEarnings: highestBid.amount },
+    $inc: { money: highestBid.amount },
   });
 
   return auction;

--- a/backend/tests/streamingAuctionEngine.test.js
+++ b/backend/tests/streamingAuctionEngine.test.js
@@ -6,9 +6,10 @@ describe("Streaming Auction Engine Unit Tests", () => {
   it("calculatePlatformBids generates valid array of platform bids sorted by highest amount", () => {
     const movie = {
       title: "Cyberpunk Action 2077",
-      rating: 88,
+      quality: 88,
+      criticScore: 85,
       budget: 80000000,
-      boxOfficeTotal: 250000000,
+      worldwideGross: 250000000,
     };
 
     const bids = calculatePlatformBids(movie, "EXCLUSIVE_DAY_DATE", 500000);
@@ -19,7 +20,7 @@ describe("Streaming Auction Engine Unit Tests", () => {
   });
 
   it("calculatePlatformBids enforces asking price baseline", () => {
-    const movie = { title: "Indie Drama", rating: 40, budget: 500000 };
+    const movie = { title: "Indie Drama", quality: 40, budget: 500000 };
     const bids = calculatePlatformBids(movie, "POST_THEATRICAL_SVOD", 1000000);
 
     assert.ok(bids.every((b) => b.amount >= 1000000), "All bids must satisfy asking price baseline");

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,6 +25,7 @@ import ReviewDashboard from "./pages/movies/ReviewDashboard";
 import ProductionQueue from "./pages/movies/ProductionQueue";
 import MovieComparison from "./pages/movies/MovieComparison";
 import StreamingDeals from "./pages/movies/StreamingDeals";
+import StreamingBiddingHall from "./pages/streaming/StreamingBiddingHall";
 import TVShowsHub from "./pages/tvshows/TVShowsHub";
 import ProduceTVShow from "./pages/tvshows/ProduceTVShow";
 import StudioStats from "./pages/studio/StudioStats";
@@ -140,6 +141,14 @@ function App() {
           element={
             <ProtectedRoute>
               <StreamingDeals />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/streaming/auctions"
+          element={
+            <ProtectedRoute>
+              <StreamingBiddingHall />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/components/common/Sidebar.jsx
+++ b/frontend/src/components/common/Sidebar.jsx
@@ -16,6 +16,7 @@ import {
   Newspaper,
   Swords,
   Trophy,
+  Gavel,
 } from "lucide-react";
 
 import { Link, useLocation } from "react-router-dom";
@@ -64,6 +65,11 @@ const Sidebar = ({ isOpen, onClose }) => {
       name: "Library",
       path: "/movies/library",
       icon: Film,
+    },
+    {
+      name: "Streaming Auctions",
+      path: "/streaming/auctions",
+      icon: Gavel,
     },
     {
       name: "Production Queue",

--- a/frontend/src/pages/streaming/StreamingBiddingHall.jsx
+++ b/frontend/src/pages/streaming/StreamingBiddingHall.jsx
@@ -1,0 +1,295 @@
+import { useState, useEffect } from "react";
+import api from "../../api/axios";
+import DashboardLayout from "../../layouts/DashboardLayout";
+import { Gavel, IndianRupee, Trophy, Flame, Plus, CheckCircle, Clock, ShieldAlert } from "lucide-react";
+
+const StreamingBiddingHall = () => {
+  const [auctions, setAuctions] = useState([]);
+  const [movies, setMovies] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [executingId, setExecutingId] = useState(null);
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [formData, setFormData] = useState({
+    movieId: "",
+    windowType: "POST_THEATRICAL_SVOD",
+    askingPrice: 500000,
+  });
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const fetchData = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const [auctionsRes, moviesRes] = await Promise.all([
+        api.get("/streaming-auctions/auctions"),
+        api.get("/movies/library"),
+      ]);
+
+      if (auctionsRes.data?.success) {
+        setAuctions(auctionsRes.data.auctions || []);
+      }
+      if (moviesRes.data?.movies) {
+        setMovies(moviesRes.data.movies || []);
+      }
+    } catch (err) {
+      console.error("Failed to load auctions data:", err);
+      setError("Unable to load auction hall. Please ensure backend services are connected.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreateAuction = async (e) => {
+    e.preventDefault();
+    if (!formData.movieId) {
+      alert("Please select a movie to auction.");
+      return;
+    }
+
+    try {
+      const res = await api.post("/streaming-auctions/auctions", formData);
+      if (res.data?.success) {
+        setShowCreateModal(false);
+        setFormData({ movieId: "", windowType: "POST_THEATRICAL_SVOD", askingPrice: 500000 });
+        fetchData();
+      }
+    } catch (err) {
+      alert(err.response?.data?.message || "Failed to initiate auction");
+    }
+  };
+
+  const handleRunBidding = async (auctionId) => {
+    try {
+      setExecutingId(auctionId);
+      const res = await api.post(`/streaming-auctions/auctions/${auctionId}/bid`);
+      if (res.data?.success) {
+        fetchData();
+      }
+    } catch (err) {
+      alert(err.response?.data?.message || "Failed to execute platform bidding war");
+    } finally {
+      setExecutingId(null);
+    }
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-7xl mx-auto space-y-8 pb-20">
+        {/* Header section */}
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h1 className="text-3xl sm:text-4xl font-extrabold text-white flex items-center gap-3">
+              <Gavel className="text-amber-400" size={36} /> Streaming Rights Bidding Hall
+            </h1>
+            <p className="text-slate-400 mt-2">
+              Launch competitive platform bidding wars between NetCinema, StreamMax, CineStream, and PrimePlay for post-theatrical and exclusive SVOD licensing.
+            </p>
+          </div>
+
+          <button
+            onClick={() => setShowCreateModal(true)}
+            className="flex items-center gap-2 bg-gradient-to-r from-amber-500 to-amber-600 hover:from-amber-400 hover:to-amber-500 text-slate-950 font-bold px-5 py-3 rounded-xl shadow-lg cursor-pointer transition-all duration-200"
+          >
+            <Plus size={20} /> Launch New Auction
+          </button>
+        </div>
+
+        {/* Modal: Create Auction */}
+        {showCreateModal && (
+          <div className="fixed inset-0 bg-black/70 backdrop-blur-xs flex items-center justify-center p-4 z-50">
+            <div className="bg-[#111827] border border-slate-700 rounded-3xl p-6 sm:p-8 max-w-lg w-full space-y-6">
+              <div className="flex items-center justify-between">
+                <h3 className="text-2xl font-bold text-white flex items-center gap-2">
+                  <Gavel size={24} className="text-amber-400" /> Start Streaming Auction
+                </h3>
+                <button
+                  onClick={() => setShowCreateModal(false)}
+                  className="text-slate-400 hover:text-white text-lg font-bold"
+                >
+                  ✕
+                </button>
+              </div>
+
+              <form onSubmit={handleCreateAuction} className="space-y-4">
+                <div>
+                  <label className="block text-xs font-bold text-slate-300 uppercase mb-2">Select Library Movie</label>
+                  <select
+                    value={formData.movieId}
+                    onChange={(e) => setFormData({ ...formData, movieId: e.target.value })}
+                    className="w-full bg-slate-900 border border-slate-700 rounded-xl px-4 py-3 text-white text-sm focus:outline-none focus:border-amber-500"
+                    required
+                  >
+                    <option value="">-- Choose a film from your library --</option>
+                    {movies.map((m) => (
+                      <option key={m._id} value={m._id}>
+                        {m.title} (Quality: {m.quality || 0})
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label className="block text-xs font-bold text-slate-300 uppercase mb-2">Exclusivity Window</label>
+                  <select
+                    value={formData.windowType}
+                    onChange={(e) => setFormData({ ...formData, windowType: e.target.value })}
+                    className="w-full bg-slate-900 border border-slate-700 rounded-xl px-4 py-3 text-white text-sm focus:outline-none focus:border-amber-500"
+                  >
+                    <option value="POST_THEATRICAL_SVOD">Post-Theatrical SVOD (Standard Multiplier)</option>
+                    <option value="GLOBAL_PREMIERE">Global Premiere Window (1.5x Multiplier)</option>
+                    <option value="EXCLUSIVE_DAY_DATE">Exclusive Day-and-Date (2.0x Multiplier)</option>
+                  </select>
+                </div>
+
+                <div>
+                  <label className="block text-xs font-bold text-slate-300 uppercase mb-2">Reserve Asking Price (₹)</label>
+                  <input
+                    type="number"
+                    min={50000}
+                    step={50000}
+                    value={formData.askingPrice}
+                    onChange={(e) => setFormData({ ...formData, askingPrice: Number(e.target.value) })}
+                    className="w-full bg-slate-900 border border-slate-700 rounded-xl px-4 py-3 text-white text-sm focus:outline-none focus:border-amber-500"
+                    required
+                  />
+                </div>
+
+                <div className="flex gap-3 pt-4">
+                  <button
+                    type="button"
+                    onClick={() => setShowCreateModal(false)}
+                    className="flex-1 bg-slate-800 hover:bg-slate-700 text-slate-300 font-bold py-3 rounded-xl transition"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    className="flex-1 bg-amber-500 hover:bg-amber-400 text-slate-950 font-bold py-3 rounded-xl transition"
+                  >
+                    Open Auction
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        )}
+
+        {/* Auctions List */}
+        <div className="space-y-6">
+          {loading ? (
+            <div className="p-12 text-center text-slate-400 animate-pulse font-medium">
+              Loading streaming bidding auctions...
+            </div>
+          ) : error ? (
+            <div className="p-8 text-center text-rose-400 bg-rose-950/20 border border-rose-900/50 rounded-2xl flex items-center justify-center gap-3">
+              <ShieldAlert size={24} /> {error}
+            </div>
+          ) : auctions.length === 0 ? (
+            <div className="bg-[#111827] border border-slate-800 rounded-2xl p-12 text-center">
+              <Gavel size={48} className="mx-auto text-slate-600 mb-4" />
+              <h3 className="text-lg font-bold text-white mb-2">No Active Streaming Auctions</h3>
+              <p className="text-sm text-slate-400 max-w-md mx-auto mb-6">
+                Monetize your released library catalogue by opening streaming window auctions to competing platforms.
+              </p>
+              <button
+                onClick={() => setShowCreateModal(true)}
+                className="bg-amber-500 hover:bg-amber-400 text-slate-950 font-bold px-6 py-2.5 rounded-xl transition"
+              >
+                Create Your First Auction
+              </button>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-6">
+              {auctions.map((auction) => (
+                <div
+                  key={auction._id}
+                  className="bg-[#111827] border border-slate-800 rounded-3xl p-6 sm:p-8 space-y-6"
+                >
+                  <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 border-b border-slate-800 pb-5">
+                    <div>
+                      <div className="flex items-center gap-3">
+                        <h2 className="text-2xl font-bold text-white">
+                          {auction.movieId?.title || "Untitled Film"}
+                        </h2>
+                        <span
+                          className={`text-xs font-bold px-3 py-1 rounded-full uppercase tracking-wider ${
+                            auction.status === "COMPLETED"
+                              ? "bg-emerald-950/80 text-emerald-400 border border-emerald-800/60"
+                              : "bg-amber-950/80 text-amber-400 border border-amber-800/60"
+                          }`}
+                        >
+                          {auction.status}
+                        </span>
+                      </div>
+                      <p className="text-xs text-slate-400 mt-1">
+                        Window: <span className="font-semibold text-slate-300">{auction.windowType.replace(/_/g, " ")}</span> • Asking Price: <span className="font-semibold text-amber-400">₹{(auction.askingPrice / 1_000_000).toFixed(2)}M</span>
+                      </p>
+                    </div>
+
+                    {auction.status === "OPEN" ? (
+                      <button
+                        onClick={() => handleRunBidding(auction._id)}
+                        disabled={executingId === auction._id}
+                        className="bg-gradient-to-r from-amber-500 to-amber-600 hover:from-amber-400 hover:to-amber-500 text-slate-950 font-black px-6 py-3 rounded-xl transition shadow-lg flex items-center justify-center gap-2 cursor-pointer disabled:opacity-50"
+                      >
+                        <Flame size={18} /> {executingId === auction._id ? "Bidding War in Progress..." : "Trigger Platform Bidding War"}
+                      </button>
+                    ) : (
+                      <div className="bg-emerald-950/50 border border-emerald-800/50 rounded-2xl px-5 py-3 text-right">
+                        <span className="text-xs text-slate-400 block font-medium">Winning Bidder</span>
+                        <span className="text-lg font-black text-emerald-400 flex items-center gap-1.5 justify-end">
+                          <Trophy size={18} className="text-amber-400" /> {auction.winningPlatform} (₹{((auction.winningBidAmount || 0) / 1_000_000).toFixed(2)}M)
+                        </span>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Bids received */}
+                  {auction.bids && auction.bids.length > 0 ? (
+                    <div>
+                      <h4 className="text-xs uppercase font-bold text-slate-400 tracking-wider mb-3">Competing Platform Bids</h4>
+                      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                        {auction.bids.map((b, idx) => (
+                          <div
+                            key={idx}
+                            className={`p-4 rounded-2xl border ${
+                              idx === 0 && auction.status === "COMPLETED"
+                                ? "bg-emerald-950/30 border-emerald-600/60 ring-1 ring-emerald-500/30"
+                                : "bg-slate-900/60 border-slate-800"
+                            }`}
+                          >
+                            <div className="flex items-center justify-between mb-2">
+                              <span className="font-bold text-white text-sm">{b.platform}</span>
+                              {idx === 0 && auction.status === "COMPLETED" && (
+                                <span className="text-xs text-emerald-400 font-bold flex items-center gap-1">
+                                  <CheckCircle size={14} /> Won
+                                </span>
+                              )}
+                            </div>
+                            <div className="text-xl font-black text-amber-400 flex items-center">
+                              <IndianRupee size={16} /> {(b.amount / 1_000_000).toFixed(2)}M
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="bg-slate-900/40 rounded-2xl p-4 border border-slate-800 text-xs text-slate-400 flex items-center gap-2">
+                      <Clock size={16} className="text-amber-400" /> Auction is live and waiting for bidding war execution.
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default StreamingBiddingHall;


### PR DESCRIPTION
# Related Issue
Closes #494

# Summary
Connects the backend streaming auction engine with a full-featured Streaming Rights Bidding Hall interface, fixes studio money payouts and ownership resolution, and enables players to run bidding wars across competing SVOD networks.

# Changes Made
- **Engine & Controller Fix**: Resolved studio via `Studio.findOne({ owner: req.user._id })` and updated winning bid payouts to increment `Studio.money`.
- **Auction Dashboard**: Created `StreamingBiddingHall.jsx` with auction creation modal, asking price inputs, window multiplier selection, and one-click bidding execution.
- **Unit Testing**: Updated test suite in `streamingAuctionEngine.test.js` to ensure 100% test pass rate.
- **Navigation**: Registered route `/streaming/auctions` in `App.jsx` and added sidebar navigation entry.

# Testing
- Backend tests verified: `node --test tests/streamingAuctionEngine.test.js` (passed 2/2).
- Frontend bundle compiled cleanly: `npm run build` in `/frontend`.
- Tested auction creation flow and payout crediting.

# Impact
Unlocks the post-theatrical window monetization loop and resolves latent controller bugs.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered