### PR TITLE
feat: build V2 social media simulation ecosystem

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -59,6 +59,7 @@ import festivalRoutes from "./routes/festivalRoutes.js";
 import progressionRoutes from "./routes/progressionRoutes.js";
 import seederRoutes from "./routes/seederRoutes.js";
 import relationshipRoutes from "./routes/relationshipRoutes.js";
+import socialMediaRoutes from "./routes/socialMediaRoutes.js";
 
 const app = express();
 app.set("trust proxy", true);
@@ -162,6 +163,7 @@ app.use("/api/festivals", apiRateLimiter, festivalRoutes);
 app.use("/api/progression", apiRateLimiter, progressionRoutes);
 app.use("/api/seeder", apiRateLimiter, seederRoutes);
 app.use("/api/relationships", apiRateLimiter, relationshipRoutes);
+app.use("/api/social", apiRateLimiter, socialMediaRoutes);
 // app.use("/api/talent-agencies", apiRateLimiter, agencyRoutes);
 
 app.use((req, res) => {

--- a/backend/src/constants/socialPlatforms.js
+++ b/backend/src/constants/socialPlatforms.js
@@ -1,0 +1,90 @@
+/**
+ * Platform-specific audience and engagement models for the V2 social media simulation.
+ * Each platform has distinct growth rates, genre affinities, and viral characteristics.
+ */
+
+export const SOCIAL_PLATFORMS = {
+  INSTAGRAM: "INSTAGRAM",
+  TIKTOK: "TIKTOK",
+  YOUTUBE: "YOUTUBE",
+  X: "X",
+};
+
+export const PLATFORM_CONFIG = {
+  [SOCIAL_PLATFORMS.INSTAGRAM]: {
+    id: SOCIAL_PLATFORMS.INSTAGRAM,
+    name: "Instagram",
+    baseEngagement: 4.5,
+    followerGrowthRate: 0.015,
+    viralVariance: 0.3,
+    genreAffinity: { Romance: 1.4, Animation: 1.3, Comedy: 1.2 },
+    contentTypes: ["BEHIND_SCENES", "INFLUENCER", "AESTHETIC_TEASER"],
+    controversyAmplifier: 0.5,
+    initialFollowers: 5000,
+  },
+  [SOCIAL_PLATFORMS.TIKTOK]: {
+    id: SOCIAL_PLATFORMS.TIKTOK,
+    name: "TikTok",
+    baseEngagement: 8.0,
+    followerGrowthRate: 0.04,
+    viralVariance: 0.8,
+    genreAffinity: { Horror: 1.5, Comedy: 1.4, Action: 1.1 },
+    contentTypes: ["MEME", "CHALLENGE", "TRAILER_CLIP"],
+    controversyAmplifier: 0.6,
+    initialFollowers: 2000,
+  },
+  [SOCIAL_PLATFORMS.YOUTUBE]: {
+    id: SOCIAL_PLATFORMS.YOUTUBE,
+    name: "YouTube",
+    baseEngagement: 3.0,
+    followerGrowthRate: 0.008,
+    viralVariance: 0.25,
+    genreAffinity: { Action: 1.3, "Sci-Fi": 1.3, Drama: 1.2 },
+    contentTypes: ["FULL_TRAILER", "BEHIND_SCENES", "REVIEW_REACTION"],
+    controversyAmplifier: 0.3,
+    initialFollowers: 10000,
+  },
+  [SOCIAL_PLATFORMS.X]: {
+    id: SOCIAL_PLATFORMS.X,
+    name: "X",
+    baseEngagement: 2.5,
+    followerGrowthRate: 0.012,
+    viralVariance: 0.5,
+    genreAffinity: { Thriller: 1.3, Drama: 1.2 },
+    contentTypes: ["HOT_TAKE", "LIVE_REACTION", "HASHTAG"],
+    controversyAmplifier: 1.2,
+    initialFollowers: 3000,
+  },
+};
+
+export const SOCIAL_EVENT_TYPES = {
+  VIRAL_TRAILER: "VIRAL_TRAILER",
+  MEME_TREND: "MEME_TREND",
+  FAN_WAR: "FAN_WAR",
+  CANCEL_CULTURE: "CANCEL_CULTURE",
+  LEAK: "LEAK",
+  SPOILER: "SPOILER",
+  CELEBRITY_POST: "CELEBRITY_POST",
+  HASHTAG_TREND: "HASHTAG_TREND",
+  BACKLASH: "BACKLASH",
+};
+
+export const SOCIAL_CAMPAIGN_TYPES = {
+  TRAILER_PUSH: { id: "TRAILER_PUSH", name: "Trailer Push", cost: 200000, durationWeeks: 3, baseHype: 6 },
+  MEME_CAMPAIGN: { id: "MEME_CAMPAIGN", name: "Meme Campaign", cost: 100000, durationWeeks: 2, baseHype: 8 },
+  INFLUENCER_BLITZ: { id: "INFLUENCER_BLITZ", name: "Influencer Blitz", cost: 350000, durationWeeks: 4, baseHype: 10 },
+  HASHTAG_CHALLENGE: { id: "HASHTAG_CHALLENGE", name: "Hashtag Challenge", cost: 150000, durationWeeks: 2, baseHype: 7 },
+  BEHIND_SCENES: { id: "BEHIND_SCENES", name: "Behind the Scenes", cost: 120000, durationWeeks: 3, baseHype: 5 },
+};
+
+export const getPlatformGenreMultiplier = (platformId, genres = []) => {
+  const config = PLATFORM_CONFIG[platformId];
+  if (!config || !Array.isArray(genres) || genres.length === 0) return 1;
+
+  let best = 1;
+  for (const genre of genres) {
+    const multiplier = config.genreAffinity[genre];
+    if (multiplier && multiplier > best) best = multiplier;
+  }
+  return best;
+};

--- a/backend/src/controllers/simulationController.js
+++ b/backend/src/controllers/simulationController.js
@@ -12,6 +12,8 @@ import MarketDirector from "../models/MarketDirector.js";
 import MarketActor from "../models/MarketActor.js";
 import MarketCrewTeam from "../models/MarketCrewTeam.js";
 import PastAward from "../models/PastAward.js";
+import SocialMediaAccount from "../models/SocialMediaAccount.js";
+import SocialMediaEvent from "../models/SocialMediaEvent.js";
 import { generateDirectors } from "../services/director/directorGenerator.js";
 import { generateActors } from "../services/actor/actorGenerator.js";
 import { generateCrewTeams } from "../services/crew/crewGenerator.js";
@@ -271,6 +273,10 @@ export const resetGame = async (req, res) => {
       await MarketDirector.deleteMany({ userId: req.user._id }, { session });
       await MarketActor.deleteMany({ userId: req.user._id }, { session });
       await MarketCrewTeam.deleteMany({ userId: req.user._id }, { session });
+
+      // Clear social media data (issue #534)
+      await SocialMediaAccount.deleteMany({ userId: req.user._id }, { session });
+      await SocialMediaEvent.deleteMany({ userId: req.user._id }, { session });
 
       // Regenerate market talents
       const freshDirectors = generateDirectors(50).map((d) => ({ ...d, userId: req.user._id }));

--- a/backend/src/controllers/socialMediaController.js
+++ b/backend/src/controllers/socialMediaController.js
@@ -1,0 +1,205 @@
+import GameState from "../models/GameState.js";
+import Studio from "../models/Studio.js";
+import Movie from "../models/Movie.js";
+import SocialMediaAccount from "../models/SocialMediaAccount.js";
+import SocialMediaEvent from "../models/SocialMediaEvent.js";
+import {
+  ensurePlatformAccounts,
+  launchSocialCampaign,
+  getSocialBoxOfficeMultiplier,
+} from "../services/simulation/engines/socialMediaEngine.js";
+import {
+  PLATFORM_CONFIG,
+  SOCIAL_CAMPAIGN_TYPES,
+} from "../constants/socialPlatforms.js";
+
+/**
+ * GET /api/social/accounts
+ */
+export const getSocialAccounts = async (req, res) => {
+  try {
+    const userId = req.user._id;
+    const studio = await Studio.findOne({ owner: userId });
+    if (!studio) {
+      return res.status(404).json({ success: false, message: "Studio not found." });
+    }
+
+    const accounts = await ensurePlatformAccounts(userId, studio._id);
+
+    const enriched = accounts.map((acc) => ({
+      ...acc.toObject(),
+      platformName: PLATFORM_CONFIG[acc.platform]?.name || acc.platform,
+    }));
+
+    return res.status(200).json({
+      success: true,
+      accounts: enriched,
+      boxOfficeMultiplier: getSocialBoxOfficeMultiplier(accounts),
+    });
+  } catch (error) {
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+/**
+ * PUT /api/social/accounts/:platform/budget
+ */
+export const updateSocialBudget = async (req, res) => {
+  try {
+    const userId = req.user._id;
+    const { platform } = req.params;
+    const { weeklyBudget } = req.body;
+
+    const account = await SocialMediaAccount.findOne({ userId, platform });
+    if (!account) {
+      return res.status(404).json({ success: false, message: "Platform account not found." });
+    }
+
+    account.weeklyBudget = weeklyBudget;
+    await account.save();
+
+    return res.status(200).json({
+      success: true,
+      message: `Weekly budget updated for ${PLATFORM_CONFIG[platform]?.name || platform}.`,
+      account,
+    });
+  } catch (error) {
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+/**
+ * POST /api/social/campaigns
+ */
+export const createSocialCampaign = async (req, res) => {
+  try {
+    const userId = req.user._id;
+    const { platform, movieId, campaignType } = req.body;
+
+    const studio = await Studio.findOne({ owner: userId });
+    const gameState = await GameState.findOne({ user: userId });
+    if (!studio || !gameState) {
+      return res.status(404).json({ success: false, message: "Game state not found." });
+    }
+
+    const movie = await Movie.findOne({ _id: movieId, studioId: studio._id });
+    if (!movie) {
+      return res.status(404).json({ success: false, message: "Movie not found." });
+    }
+
+    const { account, campaign } = await launchSocialCampaign({
+      userId,
+      studioId: studio._id,
+      platform,
+      movieId: movie._id,
+      movieTitle: movie.title,
+      campaignType,
+      currentWeek: gameState.currentWeek || 1,
+      studio,
+    });
+
+    return res.status(200).json({
+      success: true,
+      message: `${campaign.name} launched on ${PLATFORM_CONFIG[platform]?.name || platform} for "${movie.title}".`,
+      account,
+      campaign,
+    });
+  } catch (error) {
+    const status = error.message.includes("Insufficient") ? 400 : 500;
+    return res.status(status).json({ success: false, message: error.message });
+  }
+};
+
+/**
+ * GET /api/social/events
+ */
+export const getSocialEvents = async (req, res) => {
+  try {
+    const userId = req.user._id;
+    const limit = Math.min(Number(req.query.limit) || 50, 100);
+
+    const events = await SocialMediaEvent.find({ userId })
+      .sort({ week: -1, createdAt: -1 })
+      .limit(limit)
+      .lean();
+
+    return res.status(200).json({
+      success: true,
+      count: events.length,
+      events,
+    });
+  } catch (error) {
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+/**
+ * GET /api/social/analytics
+ */
+export const getSocialAnalytics = async (req, res) => {
+  try {
+    const userId = req.user._id;
+    const accounts = await SocialMediaAccount.find({ userId }).lean();
+
+    const totalFollowers = accounts.reduce((sum, a) => sum + (a.followers || 0), 0);
+    const avgEngagement =
+      accounts.length > 0
+        ? accounts.reduce((sum, a) => sum + (a.engagementRate || 0), 0) / accounts.length
+        : 0;
+    const totalMomentum = accounts.reduce((sum, a) => sum + (a.viralMomentum || 0), 0);
+
+    const recentEvents = await SocialMediaEvent.find({ userId })
+      .sort({ week: -1 })
+      .limit(10)
+      .lean();
+
+    const positiveEvents = recentEvents.filter((e) => e.sentiment === "positive").length;
+    const negativeEvents = recentEvents.filter((e) => e.sentiment === "negative").length;
+
+    return res.status(200).json({
+      success: true,
+      analytics: {
+        totalFollowers,
+        avgEngagement: Number(avgEngagement.toFixed(2)),
+        totalMomentum: Number(totalMomentum.toFixed(2)),
+        boxOfficeMultiplier: getSocialBoxOfficeMultiplier(accounts),
+        recentSentiment: { positive: positiveEvents, negative: negativeEvents },
+        platforms: accounts.map((a) => ({
+          platform: a.platform,
+          name: PLATFORM_CONFIG[a.platform]?.name,
+          followers: a.followers,
+          engagementRate: a.engagementRate,
+          viralMomentum: a.viralMomentum,
+          activeCampaigns: a.activeCampaigns?.length || 0,
+        })),
+      },
+      campaignTypes: Object.values(SOCIAL_CAMPAIGN_TYPES),
+    });
+  } catch (error) {
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+/**
+ * GET /api/social/movies
+ * Returns active movies eligible for social campaigns.
+ */
+export const getCampaignEligibleMovies = async (req, res) => {
+  try {
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({ success: false, message: "Studio not found." });
+    }
+
+    const movies = await Movie.find({
+      studioId: studio._id,
+      status: { $nin: ["RELEASED", "RELEASED_STREAMING"] },
+    })
+      .select("title status hype genres")
+      .lean();
+
+    return res.status(200).json({ success: true, movies });
+  } catch (error) {
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};

--- a/backend/src/models/SocialMediaAccount.js
+++ b/backend/src/models/SocialMediaAccount.js
@@ -1,0 +1,67 @@
+import mongoose from "mongoose";
+import { SOCIAL_PLATFORMS } from "../constants/socialPlatforms.js";
+
+/**
+ * @fileoverview SocialMediaAccount Model
+ *
+ * Stores per-platform social media presence for a studio.
+ * Kept in a separate collection to avoid unbounded GameState growth.
+ */
+
+const activeCampaignSchema = new mongoose.Schema(
+  {
+    movieId: { type: mongoose.Schema.Types.ObjectId, ref: "Movie", required: true },
+    movieTitle: { type: String, default: "" },
+    campaignType: { type: String, required: true },
+    startWeek: { type: Number, required: true },
+    endWeek: { type: Number, required: true },
+    spend: { type: Number, default: 0 },
+  },
+  { _id: false }
+);
+
+const weeklyMetricSchema = new mongoose.Schema(
+  {
+    week: { type: Number, required: true },
+    impressions: { type: Number, default: 0 },
+    engagement: { type: Number, default: 0 },
+    hypeGenerated: { type: Number, default: 0 },
+    sentiment: { type: String, enum: ["positive", "negative", "neutral"], default: "neutral" },
+  },
+  { _id: false }
+);
+
+const socialMediaAccountSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      index: true,
+    },
+    studioId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Studio",
+      required: true,
+      index: true,
+    },
+    platform: {
+      type: String,
+      enum: Object.values(SOCIAL_PLATFORMS),
+      required: true,
+    },
+    followers: { type: Number, default: 0, min: 0 },
+    engagementRate: { type: Number, default: 0, min: 0, max: 100 },
+    weeklyBudget: { type: Number, default: 0, min: 0 },
+    viralMomentum: { type: Number, default: 0, min: 0, max: 100 },
+    activeCampaigns: [activeCampaignSchema],
+    weeklyMetrics: [weeklyMetricSchema],
+  },
+  { timestamps: true }
+);
+
+socialMediaAccountSchema.index({ userId: 1, platform: 1 }, { unique: true });
+
+const SocialMediaAccount = mongoose.model("SocialMediaAccount", socialMediaAccountSchema);
+
+export default SocialMediaAccount;

--- a/backend/src/models/SocialMediaEvent.js
+++ b/backend/src/models/SocialMediaEvent.js
@@ -1,0 +1,50 @@
+import mongoose from "mongoose";
+import { SOCIAL_PLATFORMS, SOCIAL_EVENT_TYPES } from "../constants/socialPlatforms.js";
+
+/**
+ * @fileoverview SocialMediaEvent Model
+ *
+ * Persists social simulation events separately from GameState.
+ * Events are capped per user to prevent unbounded growth.
+ */
+
+const socialMediaEventSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      index: true,
+    },
+    week: { type: Number, required: true },
+    platform: {
+      type: String,
+      enum: Object.values(SOCIAL_PLATFORMS),
+      required: true,
+    },
+    eventType: {
+      type: String,
+      enum: Object.values(SOCIAL_EVENT_TYPES),
+      required: true,
+    },
+    sentiment: {
+      type: String,
+      enum: ["positive", "negative", "neutral"],
+      default: "neutral",
+    },
+    movieId: { type: mongoose.Schema.Types.ObjectId, ref: "Movie" },
+    movieTitle: { type: String, default: "" },
+    description: { type: String, required: true },
+    hypeDelta: { type: Number, default: 0 },
+    reputationDelta: { type: Number, default: 0 },
+    viralityScore: { type: Number, default: 0, min: 0, max: 100 },
+  },
+  { timestamps: true }
+);
+
+socialMediaEventSchema.index({ userId: 1, week: -1 });
+socialMediaEventSchema.index({ userId: 1, createdAt: -1 });
+
+const SocialMediaEvent = mongoose.model("SocialMediaEvent", socialMediaEventSchema);
+
+export default SocialMediaEvent;

--- a/backend/src/routes/socialMediaRoutes.js
+++ b/backend/src/routes/socialMediaRoutes.js
@@ -1,0 +1,26 @@
+import express from "express";
+import { protect } from "../middleware/authMiddleware.js";
+import { validate } from "../middleware/validationMiddleware.js";
+import {
+  updateSocialBudgetSchema,
+  launchSocialCampaignSchema,
+} from "../validators/socialMediaValidators.js";
+import {
+  getSocialAccounts,
+  updateSocialBudget,
+  createSocialCampaign,
+  getSocialEvents,
+  getSocialAnalytics,
+  getCampaignEligibleMovies,
+} from "../controllers/socialMediaController.js";
+
+const router = express.Router();
+
+router.get("/accounts", protect, getSocialAccounts);
+router.put("/accounts/:platform/budget", protect, validate(updateSocialBudgetSchema), updateSocialBudget);
+router.post("/campaigns", protect, validate(launchSocialCampaignSchema), createSocialCampaign);
+router.get("/events", protect, getSocialEvents);
+router.get("/analytics", protect, getSocialAnalytics);
+router.get("/movies", protect, getCampaignEligibleMovies);
+
+export default router;

--- a/backend/src/services/movie/releaseService.js
+++ b/backend/src/services/movie/releaseService.js
@@ -13,6 +13,8 @@ import { generateNewsFromRelease } from "../simulation/engines/newsEngine.js";
 import { findScriptById } from "./movieValidationService.js";
 import { computeClashPenalty } from "../simulation/engines/clashEngine.js";
 import { addHistoricRecord } from "../simulation/helpers/historicRecordHelper.js";
+import SocialMediaAccount from "../../models/SocialMediaAccount.js";
+import { getSocialBoxOfficeMultiplier } from "../simulation/engines/socialMediaEngine.js";
 
 /**
  * Handles the complete release process of a movie (manual or scheduled).
@@ -60,6 +62,8 @@ export const performMovieRelease = async (movie, studio, gameState, session = nu
   const activeTrends = gameState.marketTrends?.activeTrends || [];
   const marketMultiplier = getGenreMultiplier(activeTrends, script?.genres);
   const demographicMultiplier = getDemographicMultiplier(script?.genres, movie.marketingCampaigns);
+  const socialAccounts = await SocialMediaAccount.find({ userId: gameState.user }).lean();
+  const socialMultiplier = getSocialBoxOfficeMultiplier(socialAccounts);
   const boxOffice = generateBoxOffice(
     movie,
     leadActor,
@@ -69,6 +73,14 @@ export const performMovieRelease = async (movie, studio, gameState, session = nu
     franchiseDoc
   );
   Object.assign(movie, boxOffice);
+
+  if (socialMultiplier !== 1) {
+    movie.openingWeekend = Math.round(movie.openingWeekend * socialMultiplier);
+    movie.worldwideGross = Math.round(movie.worldwideGross * socialMultiplier);
+    movie.domesticGross = Math.round(movie.domesticGross * socialMultiplier);
+    movie.internationalGross = Math.round(movie.internationalGross * socialMultiplier);
+    movie.boxOffice = movie.worldwideGross;
+  }
 
   // Apply clash penalty
   const clash = computeClashPenalty(gameState, movie);

--- a/backend/src/services/simulation/engines/socialMediaEngine.js
+++ b/backend/src/services/simulation/engines/socialMediaEngine.js
@@ -1,0 +1,505 @@
+/**
+ * @fileoverview Social Media Simulation Engine (issue #534)
+ *
+ * Simulates Instagram, TikTok, YouTube, and X as distinct platforms with
+ * unique audience/engagement models. Generates social events from simulation
+ * state, applies bounded hype/reputation effects, and decays momentum weekly.
+ */
+
+import SocialMediaAccount from "../../../models/SocialMediaAccount.js";
+import SocialMediaEvent from "../../../models/SocialMediaEvent.js";
+import TalentRelationship, { RELATIONSHIP_TYPES } from "../../../models/TalentRelationship.js";
+import {
+  SOCIAL_PLATFORMS,
+  PLATFORM_CONFIG,
+  SOCIAL_EVENT_TYPES,
+  SOCIAL_CAMPAIGN_TYPES,
+  getPlatformGenreMultiplier,
+} from "../../../constants/socialPlatforms.js";
+import { addNotification } from "../helpers/notificationHelper.js";
+import { generateNewsFromEvent } from "./newsEngine.js";
+
+const MAX_WEEKLY_METRICS = 52;
+const MAX_EVENTS_PER_USER = 100;
+const MOMENTUM_DECAY = 0.15;
+
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+/**
+ * Deterministic pseudo-random in [0, 1) from a numeric seed.
+ */
+export const deterministicRandom = (seed) => {
+  const x = Math.sin(Number(seed)) * 10000;
+  return x - Math.floor(x);
+};
+
+/**
+ * Creates a seeded RNG function for a given user/week context.
+ */
+export const createSeededRng = (userId, week, salt = 0) => {
+  let counter = 0;
+  const baseSeed = String(userId).slice(-6) + week * 997 + salt * 131;
+  return () => deterministicRandom(baseSeed + counter++);
+};
+
+/**
+ * Calculates platform-specific engagement for content given genre affinity.
+ */
+export const calculatePlatformEngagement = (platformId, genres = [], followerCount = 0, rng = Math.random) => {
+  const config = PLATFORM_CONFIG[platformId];
+  if (!config) return { engagement: 0, impressions: 0 };
+
+  const genreMultiplier = getPlatformGenreMultiplier(platformId, genres);
+  const followerFactor = Math.log10(Math.max(followerCount, 100)) / 5;
+  const variance = 1 + (rng() - 0.5) * config.viralVariance;
+
+  const engagement = clamp(
+    config.baseEngagement * genreMultiplier * followerFactor * variance,
+    0,
+    100
+  );
+  const impressions = Math.floor(followerCount * (engagement / 100) * (1 + rng() * 0.5));
+
+  return {
+    engagement: Number(engagement.toFixed(2)),
+    impressions,
+  };
+};
+
+/**
+ * Calculates bounded viral hype boost for a movie on a platform.
+ */
+export const calculateViralHypeBoost = (platformId, movie, account, rng = Math.random) => {
+  const config = PLATFORM_CONFIG[platformId];
+  if (!config || !movie) return 0;
+
+  const genres = movie.genre ? [movie.genre] : movie.genres || [];
+  const genreMultiplier = getPlatformGenreMultiplier(platformId, genres);
+  const momentumFactor = 1 + (account.viralMomentum || 0) / 200;
+  const followerFactor = Math.min(1.5, Math.log10(Math.max(account.followers, 100)) / 4);
+
+  const baseBoost = 2 + rng() * 4;
+  const raw = baseBoost * genreMultiplier * momentumFactor * followerFactor;
+
+  return Number(clamp(raw, 0, 12).toFixed(2));
+};
+
+/**
+ * Returns a bounded box-office multiplier from accumulated social momentum.
+ */
+export const getSocialBoxOfficeMultiplier = (accounts = []) => {
+  if (!accounts.length) return 1;
+
+  const avgMomentum =
+    accounts.reduce((sum, acc) => sum + (acc.viralMomentum || 0), 0) / accounts.length;
+
+  return Number(clamp(1 + avgMomentum / 500, 0.95, 1.15).toFixed(4));
+};
+
+/**
+ * Initializes all four platform accounts for a user if they don't exist.
+ */
+export const ensurePlatformAccounts = async (userId, studioId) => {
+  const existing = await SocialMediaAccount.find({ userId }).lean();
+  const existingPlatforms = new Set(existing.map((a) => a.platform));
+  const created = [];
+
+  for (const platformId of Object.values(SOCIAL_PLATFORMS)) {
+    if (existingPlatforms.has(platformId)) continue;
+
+    const config = PLATFORM_CONFIG[platformId];
+    const account = await SocialMediaAccount.create({
+      userId,
+      studioId,
+      platform: platformId,
+      followers: config.initialFollowers,
+      engagementRate: config.baseEngagement,
+      weeklyBudget: 0,
+      viralMomentum: 0,
+      activeCampaigns: [],
+      weeklyMetrics: [],
+    });
+    created.push(account);
+  }
+
+  return SocialMediaAccount.find({ userId });
+};
+
+/**
+ * Generates social events from current simulation state.
+ */
+export const generateSocialEventsFromState = async ({
+  userId,
+  week,
+  studio,
+  movies,
+  accounts,
+  rng = Math.random,
+  relationships: relationshipsOverride = null,
+}) => {
+  const events = [];
+
+  const activeMovies = movies.filter((m) =>
+    ["PRE_PRODUCTION", "PRODUCTION", "POST_PRODUCTION", "READY_FOR_RELEASE"].includes(m.status)
+  );
+
+  // Positive: viral trailer reaction for high-hype movies
+  for (const movie of activeMovies) {
+    if ((movie.hype || 0) >= 60 && rng() < 0.12) {
+      const platform = accounts[Math.floor(rng() * accounts.length)];
+      if (!platform) continue;
+
+      const hypeDelta = Number(clamp(3 + rng() * 5, 1, 10).toFixed(2));
+      events.push({
+        userId,
+        week,
+        platform: platform.platform,
+        eventType: SOCIAL_EVENT_TYPES.VIRAL_TRAILER,
+        sentiment: "positive",
+        movieId: movie._id,
+        movieTitle: movie.title,
+        description: `Trailer for "${movie.title}" is going viral on ${PLATFORM_CONFIG[platform.platform].name}!`,
+        hypeDelta,
+        reputationDelta: 0,
+        viralityScore: Math.floor(60 + rng() * 40),
+      });
+    }
+  }
+
+  // Drama from talent relationships (fan wars, celebrity buzz)
+  const relationships =
+    relationshipsOverride ??
+    (await TalentRelationship.find({
+      userId,
+      type: { $in: [RELATIONSHIP_TYPES.RIVALRY, RELATIONSHIP_TYPES.ROMANTIC, RELATIONSHIP_TYPES.BREAKUP] },
+    })
+      .limit(10)
+      .lean());
+
+  for (const rel of relationships) {
+    if (rng() >= 0.08) continue;
+
+    const isNegative = rel.type === RELATIONSHIP_TYPES.BREAKUP;
+    const platformId = rel.type === RELATIONSHIP_TYPES.RIVALRY ? SOCIAL_PLATFORMS.X : SOCIAL_PLATFORMS.INSTAGRAM;
+    const eventType =
+      rel.type === RELATIONSHIP_TYPES.RIVALRY
+        ? SOCIAL_EVENT_TYPES.FAN_WAR
+        : rel.type === RELATIONSHIP_TYPES.BREAKUP
+          ? SOCIAL_EVENT_TYPES.BACKLASH
+          : SOCIAL_EVENT_TYPES.CELEBRITY_POST;
+
+    const linkedMovie = activeMovies.find(
+      (m) => m.leadActorId === rel.talentAId || m.leadActorId === rel.talentBId
+    );
+
+    events.push({
+      userId,
+      week,
+      platform: platformId,
+      eventType,
+      sentiment: isNegative ? "negative" : "positive",
+      movieId: linkedMovie?._id,
+      movieTitle: linkedMovie?.title || "",
+      description:
+        rel.type === RELATIONSHIP_TYPES.RIVALRY
+          ? `Fan war erupts between ${rel.talentAName} and ${rel.talentBName} stans on ${PLATFORM_CONFIG[platformId].name}.`
+          : rel.type === RELATIONSHIP_TYPES.BREAKUP
+            ? `Breakup gossip about ${rel.talentAName} and ${rel.talentBName} trends on social media.`
+            : `${rel.talentAName} and ${rel.talentBName}'s off-screen chemistry sparks fan excitement online.`,
+      hypeDelta: isNegative ? 2 : Number(clamp(2 + rng() * 4, 1, 8).toFixed(2)),
+      reputationDelta: isNegative ? -5 : 0,
+      viralityScore: Math.floor(40 + rng() * 50),
+    });
+  }
+
+  // Negative: cancel-culture / backlash from low reputation
+  if ((studio.reputation || 100) < 70 && rng() < 0.06) {
+    const platformId = SOCIAL_PLATFORMS.X;
+    events.push({
+      userId,
+      week,
+      platform: platformId,
+      eventType: SOCIAL_EVENT_TYPES.CANCEL_CULTURE,
+      sentiment: "negative",
+      description: "A cancel-culture hashtag targeting your studio is trending on X.",
+      hypeDelta: 0,
+      reputationDelta: -8,
+      viralityScore: Math.floor(50 + rng() * 30),
+    });
+  }
+
+  // Leaks and spoilers for movies nearing release
+  for (const movie of activeMovies.filter((m) => m.status === "READY_FOR_RELEASE")) {
+    if (rng() >= 0.05) continue;
+
+    const platformId = rng() < 0.5 ? SOCIAL_PLATFORMS.X : SOCIAL_PLATFORMS.TIKTOK;
+    const isSpoiler = rng() < 0.5;
+
+    events.push({
+      userId,
+      week,
+      platform: platformId,
+      eventType: isSpoiler ? SOCIAL_EVENT_TYPES.SPOILER : SOCIAL_EVENT_TYPES.LEAK,
+      sentiment: "negative",
+      movieId: movie._id,
+      movieTitle: movie.title,
+      description: isSpoiler
+        ? `Major spoilers for "${movie.title}" are spreading on ${PLATFORM_CONFIG[platformId].name}.`
+        : `Production leak about "${movie.title}" surfaces on ${PLATFORM_CONFIG[platformId].name}.`,
+      hypeDelta: isSpoiler ? -3 : 4,
+      reputationDelta: isSpoiler ? -3 : 0,
+      viralityScore: Math.floor(30 + rng() * 40),
+    });
+  }
+
+  // Meme trends on TikTok for comedy/horror
+  const memeMovie = activeMovies.find((m) => {
+    const g = m.genre || (m.genres || [])[0];
+    return ["Comedy", "Horror"].includes(g);
+  });
+  if (memeMovie && rng() < 0.1) {
+    events.push({
+      userId,
+      week,
+      platform: SOCIAL_PLATFORMS.TIKTOK,
+      eventType: SOCIAL_EVENT_TYPES.MEME_TREND,
+      sentiment: "positive",
+      movieId: memeMovie._id,
+      movieTitle: memeMovie.title,
+      description: `A meme trend featuring "${memeMovie.title}" is exploding on TikTok.`,
+      hypeDelta: Number(clamp(4 + rng() * 6, 2, 12).toFixed(2)),
+      reputationDelta: 0,
+      viralityScore: Math.floor(70 + rng() * 30),
+    });
+  }
+
+  return events;
+};
+
+/**
+ * Applies generated events to movies, studio reputation, and platform momentum.
+ */
+export const applySocialEvents = async (events, movies, studio, accounts, gameState) => {
+  const movieMap = new Map(movies.map((m) => [String(m._id), m]));
+  const accountMap = new Map(accounts.map((a) => [a.platform, a]));
+  const savedEvents = [];
+
+  for (const ev of events) {
+    if (ev.movieId) {
+      const movie = movieMap.get(String(ev.movieId));
+      if (movie && ev.hypeDelta) {
+        movie.hype = clamp((movie.hype || 0) + ev.hypeDelta, 0, 100);
+        await movie.save();
+      }
+    }
+
+    if (ev.reputationDelta && studio) {
+      studio.reputation = clamp((studio.reputation || 100) + ev.reputationDelta, 0, 100);
+    }
+
+    const account = accountMap.get(ev.platform);
+    if (account) {
+      if (ev.sentiment === "positive") {
+        account.viralMomentum = clamp((account.viralMomentum || 0) + ev.viralityScore * 0.1, 0, 100);
+      } else if (ev.sentiment === "negative") {
+        account.viralMomentum = clamp((account.viralMomentum || 0) - ev.viralityScore * 0.05, 0, 100);
+        account.followers = Math.max(0, Math.floor((account.followers || 0) * 0.995));
+      }
+    }
+
+    const saved = await SocialMediaEvent.create(ev);
+    savedEvents.push(saved);
+
+    const platformName = PLATFORM_CONFIG[ev.platform]?.name || ev.platform;
+    const emoji = ev.sentiment === "negative" ? "📉" : "📱";
+    addNotification(gameState, `${emoji} ${platformName}: ${ev.description}`);
+
+    await generateNewsFromEvent(
+      `${platformName} Buzz`,
+      ev.description,
+      ev.week
+    );
+  }
+
+  return savedEvents;
+};
+
+/**
+ * Trims old events to keep collection bounded.
+ */
+export const trimSocialEvents = async (userId) => {
+  const count = await SocialMediaEvent.countDocuments({ userId });
+  if (count <= MAX_EVENTS_PER_USER) return;
+
+  const excess = count - MAX_EVENTS_PER_USER;
+  const oldest = await SocialMediaEvent.find({ userId })
+    .sort({ createdAt: 1 })
+    .limit(excess)
+    .select("_id")
+    .lean();
+
+  if (oldest.length > 0) {
+    await SocialMediaEvent.deleteMany({ _id: { $in: oldest.map((e) => e._id) } });
+  }
+};
+
+/**
+ * Main weekly social media processing tick.
+ */
+export const processWeeklySocialMedia = async (gameState, studio, rng = null) => {
+  if (!gameState?.user || !studio?._id) return { eventsGenerated: 0, totalSpend: 0 };
+
+  const userId = gameState.user;
+  const week = gameState.currentWeek || 1;
+  const seededRng = rng || createSeededRng(userId, week);
+
+  const accounts = await ensurePlatformAccounts(userId, studio._id);
+
+  const { default: Movie } = await import("../../../models/Movie.js");
+  const movies = await Movie.find({
+    studioId: studio._id,
+    status: { $nin: ["RELEASED", "RELEASED_STREAMING"] },
+  });
+
+  let totalSpend = 0;
+
+  for (const account of accounts) {
+    const config = PLATFORM_CONFIG[account.platform];
+    const budget = Number(account.weeklyBudget || 0);
+
+    // Deduct weekly platform budget
+    if (budget > 0 && (studio.money || 0) >= budget) {
+      studio.money = Math.max(0, studio.money - budget);
+      totalSpend += budget;
+
+      const growth = Math.floor(budget * config.followerGrowthRate * (0.8 + seededRng() * 0.4));
+      account.followers = (account.followers || 0) + growth;
+    }
+
+    // Process active campaigns
+    account.activeCampaigns = (account.activeCampaigns || []).filter((c) => c.endWeek >= week);
+
+    for (const campaign of account.activeCampaigns || []) {
+      const movie = movies.find((m) => String(m._id) === String(campaign.movieId));
+      if (!movie) continue;
+
+      const campaignDef = SOCIAL_CAMPAIGN_TYPES[campaign.campaignType];
+      if (!campaignDef) continue;
+
+      const hypeBoost = calculateViralHypeBoost(account.platform, movie, account, seededRng);
+      movie.hype = clamp((movie.hype || 0) + hypeBoost, 0, 100);
+      account.viralMomentum = clamp((account.viralMomentum || 0) + hypeBoost * 0.5, 0, 100);
+
+      const { engagement, impressions } = calculatePlatformEngagement(
+        account.platform,
+        movie.genre ? [movie.genre] : movie.genres || [],
+        account.followers,
+        seededRng
+      );
+
+      account.weeklyMetrics = account.weeklyMetrics || [];
+      account.weeklyMetrics.push({
+        week,
+        impressions,
+        engagement,
+        hypeGenerated: hypeBoost,
+        sentiment: "positive",
+      });
+
+      await movie.save();
+    }
+
+    // Decay viral momentum
+    account.viralMomentum = clamp(
+      (account.viralMomentum || 0) * (1 - MOMENTUM_DECAY),
+      0,
+      100
+    );
+
+    // Cap weekly metrics
+    if (account.weeklyMetrics.length > MAX_WEEKLY_METRICS) {
+      account.weeklyMetrics = account.weeklyMetrics.slice(-MAX_WEEKLY_METRICS);
+    }
+
+    // Update engagement rate from recent metrics
+    const recentMetrics = account.weeklyMetrics.slice(-4);
+    if (recentMetrics.length > 0) {
+      const avgEngagement =
+        recentMetrics.reduce((sum, m) => sum + (m.engagement || 0), 0) / recentMetrics.length;
+      account.engagementRate = clamp(avgEngagement, 0, 100);
+    }
+
+    await account.save();
+  }
+
+  // Generate and apply social events from simulation state
+  const events = await generateSocialEventsFromState({
+    userId,
+    week,
+    studio,
+    movies,
+    accounts,
+    rng: seededRng,
+  });
+
+  if (events.length > 0) {
+    await applySocialEvents(events, movies, studio, accounts, gameState);
+  }
+
+  await trimSocialEvents(userId);
+
+  if (totalSpend > 0) {
+    studio._weeklyMarketingCosts = (studio._weeklyMarketingCosts || 0) + totalSpend;
+  }
+
+  return { eventsGenerated: events.length, totalSpend };
+};
+
+/**
+ * Launches a platform-specific social campaign for a movie.
+ */
+export const launchSocialCampaign = async ({
+  userId,
+  studioId,
+  platform,
+  movieId,
+  movieTitle,
+  campaignType,
+  currentWeek,
+  studio,
+}) => {
+  const campaignDef = SOCIAL_CAMPAIGN_TYPES[campaignType];
+  if (!campaignDef) {
+    throw new Error("Invalid campaign type.");
+  }
+
+  if ((studio.money || 0) < campaignDef.cost) {
+    throw new Error("Insufficient funds for this social campaign.");
+  }
+
+  const account = await SocialMediaAccount.findOne({ userId, platform });
+  if (!account) {
+    throw new Error("Platform account not found.");
+  }
+
+  studio.money = Math.max(0, studio.money - campaignDef.cost);
+
+  account.activeCampaigns = account.activeCampaigns || [];
+  account.activeCampaigns.push({
+    movieId,
+    movieTitle,
+    campaignType,
+    startWeek: currentWeek,
+    endWeek: currentWeek + campaignDef.durationWeeks,
+    spend: campaignDef.cost,
+  });
+
+  account.viralMomentum = clamp((account.viralMomentum || 0) + campaignDef.baseHype, 0, 100);
+
+  await account.save();
+  await studio.save();
+
+  return { account, campaign: campaignDef };
+};
+
+export default processWeeklySocialMedia;

--- a/backend/src/services/simulation/engines/tickEngine.js
+++ b/backend/src/services/simulation/engines/tickEngine.js
@@ -21,6 +21,7 @@ import { processUnionSatisfaction } from "./unionEngine.js";
 import { processScandals } from "./prEngine.js";
 import { processScheduledReleases } from "./clashEngine.js";
 import { processWeeklyRelationships } from "./relationshipEngine.js";
+import { processWeeklySocialMedia } from "./socialMediaEngine.js";
 
 import { addNotification } from "../helpers/notificationHelper.js";
 import { processWriterAging } from "../helpers/agingHelper.js";
@@ -249,6 +250,11 @@ export const processWeeklyTick = async (gameState, studio) => {
   // 12. PR & Scandal events — roll for studio scandals and apply
   //     reputation decay (issue #281).
   processScandals(gameState, studio);
+
+  // 12b. Social Media Simulation Ecosystem (issue #534)
+  if (gameState.user) {
+    await processWeeklySocialMedia(gameState, studio);
+  }
 
   // 13. Talent Relationship & Chemistry Lifecycle (issue #535)
   if (gameState.user) {

--- a/backend/src/validators/socialMediaValidators.js
+++ b/backend/src/validators/socialMediaValidators.js
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { SOCIAL_PLATFORMS } from "../constants/socialPlatforms.js";
+import { objectIdString } from "./gameplayValidators.js";
+
+export const updateSocialBudgetSchema = {
+  body: z.object({
+    weeklyBudget: z.number().min(0, "Weekly budget must be a non-negative number"),
+  }),
+};
+
+export const launchSocialCampaignSchema = {
+  body: z.object({
+    platform: z.enum(Object.values(SOCIAL_PLATFORMS)),
+    movieId: objectIdString,
+    campaignType: z.string().min(1, "Campaign type is required"),
+  }),
+};

--- a/backend/tests/socialMediaEngine.test.js
+++ b/backend/tests/socialMediaEngine.test.js
@@ -1,0 +1,153 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  deterministicRandom,
+  createSeededRng,
+  calculatePlatformEngagement,
+  calculateViralHypeBoost,
+  getSocialBoxOfficeMultiplier,
+  generateSocialEventsFromState,
+} from "../src/services/simulation/engines/socialMediaEngine.js";
+import {
+  SOCIAL_PLATFORMS,
+  SOCIAL_EVENT_TYPES,
+} from "../src/constants/socialPlatforms.js";
+
+describe("Social Media Engine Tests (issue #534)", () => {
+  it("produces deterministic random values for the same seed", () => {
+    const a = deterministicRandom(534001);
+    const b = deterministicRandom(534001);
+    const c = deterministicRandom(534002);
+
+    assert.strictEqual(a, b);
+    assert.notStrictEqual(a, c);
+    assert.ok(a >= 0 && a < 1);
+  });
+
+  it("creates reproducible RNG sequences when seeded", () => {
+    const rng1 = createSeededRng("user123", 10, 0);
+    const rng2 = createSeededRng("user123", 10, 0);
+
+    const seq1 = [rng1(), rng1(), rng1()];
+    const seq2 = [rng2(), rng2(), rng2()];
+
+    assert.deepStrictEqual(seq1, seq2);
+  });
+
+  it("calculates distinct engagement per platform", () => {
+    const rng = () => 0.5;
+    const instagram = calculatePlatformEngagement(SOCIAL_PLATFORMS.INSTAGRAM, ["Romance"], 10000, rng);
+    const tiktok = calculatePlatformEngagement(SOCIAL_PLATFORMS.TIKTOK, ["Horror"], 10000, rng);
+    const youtube = calculatePlatformEngagement(SOCIAL_PLATFORMS.YOUTUBE, ["Action"], 10000, rng);
+
+    assert.ok(tiktok.engagement > youtube.engagement, "TikTok should have higher base engagement than YouTube");
+    assert.ok(instagram.impressions > 0);
+    assert.ok(tiktok.impressions > 0);
+  });
+
+  it("calculates bounded viral hype boost", () => {
+    const movie = { title: "Test Movie", genre: "Horror" };
+    const account = { platform: SOCIAL_PLATFORMS.TIKTOK, followers: 50000, viralMomentum: 40 };
+    const boost = calculateViralHypeBoost(SOCIAL_PLATFORMS.TIKTOK, movie, account, () => 0.5);
+
+    assert.ok(boost >= 0 && boost <= 12);
+    assert.ok(boost > 0);
+  });
+
+  it("returns bounded box office multiplier", () => {
+    const low = getSocialBoxOfficeMultiplier([{ viralMomentum: 0 }]);
+    const high = getSocialBoxOfficeMultiplier([{ viralMomentum: 100 }, { viralMomentum: 100 }]);
+
+    assert.strictEqual(low, 1);
+    assert.ok(high >= 1 && high <= 1.15);
+  });
+
+  it("generates positive viral trailer events for high-hype movies", async () => {
+    const movies = [
+      { _id: "movie1", title: "Blockbuster", hype: 75, status: "PRODUCTION", genre: "Action" },
+    ];
+    const accounts = [{ platform: SOCIAL_PLATFORMS.YOUTUBE, followers: 20000 }];
+    const studio = { reputation: 90 };
+
+    let callCount = 0;
+    const rng = () => {
+      callCount++;
+      return callCount === 1 ? 0.05 : 0.99;
+    };
+
+    const events = await generateSocialEventsFromState({
+      userId: "507f1f77bcf86cd799439011",
+      week: 5,
+      studio,
+      movies,
+      accounts,
+      rng,
+      relationships: [],
+    });
+
+    const viralEvent = events.find((e) => e.eventType === SOCIAL_EVENT_TYPES.VIRAL_TRAILER);
+    assert.ok(viralEvent, "Should generate a viral trailer event");
+    assert.strictEqual(viralEvent.sentiment, "positive");
+    assert.ok(viralEvent.hypeDelta > 0);
+    assert.strictEqual(viralEvent.reputationDelta, 0);
+  });
+
+  it("generates negative cancel-culture events for low reputation studios", async () => {
+    const movies = [];
+    const accounts = [{ platform: SOCIAL_PLATFORMS.X, followers: 5000 }];
+    const studio = { reputation: 55 };
+
+    let callCount = 0;
+    const rng = () => {
+      callCount++;
+      return callCount === 1 ? 0.01 : 0.99;
+    };
+
+    const events = await generateSocialEventsFromState({
+      userId: "507f1f77bcf86cd799439011",
+      week: 10,
+      studio,
+      movies,
+      accounts,
+      rng,
+      relationships: [],
+    });
+
+    const cancelEvent = events.find((e) => e.eventType === SOCIAL_EVENT_TYPES.CANCEL_CULTURE);
+    assert.ok(cancelEvent, "Should generate a cancel-culture event for low reputation");
+    assert.strictEqual(cancelEvent.sentiment, "negative");
+    assert.ok(cancelEvent.reputationDelta < 0);
+  });
+
+  it("generates negative spoiler events for movies ready for release", async () => {
+    const movies = [
+      { _id: "movie2", title: "Secret Sequel", status: "READY_FOR_RELEASE", genre: "Thriller" },
+    ];
+    const accounts = [{ platform: SOCIAL_PLATFORMS.TIKTOK, followers: 30000 }];
+    const studio = { reputation: 80 };
+
+    let callCount = 0;
+    const rng = () => {
+      callCount++;
+      if (callCount === 1) return 0.01;
+      if (callCount === 2) return 0.3;
+      return 0.1;
+    };
+
+    const events = await generateSocialEventsFromState({
+      userId: "507f1f77bcf86cd799439011",
+      week: 15,
+      studio,
+      movies,
+      accounts,
+      rng,
+      relationships: [],
+    });
+
+    const leakOrSpoiler = events.find(
+      (e) => e.eventType === SOCIAL_EVENT_TYPES.SPOILER || e.eventType === SOCIAL_EVENT_TYPES.LEAK
+    );
+    assert.ok(leakOrSpoiler, "Should generate leak or spoiler event");
+    assert.strictEqual(leakOrSpoiler.sentiment, "negative");
+  });
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,7 @@ import ActiveMovies from "./pages/movies/ActiveMovies";
 import CreateMovie from "./pages/movies/CreateMovie";
 import MovieDetails from "./pages/movies/MovieDetails";
 import MarketingStrategies from "./pages/movies/MarketingStrategies";
+import SocialMediaHub from "./pages/marketing/SocialMediaHub";
 import ReadyForRelease from "./pages/movies/ReadyForRelease";
 import ReleaseResult from "./pages/movies/ReleaseResult";
 import MovieLibrary from "./pages/movies/MovieLibrary";
@@ -163,6 +164,14 @@ function App() {
           element={
             <ProtectedRoute>
               <MarketingStrategies />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/marketing/social"
+          element={
+            <ProtectedRoute>
+              <SocialMediaHub />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/components/common/Sidebar.jsx
+++ b/frontend/src/components/common/Sidebar.jsx
@@ -19,6 +19,7 @@ import {
   Heart,
   AlertTriangle,
   Tv,
+  Share2,
 } from "lucide-react";
 
 import { Link, useLocation } from "react-router-dom";
@@ -152,6 +153,11 @@ const Sidebar = ({ isOpen, onClose }) => {
       name: "Fan Club & Con",
       path: "/studio/fanclub",
       icon: Heart,
+    },
+    {
+      name: "Social Media",
+      path: "/marketing/social",
+      icon: Share2,
     },
     {
       name: "Merchandising",

--- a/frontend/src/pages/marketing/SocialMediaHub.jsx
+++ b/frontend/src/pages/marketing/SocialMediaHub.jsx
@@ -1,0 +1,325 @@
+import { useState, useEffect } from "react";
+import api from "../../api/axios";
+import DashboardLayout from "../../layouts/DashboardLayout";
+import {
+  Share2,
+  TrendingUp,
+  Users,
+  Flame,
+  AlertTriangle,
+  IndianRupee,
+  RefreshCw,
+  Zap,
+  Hash,
+} from "lucide-react";
+
+const PLATFORM_STYLES = {
+  INSTAGRAM: { gradient: "from-pink-600 to-purple-600", icon: "📸" },
+  TIKTOK: { gradient: "from-slate-800 to-cyan-600", icon: "🎵" },
+  YOUTUBE: { gradient: "from-red-700 to-red-500", icon: "▶️" },
+  X: { gradient: "from-slate-700 to-slate-900", icon: "𝕏" },
+};
+
+const SocialMediaHub = () => {
+  const [accounts, setAccounts] = useState([]);
+  const [analytics, setAnalytics] = useState(null);
+  const [events, setEvents] = useState([]);
+  const [movies, setMovies] = useState([]);
+  const [campaignTypes, setCampaignTypes] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [budgetInputs, setBudgetInputs] = useState({});
+  const [campaignForm, setCampaignForm] = useState({
+    platform: "INSTAGRAM",
+    movieId: "",
+    campaignType: "TRAILER_PUSH",
+  });
+  const [launching, setLaunching] = useState(false);
+
+  const fetchAll = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const [accountsRes, analyticsRes, eventsRes, moviesRes] = await Promise.all([
+        api.get("/social/accounts"),
+        api.get("/social/analytics"),
+        api.get("/social/events?limit=20"),
+        api.get("/social/movies"),
+      ]);
+
+      if (accountsRes.data?.success) {
+        setAccounts(accountsRes.data.accounts || []);
+        const budgets = {};
+        (accountsRes.data.accounts || []).forEach((a) => {
+          budgets[a.platform] = a.weeklyBudget || 0;
+        });
+        setBudgetInputs(budgets);
+      }
+      if (analyticsRes.data?.success) {
+        setAnalytics(analyticsRes.data.analytics);
+        setCampaignTypes(analyticsRes.data.campaignTypes || []);
+      }
+      if (eventsRes.data?.success) setEvents(eventsRes.data.events || []);
+      if (moviesRes.data?.success) setMovies(moviesRes.data.movies || []);
+    } catch {
+      setError("Unable to load social media data.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAll();
+  }, []);
+
+  const handleBudgetUpdate = async (platform) => {
+    try {
+      await api.put(`/social/accounts/${platform}/budget`, {
+        weeklyBudget: Number(budgetInputs[platform] || 0),
+      });
+      fetchAll();
+    } catch (err) {
+      alert(err.response?.data?.message || "Failed to update budget.");
+    }
+  };
+
+  const handleLaunchCampaign = async (e) => {
+    e.preventDefault();
+    if (!campaignForm.movieId) return;
+
+    try {
+      setLaunching(true);
+      const res = await api.post("/social/campaigns", campaignForm);
+      if (res.data?.success) {
+        alert(res.data.message);
+        fetchAll();
+      }
+    } catch (err) {
+      alert(err.response?.data?.message || "Failed to launch campaign.");
+    } finally {
+      setLaunching(false);
+    }
+  };
+
+  const formatNumber = (n) => (n >= 1000000 ? `${(n / 1000000).toFixed(1)}M` : n >= 1000 ? `${(n / 1000).toFixed(1)}K` : n);
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-7xl mx-auto space-y-8 pb-20">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h1 className="text-3xl sm:text-4xl font-extrabold text-white flex items-center gap-3">
+              <Share2 className="text-sky-400" size={36} /> Social Media Hub
+            </h1>
+            <p className="text-slate-400 mt-2">
+              Manage Instagram, TikTok, YouTube, and X campaigns for your studio.
+            </p>
+          </div>
+          <button
+            onClick={fetchAll}
+            className="flex items-center gap-2 px-4 py-2 rounded-xl bg-slate-800 text-slate-300 hover:bg-slate-700 transition"
+          >
+            <RefreshCw size={16} /> Refresh
+          </button>
+        </div>
+
+        {error && (
+          <div className="p-4 rounded-2xl bg-rose-950/40 border border-rose-800/40 text-rose-300">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="text-slate-400 text-center py-12">Loading social media ecosystem...</div>
+        ) : (
+          <>
+            {/* Analytics Summary */}
+            {analytics && (
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <div className="p-5 rounded-2xl bg-slate-900 border border-slate-800">
+                  <Users className="text-sky-400 mb-2" size={20} />
+                  <p className="text-2xl font-bold text-white">{formatNumber(analytics.totalFollowers)}</p>
+                  <p className="text-xs text-slate-400 uppercase tracking-wider">Total Followers</p>
+                </div>
+                <div className="p-5 rounded-2xl bg-slate-900 border border-slate-800">
+                  <TrendingUp className="text-emerald-400 mb-2" size={20} />
+                  <p className="text-2xl font-bold text-white">{analytics.avgEngagement}%</p>
+                  <p className="text-xs text-slate-400 uppercase tracking-wider">Avg Engagement</p>
+                </div>
+                <div className="p-5 rounded-2xl bg-slate-900 border border-slate-800">
+                  <Flame className="text-amber-400 mb-2" size={20} />
+                  <p className="text-2xl font-bold text-white">{analytics.totalMomentum.toFixed(0)}</p>
+                  <p className="text-xs text-slate-400 uppercase tracking-wider">Viral Momentum</p>
+                </div>
+                <div className="p-5 rounded-2xl bg-slate-900 border border-slate-800">
+                  <Zap className="text-violet-400 mb-2" size={20} />
+                  <p className="text-2xl font-bold text-white">×{analytics.boxOfficeMultiplier}</p>
+                  <p className="text-xs text-slate-400 uppercase tracking-wider">Box Office Boost</p>
+                </div>
+              </div>
+            )}
+
+            {/* Platform Cards */}
+            <div className="grid md:grid-cols-2 gap-6">
+              {accounts.map((account) => {
+                const style = PLATFORM_STYLES[account.platform] || PLATFORM_STYLES.INSTAGRAM;
+                return (
+                  <div
+                    key={account.platform}
+                    className="rounded-3xl bg-slate-900 border border-slate-800 overflow-hidden"
+                  >
+                    <div className={`p-5 bg-gradient-to-r ${style.gradient}`}>
+                      <div className="flex items-center justify-between">
+                        <h2 className="text-xl font-bold text-white flex items-center gap-2">
+                          <span>{style.icon}</span> {account.platformName}
+                        </h2>
+                        <span className="text-white/80 text-sm">
+                          {account.activeCampaigns?.length || 0} active campaigns
+                        </span>
+                      </div>
+                    </div>
+                    <div className="p-5 space-y-4">
+                      <div className="grid grid-cols-3 gap-3 text-center">
+                        <div>
+                          <p className="text-lg font-bold text-white">{formatNumber(account.followers)}</p>
+                          <p className="text-xs text-slate-500">Followers</p>
+                        </div>
+                        <div>
+                          <p className="text-lg font-bold text-white">{account.engagementRate?.toFixed(1)}%</p>
+                          <p className="text-xs text-slate-500">Engagement</p>
+                        </div>
+                        <div>
+                          <p className="text-lg font-bold text-amber-400">{account.viralMomentum?.toFixed(0)}</p>
+                          <p className="text-xs text-slate-500">Momentum</p>
+                        </div>
+                      </div>
+                      <div className="flex gap-2">
+                        <div className="relative flex-1">
+                          <IndianRupee className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" size={14} />
+                          <input
+                            type="number"
+                            min="0"
+                            value={budgetInputs[account.platform] ?? 0}
+                            onChange={(e) =>
+                              setBudgetInputs({ ...budgetInputs, [account.platform]: e.target.value })
+                            }
+                            className="w-full pl-8 pr-3 py-2 rounded-xl bg-slate-800 border border-slate-700 text-white text-sm"
+                            placeholder="Weekly budget"
+                          />
+                        </div>
+                        <button
+                          onClick={() => handleBudgetUpdate(account.platform)}
+                          className="px-4 py-2 rounded-xl bg-sky-600 hover:bg-sky-500 text-white text-sm font-medium transition"
+                        >
+                          Set
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Launch Campaign */}
+            <div className="rounded-3xl bg-slate-900 border border-slate-800 p-6">
+              <h2 className="text-xl font-bold text-white mb-4 flex items-center gap-2">
+                <Hash size={20} className="text-sky-400" /> Launch Social Campaign
+              </h2>
+              <form onSubmit={handleLaunchCampaign} className="grid md:grid-cols-4 gap-4">
+                <select
+                  value={campaignForm.platform}
+                  onChange={(e) => setCampaignForm({ ...campaignForm, platform: e.target.value })}
+                  className="px-4 py-3 rounded-xl bg-slate-800 border border-slate-700 text-white"
+                >
+                  {accounts.map((a) => (
+                    <option key={a.platform} value={a.platform}>
+                      {a.platformName}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  value={campaignForm.movieId}
+                  onChange={(e) => setCampaignForm({ ...campaignForm, movieId: e.target.value })}
+                  className="px-4 py-3 rounded-xl bg-slate-800 border border-slate-700 text-white"
+                  required
+                >
+                  <option value="">Select movie...</option>
+                  {movies.map((m) => (
+                    <option key={m._id} value={m._id}>
+                      {m.title} ({m.status})
+                    </option>
+                  ))}
+                </select>
+                <select
+                  value={campaignForm.campaignType}
+                  onChange={(e) => setCampaignForm({ ...campaignForm, campaignType: e.target.value })}
+                  className="px-4 py-3 rounded-xl bg-slate-800 border border-slate-700 text-white"
+                >
+                  {campaignTypes.map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.name} (₹{c.cost?.toLocaleString("en-IN")})
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="submit"
+                  disabled={launching}
+                  className="px-6 py-3 rounded-xl bg-gradient-to-r from-sky-600 to-violet-600 text-white font-bold hover:opacity-90 transition disabled:opacity-50"
+                >
+                  {launching ? "Launching..." : "Launch Campaign"}
+                </button>
+              </form>
+            </div>
+
+            {/* Recent Events Feed */}
+            <div className="rounded-3xl bg-slate-900 border border-slate-800 p-6">
+              <h2 className="text-xl font-bold text-white mb-4">Recent Social Events</h2>
+              {events.length === 0 ? (
+                <p className="text-slate-500">No social events yet. Advance weeks to see activity.</p>
+              ) : (
+                <div className="space-y-3">
+                  {events.map((ev) => (
+                    <div
+                      key={ev._id}
+                      className={`p-4 rounded-2xl border ${
+                        ev.sentiment === "negative"
+                          ? "bg-rose-950/20 border-rose-800/30"
+                          : ev.sentiment === "positive"
+                            ? "bg-emerald-950/20 border-emerald-800/30"
+                            : "bg-slate-800/50 border-slate-700"
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-white font-medium">{ev.description}</p>
+                          <p className="text-xs text-slate-500 mt-1">
+                            Week {ev.week} · {ev.platform} · {ev.eventType.replace(/_/g, " ")}
+                            {ev.movieTitle && ` · ${ev.movieTitle}`}
+                          </p>
+                        </div>
+                        <div className="text-right shrink-0">
+                          {ev.sentiment === "negative" ? (
+                            <AlertTriangle className="text-rose-400" size={18} />
+                          ) : (
+                            <TrendingUp className="text-emerald-400" size={18} />
+                          )}
+                          {ev.hypeDelta !== 0 && (
+                            <p className={`text-xs mt-1 ${ev.hypeDelta > 0 ? "text-emerald-400" : "text-rose-400"}`}>
+                              Hype {ev.hypeDelta > 0 ? "+" : ""}{ev.hypeDelta}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default SocialMediaHub;


### PR DESCRIPTION
## Summary
- Adds Instagram, TikTok, YouTube, and X platform simulation with distinct audience/engagement models
- Generates social events (viral trailers, memes, fan wars, cancel-culture, leaks/spoilers) from simulation state
- Applies bounded hype and reputation effects; social momentum boosts box office on release
- Persists social data in separate collections (`SocialMediaAccount`, `SocialMediaEvent`) to avoid GameState bloat
- Adds backend APIs and `SocialMediaHub` frontend at `/marketing/social`
Closes #534
**ECSOC 2026** contribution — please apply the `ECSOC2026` label.
## Acceptance criteria
- [x] Four platforms have distinct audience/engagement models
- [x] Social events generated from simulation state
- [x] Viral events affect hype/marketing/box office via bounded formulas
- [x] Negative events affect reputation
- [x] Social data persisted without unbounded GameState growth
- [x] Weekly processing is deterministic when seeded
- [x] Backend APIs and frontend components implemented
- [x] Unit tests cover positive and negative events
## Test plan
- [ ] `cd backend && npm test -- tests/socialMediaEngine.test.js` — all 8 tests pass
- [ ] Start backend + frontend, navigate to **Social Media** in sidebar
- [ ] Verify 4 platform accounts load with follower/engagement stats
- [ ] Set a weekly budget and launch a campaign on an active movie
- [ ] Advance simulation weeks — confirm social events appear in the feed
- [ ] Confirm negative events (low reputation) reduce reputation in Studio Stats
- [ ] Attach screenshot of Social Media Hub in PR
