### PR TITLE
Fix talent release status and export aiEngine module structure

### DIFF
--- a/backend/src/services/movie/releaseService.js
+++ b/backend/src/services/movie/releaseService.js
@@ -99,23 +99,23 @@ export const performMovieRelease = async (movie, studio, gameState, session = nu
   // 4. Update Careers
   processCareerImpact(gameState, movie, writer, director, leadActor, crewTeam);
 
-  // 5. Release Talent (Set back to AVAILABLE)
-  if (director) {
+  // 5. Release Talent (Set back to AVAILABLE if not currently busy with a future project)
+  if (director && (!director.busyUntilWeek || director.busyUntilWeek <= gameState.currentWeek)) {
     director.status = "AVAILABLE";
     director.busyUntilWeek = null;
   }
-  if (leadActor) {
+  if (leadActor && (!leadActor.busyUntilWeek || leadActor.busyUntilWeek <= gameState.currentWeek)) {
     leadActor.status = "AVAILABLE";
     leadActor.busyUntilWeek = null;
   }
-  if (crewTeam) {
+  if (crewTeam && (!crewTeam.busyUntilWeek || crewTeam.busyUntilWeek <= gameState.currentWeek)) {
     crewTeam.status = "AVAILABLE";
     crewTeam.busyUntilWeek = null;
   }
   if (movie.supportingActorIds && movie.supportingActorIds.length > 0) {
     movie.supportingActorIds.forEach(actorId => {
       const sActor = gameState.ownedActors.find(a => a.id === actorId);
-      if (sActor) {
+      if (sActor && (!sActor.busyUntilWeek || sActor.busyUntilWeek <= gameState.currentWeek)) {
         sActor.status = "AVAILABLE";
         sActor.busyUntilWeek = null;
       }

--- a/backend/src/services/simulation/engines/aiEngine.js
+++ b/backend/src/services/simulation/engines/aiEngine.js
@@ -1,0 +1,14 @@
+/**
+ * @fileoverview AI Studio Engine Placeholder
+ *
+ * Provides placeholder functions for AI Studio simulation logic.
+ */
+
+export const processAIStudios = async (gameState, studio) => {
+  // Placeholder for AI studio tick simulation logic
+  return [];
+};
+
+export default {
+  processAIStudios,
+};

--- a/backend/src/services/simulation/engines/productionEngine.js
+++ b/backend/src/services/simulation/engines/productionEngine.js
@@ -201,4 +201,13 @@ const releaseTalent = (gameState, movie) => {
     crewTeam.status = "AVAILABLE";
     crewTeam.busyUntilWeek = null;
   }
+  if (movie.supportingActorIds && movie.supportingActorIds.length > 0) {
+    movie.supportingActorIds.forEach(actorId => {
+      const sActor = gameState.ownedActors.find(a => a.id === actorId);
+      if (sActor) {
+        sActor.status = "AVAILABLE";
+        sActor.busyUntilWeek = null;
+      }
+    });
+  }
 };


### PR DESCRIPTION
Fixed talent release status logic to avoid overwriting future assignments when releasing movies, added supporting actor release handling in production engine, and created module placeholder for aiEngine.

---
*PR created automatically by Jules for task [10432422486042963910](https://jules.google.com/task/10432422486042963910) started by @SRV30*