### PR TITLE
feat: build dynamic entertainment news and media engine

### DIFF
--- a/backend/src/constants/newsMedia.js
+++ b/backend/src/constants/newsMedia.js
@@ -1,0 +1,216 @@
+/**
+ * Constants for the dynamic entertainment news and media engine (issue #543).
+ */
+
+export const NEWS_CATEGORIES = {
+  BOX_OFFICE: "box_office",
+  REVIEW: "review",
+  AWARD: "award",
+  RELEASE: "release",
+  TREND: "trend",
+  EVENT: "event",
+  RIVALRY: "rivalry",
+  SCANDAL: "scandal",
+  RELATIONSHIP: "relationship",
+  CELEBRITY: "celebrity",
+  STREAMING: "streaming",
+  TV: "tv",
+  FRANCHISE: "franchise",
+  BUSINESS: "business",
+  SOCIAL: "social",
+};
+
+export const NEWS_REGIONS = {
+  DOMESTIC: "DOMESTIC",
+  INTERNATIONAL: "INTERNATIONAL",
+  GLOBAL: "GLOBAL",
+};
+
+export const NEWS_SENTIMENTS = {
+  POSITIVE: "positive",
+  NEGATIVE: "negative",
+  NEUTRAL: "neutral",
+};
+
+export const NEWS_SOURCES = {
+  HOLLYWOOD_REPORTER: { id: "HOLLYWOOD_REPORTER", name: "Hollywood Reporter", credibility: 85 },
+  VARIETY: { id: "VARIETY", name: "Variety", credibility: 82 },
+  DEADLINE: { id: "DEADLINE", name: "Deadline", credibility: 78 },
+  TRADES_DAILY: { id: "TRADES_DAILY", name: "Trades Daily", credibility: 70 },
+  CINEVERSE_WIRE: { id: "CINEVERSE_WIRE", name: "CineVerse Wire", credibility: 65 },
+  GOSSIP_HOUR: { id: "GOSSIP_HOUR", name: "Gossip Hour", credibility: 40 },
+  SOCIAL_BUZZ: { id: "SOCIAL_BUZZ", name: "Social Buzz", credibility: 35 },
+  DEFAULT: { id: "CINEVERSE_WIRE", name: "CineVerse Wire", credibility: 65 },
+};
+
+/**
+ * Headline/body templates keyed by category and template id.
+ * Placeholders: {title}, {studio}, {genre}, {gross}, {budget}, {verdict},
+ * {criticScore}, {talentA}, {talentB}, {platform}, {year}, {description}
+ */
+export const NEWS_TEMPLATES = {
+  [NEWS_CATEGORIES.BOX_OFFICE]: {
+    blockbuster: {
+      headline: "HISTORIC RUN: \"{title}\" Shatters Expectations!",
+      body: "\"{title}\", the latest blockbuster from {studio}, has taken the industry by storm, grossing a massive ₹{gross} worldwide. Analysts are calling it one of the most successful releases this season!",
+      sentiment: NEWS_SENTIMENTS.POSITIVE,
+      sourceId: "VARIETY",
+      reach: 90,
+    },
+    hit: {
+      headline: "SUCCESS: \"{title}\" Reels in Big Audiences",
+      body: "With strong reviews and solid word of mouth, {studio}'s \"{title}\" secures a certified HIT verdict, grossing ₹{gross} worldwide against a budget of ₹{budget}.",
+      sentiment: NEWS_SENTIMENTS.POSITIVE,
+      sourceId: "HOLLYWOOD_REPORTER",
+      reach: 75,
+    },
+    average: {
+      headline: "STEADY: \"{title}\" Finds Moderate Success",
+      body: "\"{title}\" from {studio} completes its theatrical run with an AVERAGE verdict, grossing ₹{gross} worldwide.",
+      sentiment: NEWS_SENTIMENTS.NEUTRAL,
+      sourceId: "TRADES_DAILY",
+      reach: 50,
+    },
+    flop: {
+      headline: "DISAPPOINTMENT: \"{title}\" Underperforms at Box Office",
+      body: "Despite high marketing efforts, \"{title}\" from {studio} finished as a FLOP, grossing only ₹{gross}.",
+      sentiment: NEWS_SENTIMENTS.NEGATIVE,
+      sourceId: "DEADLINE",
+      reach: 65,
+    },
+    disaster: {
+      headline: "BOX OFFICE DISASTER: \"{title}\" Flops Spectacularly",
+      body: "Industry analysts are shocked as {studio}'s \"{title}\" collapses, grossing a mere ₹{gross} worldwide.",
+      sentiment: NEWS_SENTIMENTS.NEGATIVE,
+      sourceId: "DEADLINE",
+      reach: 80,
+    },
+  },
+  [NEWS_CATEGORIES.REVIEW]: {
+    rave: {
+      headline: "CRITICS RAVE: \"{title}\" Earns {criticScore}/100",
+      body: "Reviewers praise {studio}'s \"{title}\" as a must-see, citing standout performances and sharp direction.",
+      sentiment: NEWS_SENTIMENTS.POSITIVE,
+      sourceId: "HOLLYWOOD_REPORTER",
+      reach: 70,
+    },
+    mixed: {
+      headline: "Mixed Reviews for \"{title}\"",
+      body: "Critics are divided on {studio}'s \"{title}\", scoring it {criticScore}/100 with praise for ambition but notes on pacing.",
+      sentiment: NEWS_SENTIMENTS.NEUTRAL,
+      sourceId: "TRADES_DAILY",
+      reach: 45,
+    },
+    pan: {
+      headline: "CRITICAL PAN: \"{title}\" Slammed by Reviewers",
+      body: "\"{title}\" from {studio} receives harsh reviews at {criticScore}/100, raising concerns ahead of its box office run.",
+      sentiment: NEWS_SENTIMENTS.NEGATIVE,
+      sourceId: "DEADLINE",
+      reach: 60,
+    },
+  },
+  [NEWS_CATEGORIES.TREND]: {
+    surge: {
+      headline: "TREND ALERT: {genre} Films Surge in Popularity!",
+      body: "Audiences cannot get enough of {genre} movies. Analysts predict upcoming {genre} releases will experience a significant box office boost.",
+      sentiment: NEWS_SENTIMENTS.POSITIVE,
+      sourceId: "VARIETY",
+      reach: 55,
+    },
+  },
+  [NEWS_CATEGORIES.SCANDAL]: {
+    breaking: {
+      headline: "SCANDAL: {studio} Faces Public Backlash",
+      body: "{description} Industry insiders say the studio's reputation may take a hit as the story spreads across media outlets.",
+      sentiment: NEWS_SENTIMENTS.NEGATIVE,
+      sourceId: "GOSSIP_HOUR",
+      reach: 70,
+    },
+  },
+  [NEWS_CATEGORIES.RELATIONSHIP]: {
+    conflict: {
+      headline: "ON-SET DRAMA: {talentA} and {talentB} Clash",
+      body: "{description}",
+      sentiment: NEWS_SENTIMENTS.NEGATIVE,
+      sourceId: "GOSSIP_HOUR",
+      reach: 55,
+    },
+    romance: {
+      headline: "CELEBRITY BUZZ: {talentA} and {talentB} Spark Rumors",
+      body: "Fans are buzzing about off-screen chemistry between {talentA} and {talentB}. {description}",
+      sentiment: NEWS_SENTIMENTS.POSITIVE,
+      sourceId: "SOCIAL_BUZZ",
+      reach: 60,
+    },
+  },
+  [NEWS_CATEGORIES.AWARD]: {
+    winner: {
+      headline: "AWARDS: \"{title}\" Takes Best Picture",
+      body: "At the Year {year} ceremony, \"{title}\" from {studio} wins Best Picture, cementing its place in cinema history.",
+      sentiment: NEWS_SENTIMENTS.POSITIVE,
+      sourceId: "HOLLYWOOD_REPORTER",
+      reach: 85,
+    },
+    nominee: {
+      headline: "AWARDS SEASON: \"{title}\" Leads Nominees",
+      body: "\"{title}\" emerges as a frontrunner at the Year {year} awards, with {studio} celebrating the recognition.",
+      sentiment: NEWS_SENTIMENTS.POSITIVE,
+      sourceId: "VARIETY",
+      reach: 65,
+    },
+  },
+  [NEWS_CATEGORIES.RIVALRY]: {
+    release: {
+      headline: "COMPETITION: Rival Studio Releases \"{title}\"",
+      body: "Competitor \"{studio}\" has released \"{title}\" in the {genre} genre, achieving a {verdict} verdict with ₹{gross} worldwide.",
+      sentiment: NEWS_SENTIMENTS.NEUTRAL,
+      sourceId: "DEADLINE",
+      reach: 50,
+    },
+  },
+  [NEWS_CATEGORIES.EVENT]: {
+    scoop: {
+      headline: "INDUSTRY SCOOP: {label}",
+      body: "{description}",
+      sentiment: NEWS_SENTIMENTS.NEUTRAL,
+      sourceId: "CINEVERSE_WIRE",
+      reach: 40,
+    },
+  },
+  [NEWS_CATEGORIES.FRANCHISE]: {
+    milestone: {
+      headline: "FRANCHISE UPDATE: \"{title}\" Expands Universe",
+      body: "{studio}'s franchise gains momentum as \"{title}\" adds another chapter, boosting fan loyalty across the brand.",
+      sentiment: NEWS_SENTIMENTS.POSITIVE,
+      sourceId: "VARIETY",
+      reach: 60,
+    },
+  },
+  [NEWS_CATEGORIES.STREAMING]: {
+    deal: {
+      headline: "STREAMING DEAL: \"{title}\" Lands Platform Exclusive",
+      body: "{studio} secures a streaming deal for \"{title}\" on {platform}, signaling a shift in distribution strategy.",
+      sentiment: NEWS_SENTIMENTS.POSITIVE,
+      sourceId: "DEADLINE",
+      reach: 55,
+    },
+  },
+  [NEWS_CATEGORIES.SOCIAL]: {
+    viral: {
+      headline: "SOCIAL MEDIA: {label}",
+      body: "{description}",
+      sentiment: NEWS_SENTIMENTS.POSITIVE,
+      sourceId: "SOCIAL_BUZZ",
+      reach: 65,
+    },
+  },
+};
+
+export const fillTemplate = (template, vars = {}) => {
+  const replace = (str) =>
+    String(str).replace(/\{(\w+)\}/g, (_, key) => (vars[key] !== undefined ? vars[key] : `{${key}}`));
+  return {
+    headline: replace(template.headline),
+    body: replace(template.body),
+  };
+};

