### PR TITLE
fix(frontend): resolve undefined StreamingBiddingHall runtime error

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,6 +27,7 @@ import ReviewDashboard from "./pages/movies/ReviewDashboard";
 import ProductionQueue from "./pages/movies/ProductionQueue";
 import MovieComparison from "./pages/movies/MovieComparison";
 import StreamingDeals from "./pages/movies/StreamingDeals";
+import StreamingBiddingHall from "./pages/streaming/StreamingBiddingHall";
 import RegionalBoxOfficeHub from "./pages/movies/RegionalBoxOfficeHub";
 import TVShowsHub from "./pages/tvshows/TVShowsHub";
 import ProduceTVShow from "./pages/tvshows/ProduceTVShow";


### PR DESCRIPTION
## Summary
- Add missing `StreamingBiddingHall` import in `App.jsx` for `/streaming/auctions`
- Fixes production `ReferenceError: StreamingBiddingHall is not defined`

Closes #560

ECSOC 2026 contribution — please apply the `ECSOC2026` label.

## Test plan
- [x] `cd frontend && npm run build` succeeds
- [ ] Navigate to `/streaming/auctions` — page renders without runtime errors