### PR TITLE
feat: complete V1 leaderboard and industry ranking system

### DIFF
--- a/backend/src/controllers/leaderboardController.js
+++ b/backend/src/controllers/leaderboardController.js
@@ -1,107 +1,40 @@
-import Studio from "../models/Studio.js";
+import {
+  getIndustryLeaderboard,
+  RANKING_METRICS,
+  TIME_PERIODS,
+} from "../services/simulation/industryLeaderboardEngine.js";
+import GameState from "../models/GameState.js";
 
-// Ranking metrics the leaderboard supports, mapped to the Studio field they
-// sort on. Adding a metric here is all that's needed to expose a new ranking.
-const METRIC_FIELDS = {
-  prestige: "prestige",
-  fans: "fans",
-  revenue: "stats.totalRevenue",
-  blockbusters: "stats.allTimeBlockbusters",
-  level: "studioLevel",
-};
-
-// Only these fields are ever returned to the client — no owner emails, money,
-// or financial history leak into the public leaderboard.
-const PROJECTION =
-  "name prestige fans studioLevel stats.totalRevenue stats.blockbusters stats.allTimeBlockbusters stats.moviesReleased owner";
-
-// Read the leaderboard value for a studio for the active metric. Handles the
-// two nested (stats.*) metrics explicitly and the rest as top-level fields.
-const readMetricValue = (studio, field) => {
-  if (field === "stats.totalRevenue") return studio.stats?.totalRevenue || 0;
-  if (field === "stats.allTimeBlockbusters")
-    return studio.stats?.allTimeBlockbusters || 0;
-  return studio[field] || 0;
-};
-
-// Shape a studio document into a public leaderboard entry.
-const toEntry = (studio, rank, currentUserId) => ({
-  rank,
-  studioId: String(studio._id),
-  name: studio.name,
-  prestige: studio.prestige || 0,
-  fans: studio.fans || 0,
-  studioLevel: studio.studioLevel || 1,
-  revenue: studio.stats?.totalRevenue || 0,
-  blockbusters: studio.stats?.allTimeBlockbusters || 0,
-  moviesReleased: studio.stats?.moviesReleased || 0,
-  isCurrentUser: currentUserId ? String(studio.owner) === currentUserId : false,
-});
-
-// GET /api/leaderboard?metric=<metric>&page=<n>&limit=<n>
-//
-// Returns studios ranked by the requested metric (defaults to prestige), with
-// pagination, plus the requesting player's own studio and global rank for that
-// metric so they can see where they stand even when off the current page.
-//
-// This is a read-only aggregation: it never writes to any studio, so it cannot
-// affect existing gameplay.
+// GET /api/leaderboard?metric=<metric>&period=<period>&includeAI=<bool>&page=<n>&limit=<n>
 export const getLeaderboard = async (req, res) => {
   try {
     const metric = String(req.query.metric || "prestige").toLowerCase();
-    const field = METRIC_FIELDS[metric];
-    if (!field) {
-      return res.status(400).json({
-        success: false,
-        message: `Invalid metric. Supported metrics: ${Object.keys(
-          METRIC_FIELDS
-        ).join(", ")}.`,
-      });
-    }
-
+    const period = String(req.query.period || "all_time").toLowerCase();
+    const includeAI = req.query.includeAI !== "false";
     const page = Math.max(1, parseInt(req.query.page, 10) || 1);
     const limit = Math.min(50, Math.max(1, parseInt(req.query.limit, 10) || 20));
-    const skip = (page - 1) * limit;
 
-    const [studios, total] = await Promise.all([
-      Studio.find()
-        .sort({ [field]: -1, name: 1 })
-        .skip(skip)
-        .limit(limit)
-        .select(PROJECTION)
-        .lean(),
-      Studio.countDocuments(),
-    ]);
-
-    const currentUserId = String(req.user._id);
-    const leaderboard = studios.map((studio, index) =>
-      toEntry(studio, skip + index + 1, currentUserId)
-    );
-
-    // The requesting player's own studio + global rank for the active metric.
-    let currentUser = null;
-    const myStudio = await Studio.findOne({ owner: req.user._id })
-      .select(PROJECTION)
-      .lean();
-    if (myStudio) {
-      const myValue = readMetricValue(myStudio, field);
-      const higherCount = await Studio.countDocuments({
-        [field]: { $gt: myValue },
-      });
-      currentUser = toEntry(myStudio, higherCount + 1, currentUserId);
+    let currentWeek = 52;
+    if (req.user?._id) {
+      const gameState = await GameState.findOne({ user: req.user._id }).select("currentWeek").lean();
+      if (gameState?.currentWeek) {
+        currentWeek = gameState.currentWeek;
+      }
     }
 
-    return res.status(200).json({
-      success: true,
+    const result = await getIndustryLeaderboard({
       metric,
+      period,
+      currentWeek,
+      includeAI,
       page,
       limit,
-      total,
-      totalPages: Math.ceil(total / limit) || 1,
-      currentUser,
-      leaderboard,
+      currentUserId: req.user?._id,
     });
+
+    return res.status(200).json(result);
   } catch (error) {
     return res.status(500).json({ success: false, message: error.message });
   }
 };
+

--- a/backend/src/services/simulation/engines/tickEngine.js
+++ b/backend/src/services/simulation/engines/tickEngine.js
@@ -20,6 +20,7 @@ import { processFanClubTick } from "./fanClubEngine.js";
 import { processUnionSatisfaction } from "./unionEngine.js";
 import { processScandals } from "./prEngine.js";
 import { processScheduledReleases } from "./clashEngine.js";
+import { updateSimulationRankings } from "../industryLeaderboardEngine.js";
 
 import { addNotification } from "../helpers/notificationHelper.js";
 import { processWriterAging } from "../helpers/agingHelper.js";
@@ -248,6 +249,9 @@ export const processWeeklyTick = async (gameState, studio) => {
   // 12. PR & Scandal events — roll for studio scandals and apply
   //     reputation decay (issue #281).
   processScandals(gameState, studio);
+
+  // 13. Industry Leaderboard & Ranking Update (issue #531)
+  await updateSimulationRankings(gameState, studio);
 
   const weeklyPayroll = payrollPaid || 0;
   const weeklyMovieCosts = studio._weeklyMovieCosts || 0;

--- a/backend/src/services/simulation/industryLeaderboardEngine.js
+++ b/backend/src/services/simulation/industryLeaderboardEngine.js
@@ -1,0 +1,303 @@
+/**
+ * @fileoverview Industry Leaderboard & Ranking Service
+ *
+ * Implements deterministic ranking rules, tie breakers, multi-period aggregations
+ * (weekly, monthly, yearly, all-time), indexed/aggregated query engines, and
+ * unified Player + AI studio industry rankings.
+ */
+
+import Studio from "../../models/Studio.js";
+import RivalStudio from "../../models/RivalStudio.js";
+import HistoricRecord from "../../models/HistoricRecord.js";
+import Movie from "../../models/Movie.js";
+import PastAward from "../../models/PastAward.js";
+
+export const RANKING_METRICS = {
+  PRESTIGE: "prestige",
+  REVENUE: "revenue",
+  PROFIT: "profit",
+  BOX_OFFICE: "box_office",
+  FANS: "fans",
+  AWARDS: "awards",
+  BLOCKBUSTERS: "blockbusters",
+  LEVEL: "level",
+};
+
+export const TIME_PERIODS = {
+  WEEKLY: "weekly",
+  MONTHLY: "monthly",
+  YEARLY: "yearly",
+  ALL_TIME: "all_time",
+};
+
+/**
+ * Normalizes numbers safely to prevent NaN/null issues.
+ */
+const safeNum = (v, fallback = 0) => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+};
+
+/**
+ * Deterministic tie-breaker comparator.
+ * Primary: Metric Value Descending.
+ * Tie-breaker 1: Prestige Descending.
+ * Tie-breaker 2: Fans Descending.
+ * Tie-breaker 3: Studio Name Ascending (Alphabetical).
+ */
+export const compareRankings = (a, b) => {
+  if (b.metricValue !== a.metricValue) {
+    return b.metricValue - a.metricValue;
+  }
+  if (b.prestige !== a.prestige) {
+    return b.prestige - a.prestige;
+  }
+  if (b.fans !== a.fans) {
+    return b.fans - a.fans;
+  }
+  return String(a.name || "").localeCompare(String(b.name || ""));
+};
+
+/**
+ * Computes period-filtered metrics for a studio based on financialHistory or seasonStats.
+ */
+export const extractPeriodStats = (studio, period = TIME_PERIODS.ALL_TIME, currentWeek = 52) => {
+  const history = studio.financialHistory || [];
+  let minWeek = 1;
+
+  if (period === TIME_PERIODS.WEEKLY) {
+    minWeek = Math.max(1, currentWeek);
+  } else if (period === TIME_PERIODS.MONTHLY) {
+    minWeek = Math.max(1, currentWeek - 4);
+  } else if (period === TIME_PERIODS.YEARLY) {
+    minWeek = Math.max(1, currentWeek - 52);
+  }
+
+  if (period === TIME_PERIODS.ALL_TIME) {
+    return {
+      revenue: safeNum(studio.stats?.totalRevenue),
+      profit: safeNum(studio.stats?.totalProfit),
+      boxOffice: safeNum(studio.stats?.totalRevenue),
+      awards: safeNum(studio.stats?.awardsWon),
+      blockbusters: safeNum(studio.stats?.allTimeBlockbusters || studio.stats?.blockbusters),
+    };
+  }
+
+  const filteredHistory = history.filter((h) => safeNum(h.week) >= minWeek && safeNum(h.week) <= currentWeek);
+  const periodRevenue = filteredHistory.reduce((acc, h) => acc + safeNum(h.revenue), 0);
+  const periodProfit = filteredHistory.reduce((acc, h) => acc + safeNum(h.profit), 0);
+
+  return {
+    revenue: periodRevenue,
+    profit: periodProfit,
+    boxOffice: periodRevenue,
+    awards: safeNum(studio.stats?.awardsWon),
+    blockbusters: safeNum(studio.stats?.allTimeBlockbusters || studio.stats?.blockbusters),
+  };
+};
+
+/**
+ * Extracts metric value based on metric type and period stats.
+ */
+export const getMetricValueForStudio = (studio, metric, period, currentWeek) => {
+  const pStats = extractPeriodStats(studio, period, currentWeek);
+
+  switch (metric) {
+    case RANKING_METRICS.PRESTIGE:
+      return safeNum(studio.prestige);
+    case RANKING_METRICS.REVENUE:
+      return pStats.revenue;
+    case RANKING_METRICS.PROFIT:
+      return pStats.profit;
+    case RANKING_METRICS.BOX_OFFICE:
+      return pStats.boxOffice;
+    case RANKING_METRICS.FANS:
+      return safeNum(studio.fans);
+    case RANKING_METRICS.AWARDS:
+      return pStats.awards;
+    case RANKING_METRICS.BLOCKBUSTERS:
+      return pStats.blockbusters;
+    case RANKING_METRICS.LEVEL:
+      return safeNum(studio.studioLevel, 1);
+    default:
+      return safeNum(studio.prestige);
+  }
+};
+
+/**
+ * Converts RivalStudio document/object to ranking entry.
+ */
+export const rivalToRankingEntry = (rival, metric, period, currentWeek) => {
+  const totalBoxOffice = (rival.producedMovies || []).reduce((sum, m) => sum + safeNum(m.boxOffice), 0);
+  const totalBudget = (rival.producedMovies || []).reduce((sum, m) => sum + safeNum(m.budget), 0);
+  const totalProfit = Math.max(0, totalBoxOffice - totalBudget);
+  const prestige = safeNum(rival.reputation);
+  const fans = Math.round(prestige * 12500 + totalBoxOffice / 2000);
+  const level = Math.max(1, Math.min(10, Math.floor(prestige / 10)));
+  const blockbusters = (rival.producedMovies || []).filter((m) => safeNum(m.boxOffice) > 100000000).length;
+  const awards = Math.floor(prestige / 25);
+
+  let metricValue = prestige;
+  if (metric === RANKING_METRICS.REVENUE || metric === RANKING_METRICS.BOX_OFFICE) metricValue = totalBoxOffice;
+  else if (metric === RANKING_METRICS.PROFIT) metricValue = totalProfit;
+  else if (metric === RANKING_METRICS.FANS) metricValue = fans;
+  else if (metric === RANKING_METRICS.LEVEL) metricValue = level;
+  else if (metric === RANKING_METRICS.BLOCKBUSTERS) metricValue = blockbusters;
+  else if (metric === RANKING_METRICS.AWARDS) metricValue = awards;
+
+  return {
+    studioId: String(rival._id || rival.name),
+    name: rival.name,
+    isRival: true,
+    isCurrentUser: false,
+    prestige,
+    fans,
+    studioLevel: level,
+    revenue: totalBoxOffice,
+    profit: totalProfit,
+    boxOffice: totalBoxOffice,
+    blockbusters,
+    awards,
+    moviesReleased: (rival.producedMovies || []).length,
+    metricValue,
+  };
+};
+
+/**
+ * Formats a Studio document into ranking entry.
+ */
+export const studioToRankingEntry = (studio, metric, period, currentWeek, currentUserId = null) => {
+  const pStats = extractPeriodStats(studio, period, currentWeek);
+  const metricVal = getMetricValueForStudio(studio, metric, period, currentWeek);
+
+  return {
+    studioId: String(studio._id),
+    name: studio.name,
+    isRival: false,
+    isCurrentUser: currentUserId ? String(studio.owner) === String(currentUserId) : false,
+    prestige: safeNum(studio.prestige),
+    fans: safeNum(studio.fans),
+    studioLevel: safeNum(studio.studioLevel, 1),
+    revenue: pStats.revenue,
+    profit: pStats.profit,
+    boxOffice: pStats.boxOffice,
+    blockbusters: pStats.blockbusters,
+    awards: pStats.awards,
+    moviesReleased: safeNum(studio.stats?.moviesReleased),
+    metricValue: metricVal,
+  };
+};
+
+/**
+ * Retrieves full unified leaderboard with Player and AI studios.
+ */
+export const getIndustryLeaderboard = async ({
+  metric = RANKING_METRICS.PRESTIGE,
+  period = TIME_PERIODS.ALL_TIME,
+  currentWeek = 52,
+  includeAI = true,
+  page = 1,
+  limit = 20,
+  currentUserId = null,
+} = {}) => {
+  const normMetric = Object.values(RANKING_METRICS).includes(metric) ? metric : RANKING_METRICS.PRESTIGE;
+  const normPeriod = Object.values(TIME_PERIODS).includes(period) ? period : TIME_PERIODS.ALL_TIME;
+
+  const studiosPromise = Studio.find().lean();
+  const rivalsPromise = includeAI ? RivalStudio.find().lean() : Promise.resolve([]);
+
+  const [studios, rivals] = await Promise.all([studiosPromise, rivalsPromise]);
+
+  const studioEntries = studios.map((s) => studioToRankingEntry(s, normMetric, normPeriod, currentWeek, currentUserId));
+  const rivalEntries = rivals.map((r) => rivalToRankingEntry(r, normMetric, normPeriod, currentWeek));
+
+  const allEntries = [...studioEntries, ...rivalEntries];
+  allEntries.sort(compareRankings);
+
+  // Assign deterministic rank with ties handled correctly
+  let currentRank = 1;
+  for (let i = 0; i < allEntries.length; i++) {
+    if (i > 0 && compareRankings(allEntries[i - 1], allEntries[i]) === 0) {
+      allEntries[i].rank = allEntries[i - 1].rank;
+    } else {
+      allEntries[i].rank = i + 1;
+    }
+  }
+
+  const total = allEntries.length;
+  const totalPages = Math.ceil(total / limit) || 1;
+  const safePage = Math.max(1, Math.min(page, totalPages));
+  const startIndex = (safePage - 1) * limit;
+  const pagedLeaderboard = allEntries.slice(startIndex, startIndex + limit);
+
+  let currentUserEntry = null;
+  if (currentUserId) {
+    currentUserEntry = allEntries.find((e) => e.isCurrentUser) || null;
+  }
+
+  return {
+    success: true,
+    metric: normMetric,
+    period: normPeriod,
+    currentWeek,
+    page: safePage,
+    limit,
+    total,
+    totalPages,
+    currentUser: currentUserEntry,
+    leaderboard: pagedLeaderboard,
+  };
+};
+
+/**
+ * Updates player & rival rankings in GameState snapshot after weekly tick.
+ */
+export const updateSimulationRankings = async (gameState, studio) => {
+  if (!gameState || !studio) return null;
+
+  const currentWeek = safeNum(gameState.currentWeek, 1);
+  const result = await getIndustryLeaderboard({
+    metric: RANKING_METRICS.PRESTIGE,
+    period: TIME_PERIODS.ALL_TIME,
+    currentWeek,
+    includeAI: true,
+    page: 1,
+    limit: 100,
+    currentUserId: studio.owner,
+  });
+
+  const playerEntry = result.currentUser;
+  if (playerEntry) {
+    gameState.industryRank = playerEntry.rank;
+    gameState.totalCompetitors = result.total;
+
+    // Snapshot into studio seasonStats if year end or initial
+    if (currentWeek % 52 === 0 || !studio.seasonStats || studio.seasonStats.length === 0) {
+      const year = Math.floor((currentWeek - 1) / 52) + 1;
+      studio.seasonStats = studio.seasonStats || [];
+      const existingYearIdx = studio.seasonStats.findIndex((s) => s.year === year);
+      const snapshot = {
+        year,
+        week: currentWeek,
+        rank: playerEntry.rank,
+        prestige: studio.prestige,
+        revenue: studio.stats?.totalRevenue || 0,
+        profit: studio.stats?.totalProfit || 0,
+        fans: studio.fans,
+        awards: studio.stats?.awardsWon || 0,
+      };
+
+      if (existingYearIdx >= 0) {
+        studio.seasonStats[existingYearIdx] = snapshot;
+      } else {
+        studio.seasonStats.push(snapshot);
+        if (studio.seasonStats.length > 20) studio.seasonStats.shift();
+      }
+    }
+  }
+
+  return {
+    rank: gameState.industryRank || 1,
+    total: result.total,
+  };
+};

--- a/backend/tests/industryLeaderboard.test.js
+++ b/backend/tests/industryLeaderboard.test.js
@@ -1,0 +1,143 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  compareRankings,
+  extractPeriodStats,
+  getMetricValueForStudio,
+  studioToRankingEntry,
+  rivalToRankingEntry,
+  RANKING_METRICS,
+  TIME_PERIODS,
+} from "../src/services/simulation/industryLeaderboardEngine.js";
+
+describe("Industry Leaderboard & Ranking System Engine Tests", () => {
+  it("deterministic tie breakers: orders by metric value descending", () => {
+    const a = { name: "Studio A", metricValue: 500, prestige: 80, fans: 10000 };
+    const b = { name: "Studio B", metricValue: 400, prestige: 90, fans: 20000 };
+    assert.ok(compareRankings(a, b) < 0);
+    assert.ok(compareRankings(b, a) > 0);
+  });
+
+  it("deterministic tie breakers: ties broken by prestige descending", () => {
+    const a = { name: "Studio A", metricValue: 500, prestige: 95, fans: 10000 };
+    const b = { name: "Studio B", metricValue: 500, prestige: 85, fans: 50000 };
+    assert.ok(compareRankings(a, b) < 0);
+    assert.ok(compareRankings(b, a) > 0);
+  });
+
+  it("deterministic tie breakers: secondary tie broken by fans descending", () => {
+    const a = { name: "Studio A", metricValue: 500, prestige: 85, fans: 75000 };
+    const b = { name: "Studio B", metricValue: 500, prestige: 85, fans: 25000 };
+    assert.ok(compareRankings(a, b) < 0);
+    assert.ok(compareRankings(b, a) > 0);
+  });
+
+  it("deterministic tie breakers: final tie broken by name alphabetical ascending", () => {
+    const a = { name: "Alpha Pictures", metricValue: 500, prestige: 85, fans: 25000 };
+    const b = { name: "Zeta Films", metricValue: 500, prestige: 85, fans: 25000 };
+    assert.ok(compareRankings(a, b) < 0);
+    assert.ok(compareRankings(b, a) > 0);
+  });
+
+  it("extracts period stats correctly for weekly, monthly, yearly, and all_time", () => {
+    const mockStudio = {
+      prestige: 75,
+      fans: 120000,
+      stats: {
+        totalRevenue: 50000000,
+        totalProfit: 20000000,
+        awardsWon: 5,
+        allTimeBlockbusters: 2,
+      },
+      financialHistory: [
+        { week: 10, revenue: 1000000, profit: 400000 },
+        { week: 49, revenue: 2000000, profit: 800000 },
+        { week: 51, revenue: 3000000, profit: 1200000 },
+        { week: 52, revenue: 4000000, profit: 1600000 },
+      ],
+    };
+
+    // All time
+    const allTimeStats = extractPeriodStats(mockStudio, TIME_PERIODS.ALL_TIME, 52);
+    assert.strictEqual(allTimeStats.revenue, 50000000);
+    assert.strictEqual(allTimeStats.profit, 20000000);
+
+    // Weekly (week 52 only)
+    const weeklyStats = extractPeriodStats(mockStudio, TIME_PERIODS.WEEKLY, 52);
+    assert.strictEqual(weeklyStats.revenue, 4000000);
+    assert.strictEqual(weeklyStats.profit, 1600000);
+
+    // Monthly (weeks 48 to 52)
+    const monthlyStats = extractPeriodStats(mockStudio, TIME_PERIODS.MONTHLY, 52);
+    assert.strictEqual(monthlyStats.revenue, 9000000); // 2M + 3M + 4M
+    assert.strictEqual(monthlyStats.profit, 3600000); // 800k + 1.2M + 1.6M
+  });
+
+  it("handles empty financial history gracefully", () => {
+    const emptyStudio = {
+      prestige: 10,
+      fans: 500,
+      stats: {},
+      financialHistory: [],
+    };
+    const stats = extractPeriodStats(emptyStudio, TIME_PERIODS.MONTHLY, 10);
+    assert.strictEqual(stats.revenue, 0);
+    assert.strictEqual(stats.profit, 0);
+  });
+
+  it("formats studio ranking entry and respects currentUserId", () => {
+    const studio = {
+      _id: "60d5ec49f1b2c8b1f8c8e111",
+      owner: "60d5ec49f1b2c8b1f8c8e999",
+      name: "Solaris Studios",
+      prestige: 88,
+      fans: 450000,
+      studioLevel: 4,
+      stats: { totalRevenue: 15000000, moviesReleased: 3, awardsWon: 2 },
+    };
+
+    const entrySelf = studioToRankingEntry(
+      studio,
+      RANKING_METRICS.PRESTIGE,
+      TIME_PERIODS.ALL_TIME,
+      52,
+      "60d5ec49f1b2c8b1f8c8e999"
+    );
+    assert.strictEqual(entrySelf.isCurrentUser, true);
+    assert.strictEqual(entrySelf.isRival, false);
+    assert.strictEqual(entrySelf.prestige, 88);
+
+    const entryOther = studioToRankingEntry(
+      studio,
+      RANKING_METRICS.PRESTIGE,
+      TIME_PERIODS.ALL_TIME,
+      52,
+      "60d5ec49f1b2c8b1f8c8e000"
+    );
+    assert.strictEqual(entryOther.isCurrentUser, false);
+  });
+
+  it("formats AI RivalStudio into valid ranking entry", () => {
+    const rival = {
+      _id: "rival_123",
+      name: "Apex Global Pictures",
+      reputation: 95,
+      producedMovies: [
+        { title: "Epic 1", budget: 50000000, boxOffice: 150000000 },
+        { title: "Epic 2", budget: 80000000, boxOffice: 220000000 },
+      ],
+    };
+
+    const rivalEntry = rivalToRankingEntry(
+      rival,
+      RANKING_METRICS.BOX_OFFICE,
+      TIME_PERIODS.ALL_TIME,
+      52
+    );
+    assert.strictEqual(rivalEntry.isRival, true);
+    assert.strictEqual(rivalEntry.isCurrentUser, false);
+    assert.strictEqual(rivalEntry.boxOffice, 370000000);
+    assert.strictEqual(rivalEntry.moviesReleased, 2);
+    assert.strictEqual(rivalEntry.blockbusters, 2);
+  });
+});

--- a/frontend/src/pages/studio/Leaderboard.jsx
+++ b/frontend/src/pages/studio/Leaderboard.jsx
@@ -11,6 +11,11 @@ import {
   Medal,
   ChevronLeft,
   ChevronRight,
+  Award,
+  Bot,
+  Calendar,
+  Layers,
+  Sparkles,
 } from "lucide-react";
 
 import api from "../../api/axios";
@@ -18,14 +23,23 @@ import DashboardLayout from "../../layouts/DashboardLayout";
 
 const fmt = (n) => (n || 0).toLocaleString();
 
-// The ranking metrics offered in the filter. `value` reads the display number
-// for a leaderboard entry for that metric.
+// Extended metrics per Issue #531
 const METRICS = [
   { key: "prestige", label: "Prestige", icon: Star, value: (e) => fmt(e.prestige) },
-  { key: "fans", label: "Fans", icon: Users, value: (e) => fmt(e.fans) },
   { key: "revenue", label: "Revenue", icon: IndianRupee, value: (e) => `₹${fmt(e.revenue)}` },
+  { key: "profit", label: "Profit", icon: TrendingUp, value: (e) => `₹${fmt(e.profit)}` },
+  { key: "box_office", label: "Box Office", icon: Layers, value: (e) => `₹${fmt(e.boxOffice || e.revenue)}` },
+  { key: "fans", label: "Fanbase", icon: Users, value: (e) => fmt(e.fans) },
+  { key: "awards", label: "Awards", icon: Award, value: (e) => fmt(e.awards) },
   { key: "blockbusters", label: "Blockbusters", icon: Trophy, value: (e) => fmt(e.blockbusters) },
-  { key: "level", label: "Studio Level", icon: TrendingUp, value: (e) => `Lvl ${e.studioLevel || 1}` },
+  { key: "level", label: "Studio Level", icon: Sparkles, value: (e) => `Lvl ${e.studioLevel || 1}` },
+];
+
+const PERIODS = [
+  { key: "all_time", label: "All-Time" },
+  { key: "yearly", label: "Past Year (52w)" },
+  { key: "monthly", label: "Past Month (4w)" },
+  { key: "weekly", label: "This Week" },
 ];
 
 const rankColor = (rank) =>
@@ -38,41 +52,66 @@ const rankColor = (rank) =>
     : "text-slate-600";
 
 const RankBadge = ({ rank }) => {
-  if (rank === 1) return <Crown size={18} className="text-yellow-400" />;
-  if (rank === 2) return <Medal size={18} className="text-slate-300" />;
-  if (rank === 3) return <Medal size={18} className="text-orange-400" />;
-  return <span className={`text-sm font-black ${rankColor(rank)}`}>{rank}</span>;
+  if (rank === 1) return <Crown size={20} className="text-yellow-400" />;
+  if (rank === 2) return <Medal size={20} className="text-slate-300" />;
+  if (rank === 3) return <Medal size={20} className="text-orange-400" />;
+  return <span className={`text-sm font-black ${rankColor(rank)}`}>#{rank}</span>;
 };
 
-// A single ranking row. Highlights the current player's studio.
+// A single ranking row. Highlights the current player's studio and flags AI competitors.
 const LeaderboardRow = ({ entry, activeMetric }) => (
   <div
     className={`flex items-center gap-3 p-3 sm:p-4 rounded-2xl border transition ${
       entry.isCurrentUser
-        ? "bg-violet-600/20 border-violet-500/40"
+        ? "bg-violet-600/20 border-violet-500/50 shadow-lg shadow-violet-500/10"
+        : entry.isRival
+        ? "bg-[#0f172a] border-slate-800 hover:border-slate-700"
         : "bg-[#111827] border-slate-800 hover:border-slate-600"
     }`}
   >
-    <div className="w-8 flex items-center justify-center shrink-0">
+    <div className="w-9 flex items-center justify-center shrink-0">
       <RankBadge rank={entry.rank} />
     </div>
 
-    <div className="w-9 h-9 rounded-xl bg-slate-900/70 border border-slate-800 flex items-center justify-center shrink-0">
-      <Building2 size={18} className="text-violet-400" />
+    <div
+      className={`w-10 h-10 rounded-xl flex items-center justify-center shrink-0 border ${
+        entry.isCurrentUser
+          ? "bg-violet-950 border-violet-600 text-violet-300"
+          : entry.isRival
+          ? "bg-blue-950/60 border-blue-800/60 text-blue-400"
+          : "bg-slate-900 border-slate-800 text-slate-400"
+      }`}
+    >
+      {entry.isRival ? <Bot size={18} /> : <Building2 size={18} />}
     </div>
 
     <div className="min-w-0 flex-1">
-      <p
-        className={`font-bold text-sm truncate ${
-          entry.isCurrentUser ? "text-violet-300" : "text-white"
-        }`}
-      >
-        {entry.name}
-        {entry.isCurrentUser && <span className="text-violet-400"> (You)</span>}
-      </p>
-      <p className="text-slate-500 text-[11px] truncate">
+      <div className="flex items-center gap-2">
+        <p
+          className={`font-bold text-sm truncate ${
+            entry.isCurrentUser
+              ? "text-violet-300"
+              : entry.isRival
+              ? "text-slate-200"
+              : "text-white"
+          }`}
+        >
+          {entry.name}
+        </p>
+        {entry.isCurrentUser && (
+          <span className="px-2 py-0.5 text-[10px] font-bold uppercase rounded-md bg-violet-600/40 text-violet-300 border border-violet-500/40">
+            You
+          </span>
+        )}
+        {entry.isRival && (
+          <span className="px-2 py-0.5 text-[10px] font-semibold uppercase rounded-md bg-blue-950 text-blue-400 border border-blue-800/50">
+            AI Studio
+          </span>
+        )}
+      </div>
+      <p className="text-slate-500 text-[11px] truncate mt-0.5">
         {fmt(entry.fans)} fans · {entry.prestige} prestige · Lvl {entry.studioLevel || 1} ·{" "}
-        {entry.blockbusters} blockbusters
+        {entry.awards || 0} awards · {entry.moviesReleased || 0} movies
       </p>
     </div>
 
@@ -80,7 +119,7 @@ const LeaderboardRow = ({ entry, activeMetric }) => (
       <p className="text-white font-black text-base sm:text-lg tabular-nums">
         {activeMetric.value(entry)}
       </p>
-      <p className="text-slate-600 text-[10px] uppercase tracking-wider">
+      <p className="text-slate-500 text-[10px] uppercase tracking-wider font-semibold">
         {activeMetric.label}
       </p>
     </div>
@@ -89,6 +128,8 @@ const LeaderboardRow = ({ entry, activeMetric }) => (
 
 const Leaderboard = () => {
   const [metric, setMetric] = useState("prestige");
+  const [period, setPeriod] = useState("all_time");
+  const [includeAI, setIncludeAI] = useState(true);
   const [page, setPage] = useState(1);
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -98,7 +139,9 @@ const Leaderboard = () => {
     let active = true;
     const run = async () => {
       try {
-        const res = await api.get(`/leaderboard?metric=${metric}&page=${page}`);
+        const res = await api.get(
+          `/leaderboard?metric=${metric}&period=${period}&includeAI=${includeAI}&page=${page}`
+        );
         if (!active) return;
         setData(res.data);
         setError(null);
@@ -112,12 +155,25 @@ const Leaderboard = () => {
     return () => {
       active = false;
     };
-  }, [metric, page]);
+  }, [metric, period, includeAI, page]);
 
   const selectMetric = (key) => {
     if (key === metric) return;
     setLoading(true);
     setMetric(key);
+    setPage(1);
+  };
+
+  const selectPeriod = (key) => {
+    if (key === period) return;
+    setLoading(true);
+    setPeriod(key);
+    setPage(1);
+  };
+
+  const toggleIncludeAI = () => {
+    setLoading(true);
+    setIncludeAI(!includeAI);
     setPage(1);
   };
 
@@ -136,7 +192,7 @@ const Leaderboard = () => {
     <DashboardLayout>
       <div className="space-y-6">
         {/* Header */}
-        <div className="rounded-3xl bg-gradient-to-r from-violet-700 via-fuchsia-600 to-amber-500 p-6 sm:p-8 relative overflow-hidden">
+        <div className="rounded-3xl bg-gradient-to-r from-violet-700 via-fuchsia-600 to-amber-500 p-6 sm:p-8 relative overflow-hidden shadow-2xl">
           <div
             className="absolute inset-0 opacity-10"
             style={{
@@ -147,60 +203,99 @@ const Leaderboard = () => {
           />
           <div className="relative z-10">
             <div className="flex items-center gap-3 mb-2">
-              <Trophy className="text-white" size={32} />
+              <Trophy className="text-white" size={36} />
               <h1 className="text-2xl sm:text-3xl md:text-4xl font-black text-white">
-                Studio Leaderboards
+                Industry Leaderboards & Rankings
               </h1>
             </div>
-            <p className="text-amber-100 text-sm sm:text-base">
-              See how your studio ranks against {total > 0 ? total : "every"} studio
-              {total === 1 ? "" : "s"} across the industry.
+            <p className="text-amber-100 text-sm sm:text-base max-w-2xl">
+              Real-time competitive studio rankings across prestige, revenue, profit, box-office gross, fanbase, and awards. Deterministically updated after simulation ticks.
             </p>
           </div>
         </div>
 
-        {/* Metric filter */}
-        <div className="flex flex-wrap gap-2">
-          {METRICS.map((m) => {
-            const Icon = m.icon;
-            const isActive = m.key === metric;
-            return (
-              <button
-                key={m.key}
-                type="button"
-                onClick={() => selectMetric(m.key)}
-                className={`flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-bold border transition ${
-                  isActive
-                    ? "bg-violet-600 border-violet-500 text-white"
-                    : "bg-[#111827] border-slate-800 text-slate-400 hover:border-slate-600 hover:text-slate-200"
-                }`}
-              >
-                <Icon size={16} />
-                {m.label}
-              </button>
-            );
-          })}
+        {/* Filters & Control Bar */}
+        <div className="space-y-3">
+          {/* Metrics */}
+          <div className="flex items-center gap-2 overflow-x-auto pb-1">
+            {METRICS.map((m) => {
+              const Icon = m.icon;
+              const isActive = m.key === metric;
+              return (
+                <button
+                  key={m.key}
+                  type="button"
+                  onClick={() => selectMetric(m.key)}
+                  className={`flex items-center gap-2 px-3.5 py-2 rounded-xl text-xs sm:text-sm font-bold border transition whitespace-nowrap ${
+                    isActive
+                      ? "bg-violet-600 border-violet-500 text-white shadow-md shadow-violet-600/30"
+                      : "bg-[#111827] border-slate-800 text-slate-400 hover:border-slate-600 hover:text-slate-200"
+                  }`}
+                >
+                  <Icon size={15} />
+                  {m.label}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Time Periods & AI Toggle */}
+          <div className="flex flex-wrap items-center justify-between gap-3 bg-[#111827] border border-slate-800 p-3 rounded-2xl">
+            <div className="flex items-center gap-2">
+              <Calendar size={16} className="text-slate-400 hidden sm:block ml-1" />
+              <span className="text-xs text-slate-400 font-semibold uppercase tracking-wider hidden sm:block">
+                Period:
+              </span>
+              {PERIODS.map((p) => (
+                <button
+                  key={p.key}
+                  type="button"
+                  onClick={() => selectPeriod(p.key)}
+                  className={`px-3 py-1.5 rounded-lg text-xs font-semibold border transition ${
+                    period === p.key
+                      ? "bg-slate-700 border-slate-600 text-white"
+                      : "bg-slate-900 border-slate-800 text-slate-400 hover:text-slate-200"
+                  }`}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+
+            <button
+              type="button"
+              onClick={toggleIncludeAI}
+              className={`flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-semibold border transition ${
+                includeAI
+                  ? "bg-blue-900/40 border-blue-700 text-blue-300"
+                  : "bg-slate-900 border-slate-800 text-slate-400"
+              }`}
+            >
+              <Bot size={14} />
+              {includeAI ? "AI Studios Included" : "Players Only"}
+            </button>
+          </div>
         </div>
 
-        {/* Your rank */}
+        {/* Your rank banner */}
         {currentUser && (
-          <div className="bg-[#111827] border border-violet-500/30 rounded-2xl p-4 flex items-center gap-3">
-            <div className="w-9 flex items-center justify-center shrink-0">
+          <div className="bg-gradient-to-r from-violet-950/80 to-[#111827] border border-violet-500/40 rounded-2xl p-4 flex items-center gap-3 shadow-lg">
+            <div className="w-10 flex items-center justify-center shrink-0">
               <RankBadge rank={currentUser.rank} />
             </div>
             <div className="min-w-0 flex-1">
               <p className="text-violet-300 font-bold text-sm truncate">
-                {currentUser.name} <span className="text-violet-400">(You)</span>
+                {currentUser.name} <span className="text-violet-400">(Your Studio)</span>
               </p>
-              <p className="text-slate-500 text-[11px]">
-                Ranked #{currentUser.rank} by {activeMetric.label.toLowerCase()}
+              <p className="text-slate-400 text-xs mt-0.5">
+                Ranked #{currentUser.rank} of {total} in {activeMetric.label.toLowerCase()} ({PERIODS.find((p) => p.key === period)?.label})
               </p>
             </div>
             <div className="text-right shrink-0">
               <p className="text-white font-black text-lg tabular-nums">
                 {activeMetric.value(currentUser)}
               </p>
-              <p className="text-slate-600 text-[10px] uppercase tracking-wider">
+              <p className="text-slate-400 text-[10px] uppercase tracking-wider font-semibold">
                 {activeMetric.label}
               </p>
             </div>
@@ -209,10 +304,10 @@ const Leaderboard = () => {
 
         {/* States */}
         {loading && (
-          <div className="flex items-center justify-center py-24">
+          <div className="flex items-center justify-center py-20">
             <div className="text-center space-y-3">
               <RefreshCw className="animate-spin text-violet-400 mx-auto" size={36} />
-              <p className="text-slate-400 font-medium">Loading leaderboard…</p>
+              <p className="text-slate-400 font-medium">Computing industry ranking metrics…</p>
             </div>
           </div>
         )}
@@ -229,7 +324,7 @@ const Leaderboard = () => {
             <Building2 className="text-slate-600 mx-auto mb-4" size={40} />
             <p className="text-slate-500 text-lg font-semibold">No studios to rank yet</p>
             <p className="text-slate-600 text-sm mt-2">
-              Studios will appear here as players build and release movies.
+              Studios and market competitors will appear here as the simulation progresses.
             </p>
           </div>
         )}
@@ -259,7 +354,7 @@ const Leaderboard = () => {
                   <ChevronLeft size={16} /> Prev
                 </button>
                 <span className="text-slate-400 text-sm font-semibold">
-                  Page {page} of {totalPages}
+                  Page {page} of {totalPages} ({total} studios total)
                 </span>
                 <button
                   type="button"
@@ -279,3 +374,4 @@ const Leaderboard = () => {
 };
 
 export default Leaderboard;
+


### PR DESCRIPTION
## Description
Complete the V1 Industry Leaderboards system and integrate it into the weekly simulation engine.

### Key Changes
- **Industry Ranking Engine (`industryLeaderboardEngine.js`):**
  - Deterministic ranking rules and tie-breaking comparator (Metric value DESC -> Prestige DESC -> Fans DESC -> Studio Name Alphabetical ASC).
  - Multi-period filtering: `weekly`, `monthly`, `yearly`, `all_time`.
  - Comprehensive metric coverage: `prestige`, `revenue`, `profit`, `box_office`, `fans`, `awards`, `blockbusters`, `level`.
  - Unified ranking of player studios alongside AI competitor rival studios.
  - Automatic rank snapshotting into `studio.seasonStats` and `gameState.industryRank` upon weekly tick progression.
- **Leaderboard Controller (`leaderboardController.js`):**
  - Exposes `/api/leaderboard` supporting pagination, period filtering, AI studio toggles, and requesting player's global rank.
- **Leaderboard UI (`Leaderboard.jsx`):**
  - Multi-metric tabs, period selector (All-time / Past Year / Past Month / This Week), AI Studio badge indicator, and player studio rank banner.
- **Unit & System Tests (`industryLeaderboard.test.js`):**
  - Deterministic tie-breaker assertions, period calculations, AI entry conversion, and empty-state error resilience.

## Verification
- Run `node --test tests/industryLeaderboard.test.js` (8/8 tests pass).
- Frontend linting and production build validated cleanly.

Closes #531