--- a/backend/src/controllers/newsController.js
+++ b/backend/src/controllers/newsController.js
@@ -7,9 +7,9 @@ export const getNews = async (req, res) => {
     const skip = (page - 1) * limit;
 
     const query = {};
-    if (req.query.type) {
-      query.type = req.query.type;
-    }
+    if (req.query.type) query.type = req.query.type;
+    if (req.query.sentiment) query.sentiment = req.query.sentiment;
+    if (req.query.region) query.region = req.query.region;
 
     const total = await NewsItem.countDocuments(query);
     const news = await NewsItem.find(query)
@@ -35,7 +35,7 @@ export const getNews = async (req, res) => {
 
 export const getNewsDetail = async (req, res) => {
   try {
-    const newsItem = await NewsItem.findById(req.params.id);
+    const newsItem = await NewsItem.findById(req.params.id).lean();
     if (!newsItem) {
       return res.status(404).json({ success: false, message: "News article not found" });
     }

--- a/backend/src/controllers/streamingController.js
+++ b/backend/src/controllers/streamingController.js
@@ -3,6 +3,7 @@ import Movie from "../models/Movie.js";
 import Studio from "../models/Studio.js";
 import { addNotification } from "../services/simulation/helpers/notificationHelper.js";
 import { calculateStreamingRevenuePotential, computeHybridReleaseStrategy } from "../services/simulation/engines/streamingEngine.js";
+import { generateNewsFromStreamingDeal } from "../services/simulation/engines/newsEngine.js";
 
 // Get all streaming platforms
 export const getPlatforms = async (req, res) => {
@@ -172,6 +173,8 @@ export const acceptStreamingDeal = async (req, res) => {
     gameState.movieHistory.push(movie._id);
 
     addNotification(gameState, `Sold exclusive streaming rights for "${movie.title}" to ${platform.name} for ₹${(movie.streamingDeal.dealValue / 1000000).toFixed(1)}M.`);
+
+    await generateNewsFromStreamingDeal(movie, studio, platform.name, gameState.currentWeek);
 
     await movie.save();
     await studio.save();

--- a/backend/src/models/NewsItem.js
+++ b/backend/src/models/NewsItem.js
@@ -1,20 +1,65 @@
 import mongoose from "mongoose";
+import { NEWS_CATEGORIES, NEWS_REGIONS, NEWS_SENTIMENTS } from "../constants/newsMedia.js";
+
+const entityLinkSchema = new mongoose.Schema(
+  {
+    entityType: { type: String, required: true },
+    entityId: { type: String, default: "" },
+    entityName: { type: String, default: "" },
+  },
+  { _id: false }
+);
 
 const newsItemSchema = new mongoose.Schema(
   {
     type: {
       type: String,
-      enum: ["box_office", "award", "event", "rivalry", "trend"],
+      enum: Object.values(NEWS_CATEGORIES),
       required: true,
     },
     headline: { type: String, required: true },
     body: { type: String, required: true },
     week: { type: Number, required: true },
+    publishedWeek: { type: Number, required: true },
+
     studioId: { type: mongoose.Schema.Types.ObjectId, ref: "Studio", default: null },
     movieId: { type: mongoose.Schema.Types.ObjectId, ref: "Movie", default: null },
+    talentId: { type: String, default: null },
+    franchiseId: { type: mongoose.Schema.Types.ObjectId, ref: "Franchise", default: null },
+
+    source: {
+      id: { type: String, default: "CINEVERSE_WIRE" },
+      name: { type: String, default: "CineVerse Wire" },
+      credibility: { type: Number, default: 65, min: 0, max: 100 },
+    },
+    sentiment: {
+      type: String,
+      enum: Object.values(NEWS_SENTIMENTS),
+      default: NEWS_SENTIMENTS.NEUTRAL,
+    },
+    reach: { type: Number, default: 50, min: 0, max: 100 },
+    region: {
+      type: String,
+      enum: Object.values(NEWS_REGIONS),
+      default: NEWS_REGIONS.GLOBAL,
+    },
+
+    dedupeKey: { type: String, default: null, sparse: true },
+    triggerEvent: { type: String, default: "" },
+    socialAmplified: { type: Boolean, default: false },
+
+    hypeEffect: { type: Number, default: 0 },
+    reputationEffect: { type: Number, default: 0 },
+
+    entityLinks: [entityLinkSchema],
   },
   { timestamps: true }
 );
+
+newsItemSchema.index({ type: 1, week: -1 });
+newsItemSchema.index({ dedupeKey: 1 }, { unique: true, sparse: true });
+newsItemSchema.index({ studioId: 1, week: -1 });
+newsItemSchema.index({ sentiment: 1, week: -1 });
 
 const NewsItem = mongoose.model("NewsItem", newsItemSchema);
 export default NewsItem;

--- a/backend/src/services/movie/releaseService.js
+++ b/backend/src/services/movie/releaseService.js
@@ -9,7 +9,7 @@ import { processCareerImpact } from "../simulation/engines/careerImpactEngine.js
 import { processStudioGrowth } from "../simulation/engines/studioGrowthEngine.js";
 import { computeFranchiseProgress } from "../simulation/engines/franchiseEngine.js";
 import { addNotification } from "../simulation/helpers/notificationHelper.js";
-import { generateNewsFromRelease } from "../simulation/engines/newsEngine.js";
+import { generateNewsFromRelease, generateNewsFromFranchise } from "../simulation/engines/newsEngine.js";
 import { findScriptById } from "./movieValidationService.js";
 import { computeClashPenalty } from "../simulation/engines/clashEngine.js";
 import { addHistoricRecord } from "../simulation/helpers/historicRecordHelper.js";
@@ -137,6 +137,10 @@ export const performMovieRelease = async (movie, studio, gameState, session = nu
 
   // Generate news article for the release
   await generateNewsFromRelease(movie, studio, gameState.currentWeek);
+
+  if (franchiseDoc) {
+    await generateNewsFromFranchise(movie, studio, franchiseDoc, gameState.currentWeek);
+  }
 
   // Add to historic records
   try {

--- a/backend/src/services/simulation/engines/awardsEngine.js
+++ b/backend/src/services/simulation/engines/awardsEngine.js
@@ -2,6 +2,7 @@ import Movie from "../../../models/Movie.js";
 import Studio from "../../../models/Studio.js";
 import Notification from "../../../models/Notification.js";
 import PastAward from "../../../models/PastAward.js";
+import { generateNewsFromAwards } from "./newsEngine.js";
 
 // Awards run annually at Week 52.
 export const processAnnualAwards = async (gameState, studio) => {
@@ -78,6 +79,8 @@ export const processAnnualAwards = async (gameState, studio) => {
                 : `🏆 Annual Awards Year ${year}: Best Picture goes to '${bestPicture.title}'.`,
             createdAt: new Date(),
         });
+
+        await generateNewsFromAwards(bestPicture, studio, year, gameState.currentWeek, won);
     }
 };
 

--- a/backend/src/services/simulation/engines/newsEngine.js
+++ b/backend/src/services/simulation/engines/newsEngine.js
@@ -1,48 +1,209 @@
+/**
+ * @fileoverview Dynamic Entertainment News & Media Engine (issue #543)
+ *
+ * Procedural news generated from simulation events with source/credibility,
+ * sentiment, reach, templates, deduplication, and bounded downstream effects.
+ */
+
 import NewsItem from "../../../models/NewsItem.js";
+import {
+  NEWS_CATEGORIES,
+  NEWS_REGIONS,
+  NEWS_SENTIMENTS,
+  NEWS_SOURCES,
+  NEWS_TEMPLATES,
+  fillTemplate,
+} from "../../../constants/newsMedia.js";
+
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
 /**
- * Generate news article for a movie release.
+ * Calculates bounded hype effect from sentiment, reach, and source credibility.
+ */
+export const calculateHypeEffect = (sentiment, reach = 50, credibility = 65) => {
+  const credibilityFactor = credibility / 100;
+  const reachFactor = reach / 100;
+
+  if (sentiment === NEWS_SENTIMENTS.POSITIVE) {
+    return Number(clamp(reachFactor * credibilityFactor * 5, 0, 5).toFixed(2));
+  }
+  if (sentiment === NEWS_SENTIMENTS.NEGATIVE) {
+    return Number(clamp(-reachFactor * credibilityFactor * 3, -3, 0).toFixed(2));
+  }
+  return 0;
+};
+
+/**
+ * Calculates bounded reputation effect from sentiment, reach, and credibility.
+ */
+export const calculateReputationEffect = (sentiment, reach = 50, credibility = 65) => {
+  const credibilityFactor = credibility / 100;
+  const reachFactor = reach / 100;
+
+  if (sentiment === NEWS_SENTIMENTS.POSITIVE) {
+    return Number(clamp(reachFactor * credibilityFactor * 3, 0, 3).toFixed(2));
+  }
+  if (sentiment === NEWS_SENTIMENTS.NEGATIVE) {
+    return Number(clamp(-reachFactor * credibilityFactor * 8, -8, 0).toFixed(2));
+  }
+  return 0;
+};
+
+/**
+ * Applies article effects to studio reputation and movie hype within bounds.
+ */
+export const applyNewsEffects = (article, studio = null, movie = null) => {
+  if (studio && article.reputationEffect) {
+    studio.reputation = clamp(
+      (studio.reputation ?? 100) + article.reputationEffect,
+      0,
+      100
+    );
+  }
+  if (movie && article.hypeEffect) {
+    movie.hype = clamp((movie.hype ?? 0) + article.hypeEffect, 0, 100);
+  }
+};
+
+/**
+ * Central publish function with deduplication and effect calculation.
+ */
+export const publishNewsArticle = async ({
+  type,
+  headline,
+  body,
+  week,
+  studioId = null,
+  movieId = null,
+  talentId = null,
+  franchiseId = null,
+  sourceId = "DEFAULT",
+  sentiment = NEWS_SENTIMENTS.NEUTRAL,
+  reach = 50,
+  region = NEWS_REGIONS.GLOBAL,
+  dedupeKey = null,
+  triggerEvent = "",
+  socialAmplified = false,
+  entityLinks = [],
+  studio = null,
+  movie = null,
+}) => {
+  if (dedupeKey) {
+    const existing = await NewsItem.findOne({ dedupeKey });
+    if (existing) return existing;
+  }
+
+  const source = NEWS_SOURCES[sourceId] || NEWS_SOURCES.DEFAULT;
+  const effectiveReach = socialAmplified ? clamp(reach * 1.2, 0, 100) : reach;
+  const hypeEffect = calculateHypeEffect(sentiment, effectiveReach, source.credibility);
+  const reputationEffect = calculateReputationEffect(sentiment, effectiveReach, source.credibility);
+
+  const article = await NewsItem.create({
+    type,
+    headline,
+    body,
+    week,
+    publishedWeek: week,
+    studioId,
+    movieId,
+    talentId,
+    franchiseId,
+    source: { id: source.id, name: source.name, credibility: source.credibility },
+    sentiment,
+    reach: Number(effectiveReach.toFixed(1)),
+    region,
+    dedupeKey,
+    triggerEvent,
+    socialAmplified,
+    hypeEffect,
+    reputationEffect,
+    entityLinks,
+  });
+
+  applyNewsEffects(article, studio, movie);
+
+  if (studio?.isModified?.()) await studio.save();
+  if (movie?.isModified?.()) await movie.save();
+
+  return article;
+};
+
+const verdictTemplateKey = (verdict) => {
+  if (verdict === "ALL_TIME_BLOCKBUSTER" || verdict === "BLOCKBUSTER") return "blockbuster";
+  if (verdict === "HIT") return "hit";
+  if (verdict === "AVERAGE") return "average";
+  if (verdict === "FLOP") return "flop";
+  return "disaster";
+};
+
+const reviewTemplateKey = (criticScore) => {
+  if (criticScore >= 75) return "rave";
+  if (criticScore >= 50) return "mixed";
+  return "pan";
+};
+
+/**
+ * Generate news article for a movie release (box office + review).
  */
 export const generateNewsFromRelease = async (movie, studio, week) => {
   try {
-    if (!movie || !studio) {
-      console.warn("generateNewsFromRelease skipped: movie or studio reference is missing");
-      return null;
-    }
+    if (!movie || !studio) return null;
 
-    let headline = "";
-    let body = "";
-    const type = "box_office";
+    const vars = {
+      title: movie.title,
+      studio: studio.name,
+      gross: (movie.worldwideGross || 0).toLocaleString("en-IN"),
+      budget: (movie.budget || 0).toLocaleString("en-IN"),
+      verdict: movie.verdict || "N/A",
+      criticScore: movie.criticScore || 0,
+    };
 
-    const formattedGross = movie.worldwideGross ? movie.worldwideGross.toLocaleString() : "0";
-    const formattedBudget = movie.budget ? movie.budget.toLocaleString() : "0";
+    const boxTemplate = NEWS_TEMPLATES[NEWS_CATEGORIES.BOX_OFFICE][verdictTemplateKey(movie.verdict)];
+    const boxContent = fillTemplate(boxTemplate, vars);
 
-    if (movie.verdict === "ALL_TIME_BLOCKBUSTER" || movie.verdict === "BLOCKBUSTER") {
-      headline = `HISTORIC RUN: "${movie.title}" Shatters Expectations!`;
-      body = `"${movie.title}", the latest blockbuster from ${studio.name}, has taken the industry by storm, grossing a massive ₹${formattedGross} worldwide. Analysts are calling it one of the most successful releases this season!`;
-    } else if (movie.verdict === "HIT") {
-      headline = `SUCCESS: "${movie.title}" Reels in Big Audiences`;
-      body = `With strong reviews and solid word of mouth, ${studio.name}'s "${movie.title}" secures a certified HIT verdict. The movie has grossed ₹${formattedGross} worldwide against a production budget of ₹${formattedBudget}.`;
-    } else if (movie.verdict === "AVERAGE") {
-      headline = `STEADY: "${movie.title}" Finds Moderate Success`;
-      body = `"${movie.title}" from ${studio.name} completes its theatrical run with an AVERAGE verdict. The movie grossed ₹${formattedGross} worldwide, managing to break even and satisfy its core audience.`;
-    } else if (movie.verdict === "FLOP") {
-      headline = `DISAPPOINTMENT: "${movie.title}" Underperforms at Box Office`;
-      body = `Despite high marketing efforts, "${movie.title}" from ${studio.name} finished its run as a FLOP. The movie failed to recapture its production costs, grossing only ₹${formattedGross}.`;
-    } else {
-      // DISASTER
-      headline = `BOX OFFICE DISASTER: "${movie.title}" Flops Spectacularly`;
-      body = `Industry analysts are shocked as ${studio.name}'s high-profile project "${movie.title}" collapses, grossing a mere ₹${formattedGross} worldwide. The film goes down as a complete disaster.`;
-    }
-
-    return await NewsItem.create({
-      type,
-      headline,
-      body,
+    const boxArticle = await publishNewsArticle({
+      type: NEWS_CATEGORIES.BOX_OFFICE,
+      headline: boxContent.headline,
+      body: boxContent.body,
       week,
       studioId: studio._id,
       movieId: movie._id,
+      sourceId: boxTemplate.sourceId,
+      sentiment: boxTemplate.sentiment,
+      reach: boxTemplate.reach,
+      dedupeKey: `box_office:${movie._id}:${week}`,
+      triggerEvent: "MOVIE_RELEASE",
+      entityLinks: [
+        { entityType: "studio", entityId: String(studio._id), entityName: studio.name },
+        { entityType: "movie", entityId: String(movie._id), entityName: movie.title },
+      ],
+      studio,
+      movie,
     });
+
+    const reviewTemplate = NEWS_TEMPLATES[NEWS_CATEGORIES.REVIEW][reviewTemplateKey(movie.criticScore || 0)];
+    const reviewContent = fillTemplate(reviewTemplate, vars);
+
+    await publishNewsArticle({
+      type: NEWS_CATEGORIES.REVIEW,
+      headline: reviewContent.headline,
+      body: reviewContent.body,
+      week,
+      studioId: studio._id,
+      movieId: movie._id,
+      sourceId: reviewTemplate.sourceId,
+      sentiment: reviewTemplate.sentiment,
+      reach: reviewTemplate.reach,
+      dedupeKey: `review:${movie._id}:${week}`,
+      triggerEvent: "MOVIE_REVIEW",
+      entityLinks: [
+        { entityType: "movie", entityId: String(movie._id), entityName: movie.title },
+      ],
+      studio,
+      movie,
+    });
+
+    return boxArticle;
   } catch (error) {
     console.error("Error generating news from release:", error);
     return null;
@@ -50,32 +211,214 @@ export const generateNewsFromRelease = async (movie, studio, week) => {
 };
 
 /**
- * Generate news article for a new trend.
+ * Generate news for franchise milestone on release.
  */
-export const generateNewsFromTrend = async (trend, week) => {
-  const headline = `TREND ALERT: ${trend.genre} Films Surge in Popularity!`;
-  const body = `Audiences cannot get enough of ${trend.genre} movies. Analysts predict upcoming ${trend.genre} releases will experience a significant box office boost due to active market interest.`;
+export const generateNewsFromFranchise = async (movie, studio, franchise, week) => {
+  if (!movie || !studio || !franchise) return null;
 
-  return await NewsItem.create({
-    type: "trend",
-    headline,
-    body,
+  const template = NEWS_TEMPLATES[NEWS_CATEGORIES.FRANCHISE].milestone;
+  const content = fillTemplate(template, {
+    title: movie.title,
+    studio: studio.name,
+  });
+
+  return publishNewsArticle({
+    type: NEWS_CATEGORIES.FRANCHISE,
+    headline: content.headline,
+    body: content.body,
     week,
+    studioId: studio._id,
+    movieId: movie._id,
+    franchiseId: franchise._id,
+    sourceId: template.sourceId,
+    sentiment: template.sentiment,
+    reach: template.reach,
+    dedupeKey: `franchise:${franchise._id}:${movie._id}:${week}`,
+    triggerEvent: "FRANCHISE_RELEASE",
+    entityLinks: [
+      { entityType: "franchise", entityId: String(franchise._id), entityName: franchise.name || "Franchise" },
+      { entityType: "movie", entityId: String(movie._id), entityName: movie.title },
+    ],
+    studio,
+    movie,
   });
 };
 
 /**
- * Generate news article for a fired event.
+ * Generate news article for a new market trend.
  */
-export const generateNewsFromEvent = async (eventLabel, eventMessage, week) => {
-  const headline = `INDUSTRY SCOOP: ${eventLabel}`;
-  const body = eventMessage || "Details of the event are sending ripples through the industry.";
+export const generateNewsFromTrend = async (trend, week) => {
+  const template = NEWS_TEMPLATES[NEWS_CATEGORIES.TREND].surge;
+  const content = fillTemplate(template, { genre: trend.genre });
 
-  return await NewsItem.create({
-    type: "event",
-    headline,
-    body,
+  return publishNewsArticle({
+    type: NEWS_CATEGORIES.TREND,
+    headline: content.headline,
+    body: content.body,
     week,
+    sourceId: template.sourceId,
+    sentiment: template.sentiment,
+    reach: template.reach,
+    dedupeKey: `trend:${trend.genre}:${week}`,
+    triggerEvent: "MARKET_TREND",
+    entityLinks: [{ entityType: "genre", entityId: trend.genre, entityName: trend.genre }],
+  });
+};
+
+/**
+ * Generate news article for a fired simulation event.
+ */
+export const generateNewsFromEvent = async (eventLabel, eventMessage, week, options = {}) => {
+  const template = NEWS_TEMPLATES[NEWS_CATEGORIES.EVENT].scoop;
+  const content = fillTemplate(template, {
+    label: eventLabel,
+    description: eventMessage || "Details are sending ripples through the industry.",
+  });
+
+  const category = options.category || NEWS_CATEGORIES.EVENT;
+  const isSocial = category === NEWS_CATEGORIES.SOCIAL;
+
+  return publishNewsArticle({
+    type: isSocial ? NEWS_CATEGORIES.SOCIAL : NEWS_CATEGORIES.EVENT,
+    headline: isSocial ? content.headline : content.headline,
+    body: content.body,
+    week,
+    studioId: options.studioId || null,
+    movieId: options.movieId || null,
+    sourceId: isSocial ? "SOCIAL_BUZZ" : template.sourceId,
+    sentiment: options.sentiment || template.sentiment,
+    reach: options.reach || (isSocial ? 65 : template.reach),
+    dedupeKey: options.dedupeKey || `event:${eventLabel}:${week}`,
+    triggerEvent: options.triggerEvent || "SIMULATION_EVENT",
+    socialAmplified: isSocial,
+    entityLinks: options.entityLinks || [],
+    studio: options.studio || null,
+    movie: options.movie || null,
+  });
+};
+
+/**
+ * Generate news for a studio scandal.
+ */
+export const generateNewsFromScandal = async (scandal, studio, week) => {
+  const template = NEWS_TEMPLATES[NEWS_CATEGORIES.SCANDAL].breaking;
+  const content = fillTemplate(template, {
+    studio: studio.name,
+    description: scandal.description,
+  });
+
+  return publishNewsArticle({
+    type: NEWS_CATEGORIES.SCANDAL,
+    headline: content.headline,
+    body: content.body,
+    week,
+    studioId: studio._id,
+    sourceId: template.sourceId,
+    sentiment: template.sentiment,
+    reach: template.reach,
+    dedupeKey: `scandal:${studio._id}:${scandal.id}:${week}`,
+    triggerEvent: "STUDIO_SCANDAL",
+    entityLinks: [{ entityType: "studio", entityId: String(studio._id), entityName: studio.name }],
+  });
+};
+
+/**
+ * Generate news for talent relationship drama.
+ */
+export const generateNewsFromRelationship = async (relationship, message, week, movie = null, studio = null) => {
+  const isNegative = ["RIVALRY", "BREAKUP"].includes(relationship.type);
+  const templateKey = isNegative ? "conflict" : "romance";
+  const template = NEWS_TEMPLATES[NEWS_CATEGORIES.RELATIONSHIP][templateKey];
+  const content = fillTemplate(template, {
+    talentA: relationship.talentAName || "Star A",
+    talentB: relationship.talentBName || "Star B",
+    description: message,
+  });
+
+  return publishNewsArticle({
+    type: NEWS_CATEGORIES.RELATIONSHIP,
+    headline: content.headline,
+    body: content.body,
+    week,
+    studioId: studio?._id || null,
+    movieId: movie?._id || null,
+    talentId: relationship.talentAId,
+    sourceId: template.sourceId,
+    sentiment: template.sentiment,
+    reach: template.reach,
+    dedupeKey: `relationship:${relationship.talentAId}:${relationship.talentBId}:${week}:${relationship.type}`,
+    triggerEvent: "TALENT_RELATIONSHIP",
+    entityLinks: [
+      { entityType: "talent", entityId: relationship.talentAId, entityName: relationship.talentAName },
+      { entityType: "talent", entityId: relationship.talentBId, entityName: relationship.talentBName },
+      ...(movie ? [{ entityType: "movie", entityId: String(movie._id), entityName: movie.title }] : []),
+    ],
+    studio,
+    movie,
+  });
+};
+
+/**
+ * Generate news for annual awards.
+ */
+export const generateNewsFromAwards = async (bestPicture, studio, year, week, playerWon = false) => {
+  const templateKey = playerWon ? "winner" : "nominee";
+  const template = NEWS_TEMPLATES[NEWS_CATEGORIES.AWARD][templateKey];
+  const content = fillTemplate(template, {
+    title: bestPicture.title,
+    studio: studio?.name || "Unknown Studio",
+    year,
+  });
+
+  return publishNewsArticle({
+    type: NEWS_CATEGORIES.AWARD,
+    headline: content.headline,
+    body: content.body,
+    week,
+    studioId: bestPicture.studioId,
+    movieId: bestPicture._id,
+    sourceId: template.sourceId,
+    sentiment: template.sentiment,
+    reach: template.reach,
+    dedupeKey: `award:best_picture:${year}`,
+    triggerEvent: "ANNUAL_AWARDS",
+    entityLinks: [
+      { entityType: "movie", entityId: String(bestPicture._id), entityName: bestPicture.title },
+    ],
+    studio: playerWon ? studio : null,
+    movie: playerWon ? bestPicture : null,
+  });
+};
+
+/**
+ * Generate news for a streaming deal.
+ */
+export const generateNewsFromStreamingDeal = async (movie, studio, platformName, week) => {
+  const template = NEWS_TEMPLATES[NEWS_CATEGORIES.STREAMING].deal;
+  const content = fillTemplate(template, {
+    title: movie.title,
+    studio: studio.name,
+    platform: platformName,
+  });
+
+  return publishNewsArticle({
+    type: NEWS_CATEGORIES.STREAMING,
+    headline: content.headline,
+    body: content.body,
+    week,
+    studioId: studio._id,
+    movieId: movie._id,
+    sourceId: template.sourceId,
+    sentiment: template.sentiment,
+    reach: template.reach,
+    dedupeKey: `streaming:${movie._id}:${week}`,
+    triggerEvent: "STREAMING_DEAL",
+    entityLinks: [
+      { entityType: "movie", entityId: String(movie._id), entityName: movie.title },
+      { entityType: "platform", entityId: platformName, entityName: platformName },
+    ],
+    studio,
+    movie,
   });
 };
 
@@ -83,14 +426,27 @@ export const generateNewsFromEvent = async (eventLabel, eventMessage, week) => {
  * Generate news article for a rival release.
  */
 export const generateNewsFromRivalRelease = async (rivalRelease, week) => {
-  const formattedGross = rivalRelease.boxOffice ? rivalRelease.boxOffice.toLocaleString() : "0";
-  const headline = `COMPETITION: Rival Studio Releases "${rivalRelease.title}"`;
-  const body = `Competitor studio "${rivalRelease.studioName}" has released its new project "${rivalRelease.title}" in the ${rivalRelease.genre} genre. The movie achieved a ${rivalRelease.verdict} verdict and grossed ₹${formattedGross} worldwide.`;
+  const template = NEWS_TEMPLATES[NEWS_CATEGORIES.RIVALRY].release;
+  const content = fillTemplate(template, {
+    title: rivalRelease.title,
+    studio: rivalRelease.studioName,
+    genre: rivalRelease.genre,
+    verdict: rivalRelease.verdict,
+    gross: (rivalRelease.boxOffice || 0).toLocaleString("en-IN"),
+  });
 
-  return await NewsItem.create({
-    type: "rivalry",
-    headline,
-    body,
+  return publishNewsArticle({
+    type: NEWS_CATEGORIES.RIVALRY,
+    headline: content.headline,
+    body: content.body,
     week,
+    sourceId: template.sourceId,
+    sentiment: template.sentiment,
+    reach: template.reach,
+    dedupeKey: `rival:${rivalRelease.title}:${week}`,
+    triggerEvent: "RIVAL_RELEASE",
+    entityLinks: [
+      { entityType: "rival_studio", entityId: rivalRelease.studioName, entityName: rivalRelease.studioName },
+    ],
   });
 };

--- a/backend/src/services/simulation/engines/prEngine.js
+++ b/backend/src/services/simulation/engines/prEngine.js
@@ -1,4 +1,5 @@
 import { addNotification } from "../helpers/notificationHelper.js";
+import { generateNewsFromScandal } from "./newsEngine.js";
 
 /**
  * PR & Scandal Management Engine (issue #281)
@@ -80,7 +81,7 @@ export const PR_CAMPAIGNS = [
  * @param {object} studio - Studio document
  * @returns {Array} list of scandal events that fired
  */
-export const processScandals = (gameState, studio) => {
+export const processScandals = async (gameState, studio) => {
   const firedScandals = [];
   const currentWeek = gameState.currentWeek || 0;
 
@@ -102,6 +103,8 @@ export const processScandals = (gameState, studio) => {
         gameState,
         `SCANDAL: ${scandal.description} Reputation dropped to ${studio.reputation}.`
       );
+
+      await generateNewsFromScandal(scandal, studio, currentWeek);
 
       firedScandals.push(scandal);
 

--- a/backend/src/services/simulation/engines/relationshipEngine.js
+++ b/backend/src/services/simulation/engines/relationshipEngine.js
@@ -17,7 +17,7 @@
 
 import TalentRelationship, { RELATIONSHIP_TYPES } from "../../../models/TalentRelationship.js";
 import { addNotification } from "../helpers/notificationHelper.js";
-import { generateNewsFromEvent } from "./newsEngine.js";
+import { generateNewsFromEvent, generateNewsFromRelationship } from "./newsEngine.js";
 
 /**
  * Normalizes ID pair to ensure talentAId < talentBId for deterministic indexing.
@@ -182,7 +182,7 @@ export const processProductionCastDynamics = async (movie, gameState, studio) =>
 
         const msg = `On-set friction between ${rel.talentAName || "Lead"} and ${rel.talentBName || "Co-Star"} (${rel.type}) delayed production of "${movie.title}" by 1 week!`;
         addNotification(gameState, msg);
-        await generateNewsFromEvent("Set Conflict Reported", msg, gameState.currentWeek);
+        await generateNewsFromRelationship(rel, msg, gameState.currentWeek, movie, studio);
 
         rel.history.push({
           week: gameState.currentWeek,

--- a/backend/src/services/simulation/engines/tickEngine.js
+++ b/backend/src/services/simulation/engines/tickEngine.js
@@ -248,7 +248,7 @@ export const processWeeklyTick = async (gameState, studio) => {
 
   // 12. PR & Scandal events — roll for studio scandals and apply
   //     reputation decay (issue #281).
-  processScandals(gameState, studio);
+  await processScandals(gameState, studio);
 
   // 13. Talent Relationship & Chemistry Lifecycle (issue #535)
   if (gameState.user) {

--- a/backend/tests/newsEngine.test.js
+++ b/backend/tests/newsEngine.test.js
@@ -1,58 +1,167 @@
-import { test } from "node:test";
+import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
+  calculateHypeEffect,
+  calculateReputationEffect,
+  applyNewsEffects,
+  publishNewsArticle,
   generateNewsFromRelease,
   generateNewsFromTrend,
-  generateNewsFromEvent,
+  generateNewsFromScandal,
 } from "../src/services/simulation/engines/newsEngine.js";
+import { NEWS_SENTIMENTS } from "../src/constants/newsMedia.js";
 import NewsItem from "../src/models/NewsItem.js";
 
-test("newsEngine generateNewsFromRelease creates hit news article", async () => {
-  const originalCreate = NewsItem.create;
-  let createdPayload = null;
+describe("Dynamic News & Media Engine (issue #543)", () => {
+  it("calculates bounded hype effects from sentiment and reach", () => {
+    const positive = calculateHypeEffect(NEWS_SENTIMENTS.POSITIVE, 80, 85);
+    const negative = calculateHypeEffect(NEWS_SENTIMENTS.NEGATIVE, 80, 85);
+    const neutral = calculateHypeEffect(NEWS_SENTIMENTS.NEUTRAL, 80, 85);
 
-  NewsItem.create = async (payload) => {
-    createdPayload = payload;
-    return payload;
-  };
+    assert.ok(positive > 0 && positive <= 5);
+    assert.ok(negative < 0 && negative >= -3);
+    assert.strictEqual(neutral, 0);
+  });
 
-  try {
-    const movie = {
-      title: "Super Hit",
-      verdict: "HIT",
-      worldwideGross: 15000000,
-      budget: 5000000,
+  it("calculates bounded reputation effects from sentiment and reach", () => {
+    const positive = calculateReputationEffect(NEWS_SENTIMENTS.POSITIVE, 90, 80);
+    const negative = calculateReputationEffect(NEWS_SENTIMENTS.NEGATIVE, 90, 80);
+
+    assert.ok(positive > 0 && positive <= 3);
+    assert.ok(negative < 0 && negative >= -8);
+  });
+
+  it("applies article effects to studio and movie within bounds", () => {
+    const studio = { reputation: 50 };
+    const movie = { hype: 40 };
+    const article = { reputationEffect: 5, hypeEffect: 4 };
+
+    applyNewsEffects(article, studio, movie);
+
+    assert.strictEqual(studio.reputation, 55);
+    assert.strictEqual(movie.hype, 44);
+  });
+
+  it("publishNewsArticle deduplicates by dedupeKey", async () => {
+    const originalFindOne = NewsItem.findOne;
+    const originalCreate = NewsItem.create;
+    let createCount = 0;
+    const store = new Map();
+
+    NewsItem.findOne = async ({ dedupeKey }) => store.get(dedupeKey) || null;
+    NewsItem.create = async (payload) => {
+      createCount++;
+      store.set(payload.dedupeKey, payload);
+      return payload;
     };
-    const studio = { name: "Paramount Works" };
-    await generateNewsFromRelease(movie, studio, 5);
 
-    assert.equal(createdPayload.type, "box_office");
-    assert.ok(createdPayload.headline.includes("SUCCESS"));
-    assert.ok(createdPayload.body.includes("Paramount Works"));
-    assert.ok(createdPayload.body.includes("Super Hit"));
-    assert.equal(createdPayload.week, 5);
-  } finally {
-    NewsItem.create = originalCreate;
-  }
-});
+    try {
+      await publishNewsArticle({
+        type: "trend",
+        headline: "Test",
+        body: "Body",
+        week: 1,
+        dedupeKey: "trend:Action:1",
+      });
+      const dup = await publishNewsArticle({
+        type: "trend",
+        headline: "Test Duplicate",
+        body: "Body",
+        week: 1,
+        dedupeKey: "trend:Action:1",
+      });
 
-test("newsEngine generateNewsFromTrend creates trend alert article", async () => {
-  const originalCreate = NewsItem.create;
-  let createdPayload = null;
+      assert.strictEqual(createCount, 1);
+      assert.strictEqual(dup.headline, "Test");
+    } finally {
+      NewsItem.findOne = originalFindOne;
+      NewsItem.create = originalCreate;
+    }
+  });
 
-  NewsItem.create = async (payload) => {
-    createdPayload = payload;
-    return payload;
-  };
+  it("generateNewsFromRelease creates box office and review articles", async () => {
+    const originalCreate = NewsItem.create;
+    const originalFindOne = NewsItem.findOne;
+    const created = [];
 
-  try {
-    const trend = { genre: "Sci-Fi" };
-    await generateNewsFromTrend(trend, 10);
+    NewsItem.findOne = async () => null;
+    NewsItem.create = async (payload) => {
+      created.push(payload);
+      return payload;
+    };
 
-    assert.equal(createdPayload.type, "trend");
-    assert.ok(createdPayload.headline.includes("Sci-Fi"));
-    assert.equal(createdPayload.week, 10);
-  } finally {
-    NewsItem.create = originalCreate;
-  }
+    try {
+      const movie = {
+        _id: "movie123",
+        title: "Super Hit",
+        verdict: "HIT",
+        criticScore: 82,
+        worldwideGross: 15000000,
+        budget: 5000000,
+      };
+      const studio = { _id: "studio123", name: "Paramount Works" };
+
+      await generateNewsFromRelease(movie, studio, 5);
+
+      assert.strictEqual(created.length, 2);
+      assert.ok(created.some((a) => a.type === "box_office"));
+      assert.ok(created.some((a) => a.type === "review"));
+      assert.ok(created[0].source?.credibility > 0);
+      assert.ok(created[0].entityLinks?.length > 0);
+    } finally {
+      NewsItem.create = originalCreate;
+      NewsItem.findOne = originalFindOne;
+    }
+  });
+
+  it("generateNewsFromTrend creates trend article with dedupe key", async () => {
+    const originalCreate = NewsItem.create;
+    const originalFindOne = NewsItem.findOne;
+    let createdPayload = null;
+
+    NewsItem.findOne = async () => null;
+    NewsItem.create = async (payload) => {
+      createdPayload = payload;
+      return payload;
+    };
+
+    try {
+      await generateNewsFromTrend({ genre: "Sci-Fi" }, 10);
+
+      assert.equal(createdPayload.type, "trend");
+      assert.ok(createdPayload.headline.includes("Sci-Fi"));
+      assert.strictEqual(createdPayload.dedupeKey, "trend:Sci-Fi:10");
+      assert.strictEqual(createdPayload.sentiment, NEWS_SENTIMENTS.POSITIVE);
+    } finally {
+      NewsItem.create = originalCreate;
+      NewsItem.findOne = originalFindOne;
+    }
+  });
+
+  it("generateNewsFromScandal creates negative sentiment scandal article", async () => {
+    const originalCreate = NewsItem.create;
+    const originalFindOne = NewsItem.findOne;
+    let createdPayload = null;
+
+    NewsItem.findOne = async () => null;
+    NewsItem.create = async (payload) => {
+      createdPayload = payload;
+      return payload;
+    };
+
+    try {
+      const scandal = { id: "actor-arrested", description: "An actor was arrested." };
+      const studio = { _id: "studio456", name: "Test Studio" };
+
+      await generateNewsFromScandal(scandal, studio, 7);
+
+      assert.equal(createdPayload.type, "scandal");
+      assert.strictEqual(createdPayload.sentiment, NEWS_SENTIMENTS.NEGATIVE);
+      assert.ok(createdPayload.reputationEffect < 0);
+      assert.ok(createdPayload.headline.includes("SCANDAL"));
+    } finally {
+      NewsItem.create = originalCreate;
+      NewsItem.findOne = originalFindOne;
+    }
+  });
 });

--- a/frontend/src/components/news/NewsTrendIndicator.jsx
+++ b/frontend/src/components/news/NewsTrendIndicator.jsx
@@ -3,23 +3,23 @@ import { Sparkles, TrendingUp, TrendingDown } from "lucide-react";
 const NewsTrendIndicator = ({ newsItems = [] }) => {
   const detectTrends = () => {
     const trends = [];
-    newsItems.forEach(item => {
-      const title = item.title.toLowerCase();
-      const content = item.content?.toLowerCase() || "";
+    newsItems.forEach((item) => {
+      const headline = (item.headline || item.title || "").toLowerCase();
+      const body = (item.body || item.content || "").toLowerCase();
       
-      if (title.includes("horror") || content.includes("horror")) {
-        if (title.includes("decline") || title.includes("dead") || title.includes("drop")) {
+      if (headline.includes("horror") || body.includes("horror")) {
+        if (headline.includes("decline") || headline.includes("dead") || headline.includes("drop")) {
           trends.push({ genre: "Horror", impact: "Decline", detail: "Sharp drop in interest", positive: false });
         } else {
           trends.push({ genre: "Horror", impact: "Hot", detail: "Rising interest", positive: true });
         }
       }
-      if (title.includes("fantasy") || content.includes("fantasy")) {
-        if (title.includes("surge") || title.includes("hot") || title.includes("gold")) {
+      if (headline.includes("fantasy") || body.includes("fantasy")) {
+        if (headline.includes("surge") || headline.includes("hot") || headline.includes("gold")) {
           trends.push({ genre: "High Fantasy", impact: "Surging", detail: "Massive box office demand", positive: true });
         }
       }
-      if (title.includes("action") || content.includes("action")) {
+      if (headline.includes("action") || body.includes("action")) {
         trends.push({ genre: "Action/Sci-Fi", impact: "Stable", detail: "Solid fan support", positive: true });
       }
     });

--- a/frontend/src/pages/news/NewsDetail.jsx
+++ b/frontend/src/pages/news/NewsDetail.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import { ArrowLeft, Calendar, Newspaper, AlertCircle, TrendingUp, Info } from "lucide-react";
+import { ArrowLeft, Calendar, Newspaper, AlertCircle, TrendingUp, Info, Link2 } from "lucide-react";
 import api from "../../api/axios";
 import DashboardLayout from "../../layouts/DashboardLayout";
 
@@ -27,18 +27,28 @@ const NewsDetail = () => {
   }, [id]);
 
   const getTagColor = (type) => {
-    switch (type?.toLowerCase()) {
-      case "boxoffice":
-      case "box office":
+    switch (type) {
+      case "box_office":
         return "bg-emerald-500/10 text-emerald-400 border-emerald-500/20";
+      case "review":
+        return "bg-cyan-500/10 text-cyan-400 border-cyan-500/20";
+      case "scandal":
+        return "bg-red-500/10 text-red-400 border-red-500/20";
       case "rivalry":
         return "bg-rose-500/10 text-rose-400 border-rose-500/20";
       case "trend":
-      case "trend alert":
         return "bg-indigo-500/10 text-indigo-400 border-indigo-500/20";
+      case "award":
+        return "bg-purple-500/10 text-purple-400 border-purple-500/20";
       default:
         return "bg-slate-500/10 text-slate-400 border-slate-500/20";
     }
+  };
+
+  const getSentimentLabel = (sentiment) => {
+    if (sentiment === "positive") return { text: "Positive Coverage", color: "text-emerald-400" };
+    if (sentiment === "negative") return { text: "Negative Coverage", color: "text-rose-400" };
+    return { text: "Neutral Coverage", color: "text-slate-400" };
   };
 
   return (
@@ -57,9 +67,9 @@ const NewsDetail = () => {
           </div>
         ) : (
           <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 sm:p-8 space-y-6">
-            <div className="flex justify-between items-center border-b border-slate-800 pb-5">
+            <div className="flex flex-wrap justify-between items-center gap-3 border-b border-slate-800 pb-5">
               <span className={`px-3 py-1 rounded-full text-xs font-semibold border ${getTagColor(article.type)}`}>
-                {article.type || "Industry News"}
+                {article.type?.replace(/_/g, " ") || "Industry News"}
               </span>
               <span className="text-xs text-slate-500 flex items-center gap-1.5 font-medium">
                 <Calendar size={14} /> Week {article.week}
@@ -68,29 +78,80 @@ const NewsDetail = () => {
 
             <div className="space-y-4">
               <h1 className="text-2xl sm:text-4xl font-extrabold text-white leading-tight">
-                {article.title}
+                {article.headline}
               </h1>
-              <div className="flex items-center gap-2 text-slate-400 text-sm">
-                <Newspaper size={16} className="text-indigo-400" />
-                <span>Hollywood Reporter &bull; CineVerse Wire</span>
+              <div className="flex flex-wrap items-center gap-4 text-slate-400 text-sm">
+                <div className="flex items-center gap-2">
+                  <Newspaper size={16} className="text-indigo-400" />
+                  <span>{article.source?.name || "CineVerse Wire"}</span>
+                </div>
+                {article.source?.credibility > 0 && (
+                  <span>Credibility: {article.source.credibility}%</span>
+                )}
+                {article.reach > 0 && <span>Reach: {article.reach}</span>}
+                {article.sentiment && (
+                  <span className={getSentimentLabel(article.sentiment).color}>
+                    {getSentimentLabel(article.sentiment).text}
+                  </span>
+                )}
               </div>
             </div>
 
             <div className="text-slate-300 leading-relaxed text-base sm:text-lg space-y-4 pt-4 border-t border-slate-800/50">
-              <p>{article.content || article.message}</p>
+              <p>{article.body}</p>
             </div>
 
-            {/* Strategic Studio Insights */}
+            {article.entityLinks?.length > 0 && (
+              <div className="bg-slate-950/50 border border-slate-800 rounded-2xl p-5 space-y-3">
+                <h3 className="text-white font-bold text-sm uppercase tracking-wider flex items-center gap-2">
+                  <Link2 size={16} className="text-indigo-400" /> Linked Entities
+                </h3>
+                <div className="flex flex-wrap gap-2">
+                  {article.entityLinks.map((link, idx) => (
+                    <span
+                      key={idx}
+                      className="px-3 py-1 rounded-lg bg-slate-800 text-slate-300 text-xs font-medium"
+                    >
+                      {link.entityType}: {link.entityName || link.entityId}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {(article.hypeEffect !== 0 || article.reputationEffect !== 0) && (
+              <div className="grid grid-cols-2 gap-4">
+                {article.hypeEffect !== 0 && (
+                  <div className="bg-slate-950/50 border border-slate-800 rounded-xl p-4 text-center">
+                    <p className="text-xs text-slate-500 uppercase">Hype Impact</p>
+                    <p className={`text-lg font-bold ${article.hypeEffect > 0 ? "text-emerald-400" : "text-rose-400"}`}>
+                      {article.hypeEffect > 0 ? "+" : ""}{article.hypeEffect}
+                    </p>
+                  </div>
+                )}
+                {article.reputationEffect !== 0 && (
+                  <div className="bg-slate-950/50 border border-slate-800 rounded-xl p-4 text-center">
+                    <p className="text-xs text-slate-500 uppercase">Reputation Impact</p>
+                    <p className={`text-lg font-bold ${article.reputationEffect > 0 ? "text-emerald-400" : "text-rose-400"}`}>
+                      {article.reputationEffect > 0 ? "+" : ""}{article.reputationEffect}
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
+
             <div className="bg-indigo-500/5 border border-indigo-500/20 rounded-2xl p-5 space-y-3 mt-6">
               <h3 className="text-white font-bold text-sm uppercase tracking-wider flex items-center gap-2">
                 <Info size={16} className="text-indigo-400" /> Studio Advisor Recommendations
               </h3>
               <p className="text-sm text-slate-400 leading-relaxed">
-                {article.type?.toLowerCase() === "trend alert"
+                {article.type === "trend"
                   ? "Market dynamics are shifting rapidly. Pivot scripts currently in the PLANNING phase to align with these trends to optimize box office multipliers upon release."
-                  : article.type?.toLowerCase() === "rivalry"
-                  ? "Ensure your active movies have boosted marketing campaigns to resist rival box office pressure."
-                  : "Leverage this momentum. Consider initiating production on new scripts or locking down critical talent while market interest remains high."}
+                  : article.type === "rivalry"
+                    ? "Ensure your active movies have boosted marketing campaigns to resist rival box office pressure."
+                    : article.sentiment === "negative"
+                      ? "Consider launching a PR campaign to counter negative coverage and restore public trust."
+                      : "Leverage this momentum. Consider initiating production on new scripts or locking down critical talent while market interest remains high."}
               </p>
             </div>
           </div>

--- a/frontend/src/pages/news/NewsFeed.jsx
+++ b/frontend/src/pages/news/NewsFeed.jsx
@@ -38,6 +38,8 @@ const NewsFeed = () => {
     switch (type) {
       case "box_office":
         return "bg-emerald-500/10 text-emerald-400 border-emerald-500/20";
+      case "review":
+        return "bg-cyan-500/10 text-cyan-400 border-cyan-500/20";
       case "trend":
         return "bg-indigo-500/10 text-indigo-400 border-indigo-500/20";
       case "event":
@@ -46,26 +48,45 @@ const NewsFeed = () => {
         return "bg-rose-500/10 text-rose-400 border-rose-500/20";
       case "award":
         return "bg-purple-500/10 text-purple-400 border-purple-500/20";
+      case "scandal":
+        return "bg-red-500/10 text-red-400 border-red-500/20";
+      case "relationship":
+      case "celebrity":
+        return "bg-pink-500/10 text-pink-400 border-pink-500/20";
+      case "streaming":
+        return "bg-violet-500/10 text-violet-400 border-violet-500/20";
+      case "franchise":
+        return "bg-orange-500/10 text-orange-400 border-orange-500/20";
+      case "social":
+        return "bg-sky-500/10 text-sky-400 border-sky-500/20";
       default:
         return "bg-slate-500/10 text-slate-400 border-slate-500/20";
     }
   };
 
   const getTypeLabel = (type) => {
-    switch (type) {
-      case "box_office":
-        return "Box Office";
-      case "trend":
-        return "Trend Alert";
-      case "event":
-        return "Industry Event";
-      case "rivalry":
-        return "Rivalry";
-      case "award":
-        return "Awards";
-      default:
-        return "General";
-    }
+    const labels = {
+      box_office: "Box Office",
+      review: "Review",
+      trend: "Trend Alert",
+      event: "Industry Event",
+      rivalry: "Rivalry",
+      award: "Awards",
+      scandal: "Scandal",
+      relationship: "Relationships",
+      celebrity: "Celebrity",
+      streaming: "Streaming",
+      franchise: "Franchise",
+      business: "Business",
+      social: "Social Media",
+    };
+    return labels[type] || "General";
+  };
+
+  const getSentimentColor = (sentiment) => {
+    if (sentiment === "positive") return "text-emerald-400";
+    if (sentiment === "negative") return "text-rose-400";
+    return "text-slate-400";
   };
 
   return (
@@ -81,9 +102,10 @@ const NewsFeed = () => {
             {[
               { label: "All News", value: "" },
               { label: "Box Office", value: "box_office" },
+              { label: "Reviews", value: "review" },
               { label: "Trends", value: "trend" },
-              { label: "Events", value: "event" },
-              { label: "Rivalry", value: "rivalry" },
+              { label: "Scandals", value: "scandal" },
+              { label: "Awards", value: "award" },
             ].map((btn) => (
               <button
                 key={btn.value}
@@ -126,15 +148,29 @@ const NewsFeed = () => {
                   className="block bg-slate-950/60 backdrop-blur-xl border border-slate-800/60 rounded-2xl p-6 hover:border-slate-700/80 transition-all duration-300 hover:translate-y-[-2px] group cursor-pointer"
                 >
                   <div className="flex items-center justify-between gap-4 mb-3">
-                    <span className={`px-2.5 py-1 rounded-full text-xs font-semibold border ${getBadgeColor(item.type)}`}>
-                      {getTypeLabel(item.type)}
-                    </span>
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className={`px-2.5 py-1 rounded-full text-xs font-semibold border ${getBadgeColor(item.type)}`}>
+                        {getTypeLabel(item.type)}
+                      </span>
+                      {item.sentiment && (
+                        <span className={`text-xs font-medium capitalize ${getSentimentColor(item.sentiment)}`}>
+                          {item.sentiment}
+                        </span>
+                      )}
+                    </div>
                     <span className="text-xs text-slate-500 font-medium">Week {item.week}</span>
                   </div>
                   <h3 className="text-xl font-bold text-white group-hover:text-blue-400 transition-colors duration-200">
                     {item.headline}
                   </h3>
-                  <p className="mt-3 text-slate-400 leading-relaxed text-sm md:text-base">{item.body}</p>
+                  <p className="mt-3 text-slate-400 leading-relaxed text-sm md:text-base line-clamp-2">{item.body}</p>
+                  {(item.source?.name || item.reach) && (
+                    <div className="mt-3 flex items-center gap-3 text-xs text-slate-500">
+                      {item.source?.name && <span>{item.source.name}</span>}
+                      {item.reach > 0 && <span>Reach: {item.reach}</span>}
+                      {item.source?.credibility > 0 && <span>Credibility: {item.source.credibility}%</span>}
+                    </div>
+                  )}
                 </Link>
               ))
             )}


### PR DESCRIPTION
## Summary

- Extends the news article schema with source/credibility, sentiment, reach, regional audience, entity links, and deduplication
- Adds procedural article generation from simulation events (releases, reviews, scandals, relationships, awards, streaming deals, franchise milestones, trends, rivals)
- Applies bounded hype and reputation effects based on sentiment, reach, and source credibility
- Updates Industry News feed and article detail pages to display media metadata and linked entities

Closes #543

**ECSOC 2026** contribution — please apply the `ECSOC2026` label.

## Test plan

- [ ] `cd backend && node --test tests/newsEngine.test.js` — all 7 tests pass
- [ ] Advance simulation weeks — confirm articles appear in `/news`
- [ ] Release a movie — confirm box office + review articles
- [ ] Attach screenshot of updated News Feed