### PR TITLE
feat: Build regional and global cinema market simulation

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -59,6 +59,7 @@ import festivalRoutes from "./routes/festivalRoutes.js";
 import progressionRoutes from "./routes/progressionRoutes.js";
 import seederRoutes from "./routes/seederRoutes.js";
 import relationshipRoutes from "./routes/relationshipRoutes.js";
+import cinemaMarketRoutes from "./routes/cinemaMarketRoutes.js";
 
 const app = express();
 app.set("trust proxy", true);
@@ -162,6 +163,7 @@ app.use("/api/festivals", apiRateLimiter, festivalRoutes);
 app.use("/api/progression", apiRateLimiter, progressionRoutes);
 app.use("/api/seeder", apiRateLimiter, seederRoutes);
 app.use("/api/relationships", apiRateLimiter, relationshipRoutes);
+app.use("/api/cinema-markets", apiRateLimiter, cinemaMarketRoutes);
 // app.use("/api/talent-agencies", apiRateLimiter, agencyRoutes);
 
 app.use((req, res) => {

--- a/backend/src/constants/cinemaMarkets.js
+++ b/backend/src/constants/cinemaMarkets.js
@@ -1,0 +1,110 @@
+/**
+ * Regional and global cinema market definitions (issue #545).
+ * Each market has distinct audience, budget, genre, and distribution parameters.
+ */
+
+export const CINEMA_MARKET_IDS = {
+  BOLLYWOOD: "BOLLYWOOD",
+  TOLLYWOOD: "TOLLYWOOD",
+  KOLLYWOOD: "KOLLYWOOD",
+  HOLLYWOOD: "HOLLYWOOD",
+  KOREAN: "KOREAN",
+  JAPANESE: "JAPANESE",
+};
+
+export const CINEMA_MARKETS = {
+  [CINEMA_MARKET_IDS.BOLLYWOOD]: {
+    id: CINEMA_MARKET_IDS.BOLLYWOOD,
+    name: "Bollywood (Hindi)",
+    region: "SOUTH_ASIA",
+    currency: "INR",
+    currencyToINR: 1,
+    audienceBase: 1.0,
+    avgTicketPriceINR: 280,
+    productionCostMultiplier: 0.85,
+    distributionFeePct: 0.22,
+    genreAffinities: { Drama: 1.3, Romance: 1.45, Action: 1.2, Comedy: 1.25 },
+    talentPoolRegion: "INDIA_HINDI",
+    localizationCostBase: 0,
+  },
+  [CINEMA_MARKET_IDS.TOLLYWOOD]: {
+    id: CINEMA_MARKET_IDS.TOLLYWOOD,
+    name: "Tollywood (Telugu)",
+    region: "SOUTH_ASIA",
+    currency: "INR",
+    currencyToINR: 1,
+    audienceBase: 0.55,
+    avgTicketPriceINR: 220,
+    productionCostMultiplier: 0.7,
+    distributionFeePct: 0.2,
+    genreAffinities: { Action: 1.4, Drama: 1.15, Romance: 1.2 },
+    talentPoolRegion: "INDIA_TELUGU",
+    localizationCostBase: 150000,
+  },
+  [CINEMA_MARKET_IDS.KOLLYWOOD]: {
+    id: CINEMA_MARKET_IDS.KOLLYWOOD,
+    name: "Kollywood (Tamil)",
+    region: "SOUTH_ASIA",
+    currency: "INR",
+    currencyToINR: 1,
+    audienceBase: 0.5,
+    avgTicketPriceINR: 210,
+    productionCostMultiplier: 0.72,
+    distributionFeePct: 0.2,
+    genreAffinities: { Action: 1.35, Drama: 1.2, Thriller: 1.25 },
+    talentPoolRegion: "INDIA_TAMIL",
+    localizationCostBase: 150000,
+  },
+  [CINEMA_MARKET_IDS.HOLLYWOOD]: {
+    id: CINEMA_MARKET_IDS.HOLLYWOOD,
+    name: "Hollywood (US)",
+    region: "NORTH_AMERICA",
+    currency: "USD",
+    currencyToINR: 83,
+    audienceBase: 1.2,
+    avgTicketPriceINR: 996,
+    productionCostMultiplier: 1.4,
+    distributionFeePct: 0.3,
+    genreAffinities: { Action: 1.3, "Sci-Fi": 1.35, Horror: 1.2, Animation: 1.25 },
+    talentPoolRegion: "US",
+    localizationCostBase: 2500000,
+  },
+  [CINEMA_MARKET_IDS.KOREAN]: {
+    id: CINEMA_MARKET_IDS.KOREAN,
+    name: "Korean Cinema",
+    region: "EAST_ASIA",
+    currency: "KRW",
+    currencyToINR: 0.063,
+    audienceBase: 0.45,
+    avgTicketPriceINR: 720,
+    productionCostMultiplier: 0.9,
+    distributionFeePct: 0.25,
+    genreAffinities: { Drama: 1.4, Thriller: 1.3, Romance: 1.25, Horror: 1.2 },
+    talentPoolRegion: "KOREA",
+    localizationCostBase: 1800000,
+  },
+  [CINEMA_MARKET_IDS.JAPANESE]: {
+    id: CINEMA_MARKET_IDS.JAPANESE,
+    name: "Japanese Cinema",
+    region: "EAST_ASIA",
+    currency: "JPY",
+    currencyToINR: 0.56,
+    audienceBase: 0.4,
+    avgTicketPriceINR: 840,
+    productionCostMultiplier: 0.95,
+    distributionFeePct: 0.28,
+    genreAffinities: { Animation: 1.5, Drama: 1.2, "Sci-Fi": 1.25, Horror: 1.15 },
+    talentPoolRegion: "JAPAN",
+    localizationCostBase: 2000000,
+  },
+};
+
+export const INDIAN_MARKETS = [
+  CINEMA_MARKET_IDS.BOLLYWOOD,
+  CINEMA_MARKET_IDS.TOLLYWOOD,
+  CINEMA_MARKET_IDS.KOLLYWOOD,
+];
+
+export const getMarketList = () => Object.values(CINEMA_MARKETS);
+
+export const getMarketById = (marketId) => CINEMA_MARKETS[marketId] || null;

--- a/backend/src/controllers/cinemaMarketController.js
+++ b/backend/src/controllers/cinemaMarketController.js
@@ -1,0 +1,166 @@
+import Movie from "../models/Movie.js";
+import Studio from "../models/Studio.js";
+import GameState from "../models/GameState.js";
+import { getMarketList } from "../constants/cinemaMarkets.js";
+import {
+  calculateMultiMarketRelease,
+  projectMarketRevenue,
+} from "../services/simulation/engines/cinemaMarketEngine.js";
+
+/**
+ * GET /api/cinema-markets
+ */
+export const getCinemaMarkets = async (req, res) => {
+  try {
+    return res.status(200).json({
+      success: true,
+      markets: getMarketList(),
+    });
+  } catch (error) {
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+/**
+ * GET /api/cinema-markets/movies
+ */
+export const getStudioMarketMovies = async (req, res) => {
+  try {
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({ success: false, message: "Studio not found." });
+    }
+
+    const movies = await Movie.find({
+      studioId: studio._id,
+      status: { $nin: ["RELEASED", "RELEASED_STREAMING"] },
+    })
+      .select("title status genre targetMarkets primaryMarket crossMarketRelease budget hype quality")
+      .lean();
+
+    return res.status(200).json({ success: true, movies });
+  } catch (error) {
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+/**
+ * PUT /api/cinema-markets/movies/:movieId/targets
+ */
+export const setMovieTargetMarkets = async (req, res) => {
+  try {
+    const { movieId } = req.params;
+    const { targetMarkets, primaryMarket, crossMarketRelease, isCoProduction } = req.body;
+
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({ success: false, message: "Studio not found." });
+    }
+
+    if (!targetMarkets.includes(primaryMarket)) {
+      return res.status(400).json({
+        success: false,
+        message: "Primary market must be included in target markets.",
+      });
+    }
+
+    const movie = await Movie.findOne({ _id: movieId, studioId: studio._id });
+    if (!movie) {
+      return res.status(404).json({ success: false, message: "Movie not found." });
+    }
+
+    movie.targetMarkets = targetMarkets;
+    movie.primaryMarket = primaryMarket;
+    movie.crossMarketRelease = crossMarketRelease ?? targetMarkets.length > 1;
+    movie.isCoProduction = isCoProduction ?? false;
+    await movie.save();
+
+    return res.status(200).json({
+      success: true,
+      message: `Market targets updated for "${movie.title}".`,
+      movie,
+    });
+  } catch (error) {
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+/**
+ * GET /api/cinema-markets/movies/:movieId/projections
+ */
+export const getMovieMarketProjections = async (req, res) => {
+  try {
+    const studio = await Studio.findOne({ owner: req.user._id });
+    const gameState = await GameState.findOne({ user: req.user._id });
+    if (!studio || !gameState) {
+      return res.status(404).json({ success: false, message: "Game state not found." });
+    }
+
+    const movie = await Movie.findOne({ _id: req.params.movieId, studioId: studio._id });
+    if (!movie) {
+      return res.status(404).json({ success: false, message: "Movie not found." });
+    }
+
+    const leadActor = gameState.ownedActors.find((a) => a.id === movie.leadActorId) || {};
+    const director = gameState.ownedDirectors.find((d) => d.id === movie.directorId) || {};
+    const targets = movie.targetMarkets?.length ? movie.targetMarkets : [movie.primaryMarket || "BOLLYWOOD"];
+
+    const projection = projectMarketRevenue(
+      movie,
+      leadActor,
+      director,
+      targets,
+      movie.primaryMarket || targets[0]
+    );
+
+    return res.status(200).json({ success: true, projection });
+  } catch (error) {
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+/**
+ * GET /api/cinema-markets/analytics
+ */
+export const getCinemaMarketAnalytics = async (req, res) => {
+  try {
+    const studio = await Studio.findOne({ owner: req.user._id });
+    if (!studio) {
+      return res.status(404).json({ success: false, message: "Studio not found." });
+    }
+
+    const released = await Movie.find({
+      studioId: studio._id,
+      status: { $in: ["RELEASED", "RELEASED_STREAMING"] },
+      cinemaMarketRevenue: { $exists: true, $ne: [] },
+    }).lean();
+
+    const marketTotals = {};
+    let totalRevenue = 0;
+
+    for (const movie of released) {
+      for (const entry of movie.cinemaMarketRevenue || []) {
+        marketTotals[entry.marketId] = (marketTotals[entry.marketId] || 0) + (entry.grossINR || 0);
+        totalRevenue += entry.grossINR || 0;
+      }
+    }
+
+    const breakdown = Object.entries(marketTotals).map(([marketId, grossINR]) => ({
+      marketId,
+      grossINR,
+      share: totalRevenue > 0 ? Number(((grossINR / totalRevenue) * 100).toFixed(1)) : 0,
+    }));
+
+    return res.status(200).json({
+      success: true,
+      analytics: {
+        totalRevenue,
+        marketBreakdown: breakdown,
+        releasedCount: released.length,
+        crossMarketReleases: released.filter((m) => (m.targetMarkets?.length || 0) > 1).length,
+      },
+    });
+  } catch (error) {
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};

--- a/backend/src/models/Movie.js
+++ b/backend/src/models/Movie.js
@@ -106,6 +106,24 @@ const movieSchema = new mongoose.Schema(
     coProducerStudioId: { type: String, default: null },
     coProducerShare: { type: Number, default: 0 },
 
+    // Regional & global cinema markets (issue #545)
+    targetMarkets: [{ type: String }],
+    primaryMarket: { type: String, default: "BOLLYWOOD" },
+    crossMarketRelease: { type: Boolean, default: false },
+    isCoProduction: { type: Boolean, default: false },
+    cinemaMarketRevenue: [
+      {
+        marketId: String,
+        marketName: String,
+        grossINR: Number,
+        grossLocal: Number,
+        netRevenue: Number,
+        localizationCost: Number,
+        ticketsSold: Number,
+        currency: String,
+      },
+    ],
+
     // Re-release and Director's Cut support (issue #283)
     isReRelease: { type: Boolean, default: false },
     reReleaseWeek: { type: Number, default: null },

--- a/backend/src/routes/cinemaMarketRoutes.js
+++ b/backend/src/routes/cinemaMarketRoutes.js
@@ -1,0 +1,24 @@
+import express from "express";
+import { protect } from "../middleware/authMiddleware.js";
+import { validate } from "../middleware/validationMiddleware.js";
+import {
+  setMovieTargetMarketsSchema,
+  projectMarketRevenueSchema,
+} from "../validators/cinemaMarketValidators.js";
+import {
+  getCinemaMarkets,
+  getStudioMarketMovies,
+  setMovieTargetMarkets,
+  getMovieMarketProjections,
+  getCinemaMarketAnalytics,
+} from "../controllers/cinemaMarketController.js";
+
+const router = express.Router();
+
+router.get("/", protect, getCinemaMarkets);
+router.get("/movies", protect, getStudioMarketMovies);
+router.get("/analytics", protect, getCinemaMarketAnalytics);
+router.put("/movies/:movieId/targets", protect, validate(setMovieTargetMarketsSchema), setMovieTargetMarkets);
+router.get("/movies/:movieId/projections", protect, validate(projectMarketRevenueSchema), getMovieMarketProjections);
+
+export default router;

--- a/backend/src/services/movie/releaseService.js
+++ b/backend/src/services/movie/releaseService.js
@@ -13,6 +13,7 @@ import { generateNewsFromRelease } from "../simulation/engines/newsEngine.js";
 import { findScriptById } from "./movieValidationService.js";
 import { computeClashPenalty } from "../simulation/engines/clashEngine.js";
 import { addHistoricRecord } from "../simulation/helpers/historicRecordHelper.js";
+import { calculateMultiMarketRelease } from "../simulation/engines/cinemaMarketEngine.js";
 
 /**
  * Handles the complete release process of a movie (manual or scheduled).
@@ -60,14 +61,28 @@ export const performMovieRelease = async (movie, studio, gameState, session = nu
   const activeTrends = gameState.marketTrends?.activeTrends || [];
   const marketMultiplier = getGenreMultiplier(activeTrends, script?.genres);
   const demographicMultiplier = getDemographicMultiplier(script?.genres, movie.marketingCampaigns);
-  const boxOffice = generateBoxOffice(
-    movie,
-    leadActor,
-    director,
-    marketMultiplier,
-    demographicMultiplier,
-    franchiseDoc
-  );
+
+  let boxOffice;
+  if (movie.targetMarkets?.length > 0) {
+    const marketResult = calculateMultiMarketRelease(
+      movie,
+      leadActor || { popularity: 50 },
+      director || { skill: 50 },
+      movie.targetMarkets,
+      movie.primaryMarket || movie.targetMarkets[0]
+    );
+    movie.cinemaMarketRevenue = marketResult.markets;
+    boxOffice = marketResult;
+  } else {
+    boxOffice = generateBoxOffice(
+      movie,
+      leadActor,
+      director,
+      marketMultiplier,
+      demographicMultiplier,
+      franchiseDoc
+    );
+  }
   Object.assign(movie, boxOffice);
 
   // Apply clash penalty

--- a/backend/src/services/simulation/engines/cinemaMarketEngine.js
+++ b/backend/src/services/simulation/engines/cinemaMarketEngine.js
@@ -1,0 +1,227 @@
+/**
+ * @fileoverview Regional & Global Cinema Market Engine (issue #545)
+ *
+ * Simulates distinct entertainment markets with audience preferences, localization,
+ * cross-market releases, and per-market revenue calculation normalized to INR.
+ */
+
+import {
+  CINEMA_MARKETS,
+  CINEMA_MARKET_IDS,
+  INDIAN_MARKETS,
+  getMarketById,
+} from "../../../constants/cinemaMarkets.js";
+import { MAX_GROSS } from "./boxOfficeEngine.js";
+import { getVerdict } from "../../../constants/verdicts.js";
+
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+/**
+ * Normalizes a local-currency amount to INR.
+ */
+export const normalizeToINR = (amount, marketId) => {
+  const market = getMarketById(marketId);
+  if (!market) return amount;
+  return Math.round(amount * market.currencyToINR);
+};
+
+/**
+ * Returns genre affinity multiplier for a market.
+ */
+export const getMarketGenreAffinity = (marketId, genre) => {
+  const market = getMarketById(marketId);
+  if (!market || !genre) return 1;
+  return market.genreAffinities[genre] || 1;
+};
+
+/**
+ * Returns talent pool region bonus when lead actor region matches market.
+ */
+export const getTalentRegionBonus = (marketId, talentRegion = "") => {
+  const market = getMarketById(marketId);
+  if (!market) return 1;
+
+  if (!talentRegion) return 1;
+  if (talentRegion === market.talentPoolRegion) return 1.2;
+
+  const indianRegions = ["INDIA_HINDI", "INDIA_TELUGU", "INDIA_TAMIL"];
+  if (
+    indianRegions.includes(market.talentPoolRegion) &&
+    indianRegions.includes(talentRegion)
+  ) {
+    return 1.08;
+  }
+
+  return 0.92;
+};
+
+/**
+ * Calculates localization cost for releasing in a non-primary market.
+ */
+export const calculateLocalizationCost = (marketId, primaryMarketId, movie) => {
+  if (marketId === primaryMarketId) return 0;
+
+  const market = getMarketById(marketId);
+  if (!market) return 0;
+
+  let cost = market.localizationCostBase + (movie.budget || 0) * 0.015;
+
+  if (
+    INDIAN_MARKETS.includes(marketId) &&
+    INDIAN_MARKETS.includes(primaryMarketId) &&
+    movie.isCoProduction
+  ) {
+    cost *= 0.6;
+  }
+
+  return Math.round(cost);
+};
+
+/**
+ * Cross-market release bonus (up to 12%).
+ */
+export const getCrossMarketBonus = (marketCount) => {
+  if (marketCount <= 1) return 1;
+  return 1 + Math.min(0.12, (marketCount - 1) * 0.03);
+};
+
+/**
+ * Calculates revenue for a single cinema market.
+ */
+export const calculateSingleMarketRevenue = (
+  movie,
+  marketId,
+  leadActor = {},
+  director = {},
+  primaryMarketId,
+  rng = Math.random
+) => {
+  const market = getMarketById(marketId);
+  if (!market) return null;
+
+  const genre = movie.genre || "Drama";
+  const genreAffinity = getMarketGenreAffinity(marketId, genre);
+  const talentRegion = leadActor.region || leadActor.talentRegion || "";
+  const talentBonus = getTalentRegionBonus(marketId, talentRegion);
+
+  const budget = Math.max(movie.budget || 1000000, 500000);
+  const qualityFactor = (movie.quality || 50) / 100;
+  const hypeFactor = (movie.hype || 50) / 100;
+  const starPower = ((leadActor.popularity || 50) / 100) * 0.4 + 0.6;
+  const directorBoost = ((director.skill || director.popularity || 50) / 100) * 0.1 + 0.95;
+
+  const baseRevenue =
+    budget *
+    market.productionCostMultiplier *
+    market.audienceBase *
+    genreAffinity *
+    qualityFactor *
+    hypeFactor *
+    starPower *
+    talentBonus *
+    directorBoost;
+
+  const variance = 0.75 + rng() * 0.5;
+  let grossINR = Math.round(baseRevenue * variance * market.avgTicketPriceINR / 250);
+
+  const localizationCost = calculateLocalizationCost(marketId, primaryMarketId, movie);
+  const distributionFee = Math.round(grossINR * market.distributionFeePct);
+  const netRevenue = Math.max(0, grossINR - localizationCost - distributionFee);
+
+  const ticketsSold = Math.round(grossINR / market.avgTicketPriceINR);
+
+  return {
+    marketId,
+    marketName: market.name,
+    currency: market.currency,
+    grossINR: clamp(grossINR, 0, MAX_GROSS),
+    grossLocal: Math.round(grossINR / market.currencyToINR),
+    netRevenue: clamp(netRevenue, 0, MAX_GROSS),
+    localizationCost,
+    distributionFee,
+    ticketsSold,
+    audienceReach: clamp(Math.round(ticketsSold / 1000), 0, 100),
+    genreAffinity,
+    talentBonus,
+  };
+};
+
+/**
+ * Calculates multi-market release revenue for targeted cinema markets.
+ */
+export const calculateMultiMarketRelease = (
+  movie,
+  leadActor = {},
+  director = {},
+  targetMarkets = [],
+  primaryMarketId = CINEMA_MARKET_IDS.BOLLYWOOD,
+  rng = Math.random
+) => {
+  const markets = targetMarkets.length > 0 ? targetMarkets : [primaryMarketId];
+  const crossBonus = getCrossMarketBonus(markets.length);
+
+  const marketResults = markets
+    .map((marketId) =>
+      calculateSingleMarketRevenue(movie, marketId, leadActor, director, primaryMarketId, rng)
+    )
+    .filter(Boolean);
+
+  let totalWorldwide = marketResults.reduce((sum, m) => sum + m.grossINR, 0);
+  totalWorldwide = Math.round(totalWorldwide * crossBonus);
+  totalWorldwide = clamp(totalWorldwide, 0, MAX_GROSS);
+
+  const primaryResult = marketResults.find((m) => m.marketId === primaryMarketId) || marketResults[0];
+  const domesticGross = primaryResult ? primaryResult.grossINR : Math.round(totalWorldwide * 0.45);
+  const internationalGross = clamp(totalWorldwide - domesticGross, 0, MAX_GROSS);
+
+  const openingWeekend = Math.round(totalWorldwide * (0.28 + rng() * 0.08));
+  const totalBudget = (movie.budget || 0) + (movie.marketingBudget || 0);
+  const totalLocalization = marketResults.reduce((sum, m) => sum + m.localizationCost, 0);
+  const profit = totalWorldwide - totalBudget - totalLocalization;
+  const roi = totalBudget > 0 ? profit / totalBudget : 0;
+
+  const regionalSplit = {
+    northAmerica: marketResults.find((m) => m.marketId === CINEMA_MARKET_IDS.HOLLYWOOD)?.grossINR || 0,
+    europe: 0,
+    asiaPacific: marketResults
+      .filter((m) =>
+        [CINEMA_MARKET_IDS.BOLLYWOOD, CINEMA_MARKET_IDS.TOLLYWOOD, CINEMA_MARKET_IDS.KOLLYWOOD, CINEMA_MARKET_IDS.KOREAN, CINEMA_MARKET_IDS.JAPANESE].includes(
+          m.marketId
+        )
+      )
+      .reduce((sum, m) => sum + m.grossINR, 0),
+    latinAmerica: 0,
+  };
+
+  return {
+    markets: marketResults,
+    totalWorldwide,
+    worldwideGross: totalWorldwide,
+    domesticGross: clamp(domesticGross, 0, MAX_GROSS),
+    internationalGross,
+    openingWeekend: clamp(openingWeekend, 0, MAX_GROSS),
+    boxOffice: totalWorldwide,
+    profit,
+    roi,
+    verdict: getVerdict(roi),
+    regionalSplit,
+    crossMarketBonus: crossBonus,
+    totalLocalizationCost: totalLocalization,
+  };
+};
+
+/**
+ * Projects revenue for active movies without persisting.
+ */
+export const projectMarketRevenue = (movie, leadActor, director, targetMarkets, primaryMarketId) => {
+  return calculateMultiMarketRelease(
+    movie,
+    leadActor,
+    director,
+    targetMarkets,
+    primaryMarketId,
+    () => 0.85
+  );
+};
+
+export default calculateMultiMarketRelease;

--- a/backend/src/validators/cinemaMarketValidators.js
+++ b/backend/src/validators/cinemaMarketValidators.js
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { CINEMA_MARKET_IDS } from "../constants/cinemaMarkets.js";
+import { objectIdString } from "./gameplayValidators.js";
+
+const marketIdEnum = z.enum(Object.values(CINEMA_MARKET_IDS));
+
+export const setMovieTargetMarketsSchema = {
+  params: z.object({
+    movieId: objectIdString,
+  }),
+  body: z.object({
+    targetMarkets: z.array(marketIdEnum).min(1).max(6),
+    primaryMarket: marketIdEnum,
+    crossMarketRelease: z.boolean().optional(),
+    isCoProduction: z.boolean().optional(),
+  }),
+};
+
+export const projectMarketRevenueSchema = {
+  params: z.object({
+    movieId: objectIdString,
+  }),
+};

--- a/backend/tests/cinemaMarketEngine.test.js
+++ b/backend/tests/cinemaMarketEngine.test.js
@@ -1,0 +1,122 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  normalizeToINR,
+  getMarketGenreAffinity,
+  getTalentRegionBonus,
+  calculateLocalizationCost,
+  getCrossMarketBonus,
+  calculateSingleMarketRevenue,
+  calculateMultiMarketRelease,
+} from "../src/services/simulation/engines/cinemaMarketEngine.js";
+import { CINEMA_MARKET_IDS } from "../src/constants/cinemaMarkets.js";
+
+describe("Cinema Market Engine (issue #545)", () => {
+  const baseMovie = {
+    title: "Test Film",
+    genre: "Action",
+    budget: 50000000,
+    marketingBudget: 10000000,
+    quality: 75,
+    hype: 80,
+  };
+
+  const leadActor = { popularity: 85, region: "INDIA_HINDI" };
+  const director = { skill: 70 };
+
+  it("normalizes currency amounts to INR", () => {
+    assert.strictEqual(normalizeToINR(100, CINEMA_MARKET_IDS.BOLLYWOOD), 100);
+    assert.strictEqual(normalizeToINR(1, CINEMA_MARKET_IDS.HOLLYWOOD), 83);
+  });
+
+  it("returns distinct genre affinities per market", () => {
+    const bollywoodRomance = getMarketGenreAffinity(CINEMA_MARKET_IDS.BOLLYWOOD, "Romance");
+    const hollywoodRomance = getMarketGenreAffinity(CINEMA_MARKET_IDS.HOLLYWOOD, "Romance");
+    const japaneseAnimation = getMarketGenreAffinity(CINEMA_MARKET_IDS.JAPANESE, "Animation");
+
+    assert.ok(bollywoodRomance > hollywoodRomance);
+    assert.strictEqual(japaneseAnimation, 1.5);
+  });
+
+  it("applies talent region bonus for matching pools", () => {
+    const match = getTalentRegionBonus(CINEMA_MARKET_IDS.BOLLYWOOD, "INDIA_HINDI");
+    const mismatch = getTalentRegionBonus(CINEMA_MARKET_IDS.HOLLYWOOD, "INDIA_HINDI");
+
+    assert.strictEqual(match, 1.2);
+    assert.ok(mismatch < 1);
+  });
+
+  it("calculates localization cost for cross-market releases", () => {
+    const cost = calculateLocalizationCost(CINEMA_MARKET_IDS.HOLLYWOOD, CINEMA_MARKET_IDS.BOLLYWOOD, baseMovie);
+    const noCost = calculateLocalizationCost(CINEMA_MARKET_IDS.BOLLYWOOD, CINEMA_MARKET_IDS.BOLLYWOOD, baseMovie);
+
+    assert.ok(cost > noCost);
+    assert.strictEqual(noCost, 0);
+  });
+
+  it("applies cross-market release bonus", () => {
+    assert.strictEqual(getCrossMarketBonus(1), 1);
+    assert.ok(getCrossMarketBonus(3) > 1);
+    assert.ok(getCrossMarketBonus(6) <= 1.12);
+  });
+
+  it("calculates single market revenue with distinct parameters", () => {
+    const rng = () => 0.9;
+    const bollywood = calculateSingleMarketRevenue(
+      baseMovie,
+      CINEMA_MARKET_IDS.BOLLYWOOD,
+      leadActor,
+      director,
+      CINEMA_MARKET_IDS.BOLLYWOOD,
+      rng
+    );
+    const hollywood = calculateSingleMarketRevenue(
+      baseMovie,
+      CINEMA_MARKET_IDS.HOLLYWOOD,
+      { popularity: 85, region: "US" },
+      director,
+      CINEMA_MARKET_IDS.BOLLYWOOD,
+      rng
+    );
+
+    assert.ok(bollywood.grossINR > 0);
+    assert.ok(hollywood.grossINR > 0);
+    assert.notStrictEqual(bollywood.grossINR, hollywood.grossINR);
+    assert.ok(hollywood.localizationCost > bollywood.localizationCost);
+  });
+
+  it("calculates multi-market global release revenue", () => {
+    const rng = () => 0.85;
+    const result = calculateMultiMarketRelease(
+      baseMovie,
+      leadActor,
+      director,
+      [CINEMA_MARKET_IDS.BOLLYWOOD, CINEMA_MARKET_IDS.TOLLYWOOD, CINEMA_MARKET_IDS.HOLLYWOOD],
+      CINEMA_MARKET_IDS.BOLLYWOOD,
+      rng
+    );
+
+    assert.strictEqual(result.markets.length, 3);
+    assert.ok(result.totalWorldwide > 0);
+    assert.ok(result.crossMarketBonus > 1);
+    assert.ok(result.worldwideGross >= result.domesticGross);
+    assert.ok(result.profit !== undefined);
+    assert.ok(result.verdict);
+  });
+
+  it("single-market release matches primary market domestic gross", () => {
+    const rng = () => 0.8;
+    const result = calculateMultiMarketRelease(
+      baseMovie,
+      leadActor,
+      director,
+      [CINEMA_MARKET_IDS.KOLLYWOOD],
+      CINEMA_MARKET_IDS.KOLLYWOOD,
+      rng
+    );
+
+    assert.strictEqual(result.markets.length, 1);
+    assert.strictEqual(result.crossMarketBonus, 1);
+    assert.strictEqual(result.domesticGross, result.markets[0].grossINR);
+  });
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,6 +28,7 @@ import ProductionQueue from "./pages/movies/ProductionQueue";
 import MovieComparison from "./pages/movies/MovieComparison";
 import StreamingDeals from "./pages/movies/StreamingDeals";
 import RegionalBoxOfficeHub from "./pages/movies/RegionalBoxOfficeHub";
+import CinemaMarketsHub from "./pages/movies/CinemaMarketsHub";
 import TVShowsHub from "./pages/tvshows/TVShowsHub";
 import ProduceTVShow from "./pages/tvshows/ProduceTVShow";
 import StudioStats from "./pages/studio/StudioStats";
@@ -179,6 +180,14 @@ function App() {
           element={
             <ProtectedRoute>
               <RegionalBoxOfficeHub />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/movies/cinema-markets"
+          element={
+            <ProtectedRoute>
+              <CinemaMarketsHub />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/components/common/Sidebar.jsx
+++ b/frontend/src/components/common/Sidebar.jsx
@@ -74,6 +74,11 @@ const Sidebar = ({ isOpen, onClose }) => {
       icon: Globe,
     },
     {
+      name: "Cinema Markets",
+      path: "/movies/cinema-markets",
+      icon: Globe,
+    },
+    {
       name: "Production Queue",
       path: "/movies/queue",
       icon: Layers,

--- a/frontend/src/pages/movies/CinemaMarketsHub.jsx
+++ b/frontend/src/pages/movies/CinemaMarketsHub.jsx
@@ -1,0 +1,251 @@
+import { useState, useEffect } from "react";
+import api from "../../api/axios";
+import DashboardLayout from "../../layouts/DashboardLayout";
+import { Globe, Film, TrendingUp, IndianRupee, MapPin, RefreshCw } from "lucide-react";
+
+const MARKET_COLORS = {
+  BOLLYWOOD: "from-orange-500 to-amber-600",
+  TOLLYWOOD: "from-red-600 to-rose-500",
+  KOLLYWOOD: "from-violet-600 to-purple-500",
+  HOLLYWOOD: "from-blue-600 to-indigo-600",
+  KOREAN: "from-pink-500 to-rose-600",
+  JAPANESE: "from-slate-600 to-slate-800",
+};
+
+const CinemaMarketsHub = () => {
+  const [markets, setMarkets] = useState([]);
+  const [movies, setMovies] = useState([]);
+  const [analytics, setAnalytics] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [selectedMovie, setSelectedMovie] = useState("");
+  const [selectedMarkets, setSelectedMarkets] = useState(["BOLLYWOOD"]);
+  const [primaryMarket, setPrimaryMarket] = useState("BOLLYWOOD");
+  const [projection, setProjection] = useState(null);
+  const [saving, setSaving] = useState(false);
+
+  const fetchAll = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const [marketsRes, moviesRes, analyticsRes] = await Promise.all([
+        api.get("/cinema-markets"),
+        api.get("/cinema-markets/movies"),
+        api.get("/cinema-markets/analytics"),
+      ]);
+      if (marketsRes.data?.success) setMarkets(marketsRes.data.markets || []);
+      if (moviesRes.data?.success) setMovies(moviesRes.data.movies || []);
+      if (analyticsRes.data?.success) setAnalytics(analyticsRes.data.analytics);
+    } catch {
+      setError("Unable to load cinema market data.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAll();
+  }, []);
+
+  const toggleMarket = (marketId) => {
+    setSelectedMarkets((prev) => {
+      if (prev.includes(marketId)) {
+        const next = prev.filter((id) => id !== marketId);
+        if (primaryMarket === marketId && next.length > 0) setPrimaryMarket(next[0]);
+        return next.length > 0 ? next : prev;
+      }
+      return [...prev, marketId];
+    });
+  };
+
+  const handleSaveTargets = async (e) => {
+    e.preventDefault();
+    if (!selectedMovie) return;
+
+    try {
+      setSaving(true);
+      await api.put(`/cinema-markets/movies/${selectedMovie}/targets`, {
+        targetMarkets: selectedMarkets,
+        primaryMarket,
+        crossMarketRelease: selectedMarkets.length > 1,
+      });
+      const projRes = await api.get(`/cinema-markets/movies/${selectedMovie}/projections`);
+      setProjection(projRes.data?.projection || null);
+      fetchAll();
+    } catch (err) {
+      alert(err.response?.data?.message || "Failed to update market targets.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const formatINR = (n) =>
+    n >= 10000000 ? `₹${(n / 10000000).toFixed(1)} Cr` : `₹${(n / 100000).toFixed(1)} L`;
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-7xl mx-auto space-y-8 pb-20">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h1 className="text-3xl sm:text-4xl font-extrabold text-white flex items-center gap-3">
+              <Globe className="text-emerald-400" size={36} /> Cinema Markets
+            </h1>
+            <p className="text-slate-400 mt-2">
+              Target Bollywood, Tollywood, Kollywood, Hollywood, Korean, and Japanese markets.
+            </p>
+          </div>
+          <button
+            onClick={fetchAll}
+            className="flex items-center gap-2 px-4 py-2 rounded-xl bg-slate-800 text-slate-300 hover:bg-slate-700 transition"
+          >
+            <RefreshCw size={16} /> Refresh
+          </button>
+        </div>
+
+        {error && (
+          <div className="p-4 rounded-2xl bg-rose-950/40 border border-rose-800/40 text-rose-300">{error}</div>
+        )}
+
+        {loading ? (
+          <div className="text-slate-400 text-center py-12">Loading cinema markets...</div>
+        ) : (
+          <>
+            {analytics && (
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                <div className="p-5 rounded-2xl bg-slate-900 border border-slate-800">
+                  <IndianRupee className="text-emerald-400 mb-2" size={20} />
+                  <p className="text-2xl font-bold text-white">{formatINR(analytics.totalRevenue)}</p>
+                  <p className="text-xs text-slate-400 uppercase">Total Market Revenue</p>
+                </div>
+                <div className="p-5 rounded-2xl bg-slate-900 border border-slate-800">
+                  <Film className="text-blue-400 mb-2" size={20} />
+                  <p className="text-2xl font-bold text-white">{analytics.releasedCount}</p>
+                  <p className="text-xs text-slate-400 uppercase">Market Releases</p>
+                </div>
+                <div className="p-5 rounded-2xl bg-slate-900 border border-slate-800">
+                  <TrendingUp className="text-violet-400 mb-2" size={20} />
+                  <p className="text-2xl font-bold text-white">{analytics.crossMarketReleases}</p>
+                  <p className="text-xs text-slate-400 uppercase">Cross-Market Releases</p>
+                </div>
+              </div>
+            )}
+
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {markets.map((market) => (
+                <div key={market.id} className="rounded-2xl bg-slate-900 border border-slate-800 overflow-hidden">
+                  <div className={`p-4 bg-gradient-to-r ${MARKET_COLORS[market.id] || "from-slate-600 to-slate-700"}`}>
+                    <h3 className="text-lg font-bold text-white">{market.name}</h3>
+                    <p className="text-white/70 text-xs">{market.region} · {market.currency}</p>
+                  </div>
+                  <div className="p-4 space-y-2 text-sm">
+                    <div className="flex justify-between text-slate-400">
+                      <span>Avg Ticket</span>
+                      <span className="text-white">₹{market.avgTicketPriceINR}</span>
+                    </div>
+                    <div className="flex justify-between text-slate-400">
+                      <span>Prod. Cost Mult.</span>
+                      <span className="text-white">×{market.productionCostMultiplier}</span>
+                    </div>
+                    <div className="flex justify-between text-slate-400">
+                      <span>Distribution Fee</span>
+                      <span className="text-white">{(market.distributionFeePct * 100).toFixed(0)}%</span>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="rounded-3xl bg-slate-900 border border-slate-800 p-6">
+              <h2 className="text-xl font-bold text-white mb-4 flex items-center gap-2">
+                <MapPin size={20} className="text-emerald-400" /> Set Market Targets
+              </h2>
+              <form onSubmit={handleSaveTargets} className="space-y-4">
+                <select
+                  value={selectedMovie}
+                  onChange={(e) => setSelectedMovie(e.target.value)}
+                  className="w-full px-4 py-3 rounded-xl bg-slate-800 border border-slate-700 text-white"
+                  required
+                >
+                  <option value="">Select active movie...</option>
+                  {movies.map((m) => (
+                    <option key={m._id} value={m._id}>
+                      {m.title} ({m.status}) — {m.targetMarkets?.join(", ") || "No targets"}
+                    </option>
+                  ))}
+                </select>
+
+                <div className="flex flex-wrap gap-2">
+                  {markets.map((market) => (
+                    <button
+                      key={market.id}
+                      type="button"
+                      onClick={() => toggleMarket(market.id)}
+                      className={`px-3 py-2 rounded-xl text-sm font-medium border transition ${
+                        selectedMarkets.includes(market.id)
+                          ? "bg-emerald-600 border-emerald-500 text-white"
+                          : "bg-slate-800 border-slate-700 text-slate-400 hover:text-white"
+                      }`}
+                    >
+                      {market.name}
+                    </button>
+                  ))}
+                </div>
+
+                <div className="flex flex-col sm:flex-row gap-4">
+                  <select
+                    value={primaryMarket}
+                    onChange={(e) => setPrimaryMarket(e.target.value)}
+                    className="flex-1 px-4 py-3 rounded-xl bg-slate-800 border border-slate-700 text-white"
+                  >
+                    {selectedMarkets.map((id) => {
+                      const m = markets.find((mk) => mk.id === id);
+                      return (
+                        <option key={id} value={id}>
+                          Primary: {m?.name || id}
+                        </option>
+                      );
+                    })}
+                  </select>
+                  <button
+                    type="submit"
+                    disabled={saving || !selectedMovie}
+                    className="px-6 py-3 rounded-xl bg-emerald-600 hover:bg-emerald-500 text-white font-bold disabled:opacity-50 transition"
+                  >
+                    {saving ? "Saving..." : "Save Market Targets"}
+                  </button>
+                </div>
+              </form>
+
+              {projection && (
+                <div className="mt-6 p-4 rounded-2xl bg-slate-950 border border-slate-800">
+                  <h3 className="text-white font-bold mb-3">Revenue Projection</h3>
+                  <p className="text-emerald-400 text-lg font-bold mb-2">
+                    Worldwide: {formatINR(projection.totalWorldwide)}
+                    {projection.crossMarketBonus > 1 && (
+                      <span className="text-sm text-slate-400 ml-2">
+                        (+{Math.round((projection.crossMarketBonus - 1) * 100)}% cross-market bonus)
+                      </span>
+                    )}
+                  </p>
+                  <div className="grid sm:grid-cols-2 gap-2">
+                    {projection.markets?.map((m) => (
+                      <div key={m.marketId} className="p-3 rounded-xl bg-slate-900 text-sm">
+                        <p className="text-white font-medium">{m.marketName}</p>
+                        <p className="text-slate-400">Gross: {formatINR(m.grossINR)}</p>
+                        {m.localizationCost > 0 && (
+                          <p className="text-rose-400 text-xs">Localization: {formatINR(m.localizationCost)}</p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default CinemaMarketsHub;


### PR DESCRIPTION
## Summary

- Adds six cinema markets (Bollywood, Tollywood, Kollywood, Hollywood, Korean, Japanese) with distinct audience, budget, genre, and distribution parameters
- Movies can target multiple markets with per-market revenue calculation normalized to INR
- Cross-market releases apply localization costs and a bounded cross-market bonus
- Talent region bonuses and genre affinities affect market-specific revenue
- Adds Cinema Markets hub UI and backend APIs for targeting, projections, and analytics

Closes #545

**ECSOC 2026** contribution — please apply the `ECSOC2026` label.

## Acceptance criteria

- [x] Movies can target multiple markets
- [x] Each market has distinct parameters
- [x] Revenue is calculated by market
- [x] Talent and audience pools are region-aware
- [x] Cross-market releases work
- [x] Tests cover regional and global releases

## Test plan

- [ ] `cd backend && node --test tests/cinemaMarketEngine.test.js` — all 8 tests pass
- [ ] Open `/movies/cinema-markets`, set market targets on an active movie
- [ ] Release the movie and verify per-market revenue in analytics
- [ ] Attach screenshot of Cinema Markets hub in PR